### PR TITLE
feat: add database models, Alembic migrations, and FastAPI skeleton (…

### DIFF
--- a/alembic.ini
+++ b/alembic.ini
@@ -1,0 +1,149 @@
+# A generic, single database configuration.
+
+[alembic]
+# path to migration scripts.
+# this is typically a path given in POSIX (e.g. forward slashes)
+# format, relative to the token %(here)s which refers to the location of this
+# ini file
+script_location = %(here)s/alembic
+
+# template used to generate migration file names; The default value is %%(rev)s_%%(slug)s
+# Uncomment the line below if you want the files to be prepended with date and time
+# see https://alembic.sqlalchemy.org/en/latest/tutorial.html#editing-the-ini-file
+# for all available tokens
+# file_template = %%(year)d_%%(month).2d_%%(day).2d_%%(hour).2d%%(minute).2d-%%(rev)s_%%(slug)s
+# Or organize into date-based subdirectories (requires recursive_version_locations = true)
+# file_template = %%(year)d/%%(month).2d/%%(day).2d_%%(hour).2d%%(minute).2d_%%(second).2d_%%(rev)s_%%(slug)s
+
+# sys.path path, will be prepended to sys.path if present.
+# defaults to the current working directory.  for multiple paths, the path separator
+# is defined by "path_separator" below.
+prepend_sys_path = .
+
+
+# timezone to use when rendering the date within the migration file
+# as well as the filename.
+# If specified, requires the tzdata library which can be installed by adding
+# `alembic[tz]` to the pip requirements.
+# string value is passed to ZoneInfo()
+# leave blank for localtime
+# timezone =
+
+# max length of characters to apply to the "slug" field
+# truncate_slug_length = 40
+
+# set to 'true' to run the environment during
+# the 'revision' command, regardless of autogenerate
+# revision_environment = false
+
+# set to 'true' to allow .pyc and .pyo files without
+# a source .py file to be detected as revisions in the
+# versions/ directory
+# sourceless = false
+
+# version location specification; This defaults
+# to <script_location>/versions.  When using multiple version
+# directories, initial revisions must be specified with --version-path.
+# The path separator used here should be the separator specified by "path_separator"
+# below.
+# version_locations = %(here)s/bar:%(here)s/bat:%(here)s/alembic/versions
+
+# path_separator; This indicates what character is used to split lists of file
+# paths, including version_locations and prepend_sys_path within configparser
+# files such as alembic.ini.
+# The default rendered in new alembic.ini files is "os", which uses os.pathsep
+# to provide os-dependent path splitting.
+#
+# Note that in order to support legacy alembic.ini files, this default does NOT
+# take place if path_separator is not present in alembic.ini.  If this
+# option is omitted entirely, fallback logic is as follows:
+#
+# 1. Parsing of the version_locations option falls back to using the legacy
+#    "version_path_separator" key, which if absent then falls back to the legacy
+#    behavior of splitting on spaces and/or commas.
+# 2. Parsing of the prepend_sys_path option falls back to the legacy
+#    behavior of splitting on spaces, commas, or colons.
+#
+# Valid values for path_separator are:
+#
+# path_separator = :
+# path_separator = ;
+# path_separator = space
+# path_separator = newline
+#
+# Use os.pathsep. Default configuration used for new projects.
+path_separator = os
+
+# set to 'true' to search source files recursively
+# in each "version_locations" directory
+# new in Alembic version 1.10
+# recursive_version_locations = false
+
+# the output encoding used when revision files
+# are written from script.py.mako
+# output_encoding = utf-8
+
+# database URL.  This is consumed by the user-maintained env.py script only.
+# other means of configuring database URLs may be customized within the env.py
+# file.
+sqlalchemy.url = driver://user:pass@localhost/dbname
+
+
+[post_write_hooks]
+# post_write_hooks defines scripts or Python functions that are run
+# on newly generated revision scripts.  See the documentation for further
+# detail and examples
+
+# format using "black" - use the console_scripts runner, against the "black" entrypoint
+# hooks = black
+# black.type = console_scripts
+# black.entrypoint = black
+# black.options = -l 79 REVISION_SCRIPT_FILENAME
+
+# lint with attempts to fix using "ruff" - use the module runner, against the "ruff" module
+# hooks = ruff
+# ruff.type = module
+# ruff.module = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Alternatively, use the exec runner to execute a binary found on your PATH
+# hooks = ruff
+# ruff.type = exec
+# ruff.executable = ruff
+# ruff.options = check --fix REVISION_SCRIPT_FILENAME
+
+# Logging configuration.  This is also consumed by the user-maintained
+# env.py script only.
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/alembic/README
+++ b/alembic/README
@@ -1,0 +1,1 @@
+Generic single-database configuration.

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,0 +1,70 @@
+import asyncio
+from logging.config import fileConfig
+
+from sqlalchemy import pool
+from sqlalchemy.ext.asyncio import async_engine_from_config
+
+from alembic import context
+
+from backend.config import get_settings
+from backend.database import Base
+from backend.models import (  # noqa: F401 — ensure all models are registered
+    User, Expense, Goal, MonthlyReport,
+    MarketSnapshot, InvestmentLog, LLMCache,
+)
+
+config = context.config
+
+# Override sqlalchemy.url from env
+settings = get_settings()
+# Alembic needs a sync-compatible URL for offline mode,
+# but for online async we use asyncpg directly
+config.set_main_option("sqlalchemy.url", settings.database_url)
+
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def do_run_migrations(connection):
+    context.configure(connection=connection, target_metadata=target_metadata)
+
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+async def run_async_migrations() -> None:
+    connectable = async_engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+
+    async with connectable.connect() as connection:
+        await connection.run_sync(do_run_migrations)
+
+    await connectable.dispose()
+
+
+def run_migrations_online() -> None:
+    asyncio.run(run_async_migrations())
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/alembic/script.py.mako
+++ b/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: Union[str, Sequence[str], None] = ${repr(down_revision)}
+branch_labels: Union[str, Sequence[str], None] = ${repr(branch_labels)}
+depends_on: Union[str, Sequence[str], None] = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    ${downgrades if downgrades else "pass"}

--- a/alembic/versions/4af8805c9efd_initial_schema.py
+++ b/alembic/versions/4af8805c9efd_initial_schema.py
@@ -1,0 +1,175 @@
+"""initial schema
+
+Revision ID: 4af8805c9efd
+Revises:
+Create Date: 2026-03-24 04:56:13.488553
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+# revision identifiers, used by Alembic.
+revision: str = '4af8805c9efd'
+down_revision: Union[str, Sequence[str], None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    # users
+    op.create_table(
+        'users',
+        sa.Column('id', sa.UUID(), nullable=False, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('telegram_id', sa.BigInteger(), nullable=False),
+        sa.Column('telegram_handle', sa.String(255), nullable=True),
+        sa.Column('display_name', sa.String(255), nullable=True),
+        sa.Column('timezone', sa.String(50), nullable=False, server_default='Asia/Ho_Chi_Minh'),
+        sa.Column('currency', sa.String(10), nullable=False, server_default='VND'),
+        sa.Column('monthly_income', sa.Numeric(15, 2), nullable=True),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('telegram_id'),
+    )
+
+    # expenses
+    op.create_table(
+        'expenses',
+        sa.Column('id', sa.UUID(), nullable=False, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('amount', sa.Numeric(15, 2), nullable=False),
+        sa.Column('currency', sa.String(10), nullable=False, server_default='VND'),
+        sa.Column('merchant', sa.String(500), nullable=True),
+        sa.Column('category', sa.String(100), nullable=False),
+        sa.Column('source', sa.String(50), nullable=False),
+        sa.Column('expense_date', sa.Date(), nullable=False),
+        sa.Column('month_key', sa.String(7), nullable=False),
+        sa.Column('note', sa.Text(), nullable=True),
+        sa.Column('raw_data', postgresql.JSONB(), nullable=True),
+        sa.Column('needs_review', sa.Boolean(), nullable=False, server_default=sa.text('false')),
+        sa.Column('gmail_message_id', sa.String(255), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('idx_expenses_user_id', 'expenses', ['user_id'])
+    op.create_index('idx_expenses_month_key', 'expenses', ['user_id', 'month_key'])
+    op.create_index('idx_expenses_category', 'expenses', ['user_id', 'category'])
+    op.create_index(
+        'idx_expenses_gmail_id', 'expenses', ['gmail_message_id'],
+        postgresql_where=sa.text('gmail_message_id IS NOT NULL'),
+    )
+
+    # goals
+    op.create_table(
+        'goals',
+        sa.Column('id', sa.UUID(), nullable=False, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('goal_name', sa.String(500), nullable=False),
+        sa.Column('target_amount', sa.Numeric(15, 2), nullable=False),
+        sa.Column('current_amount', sa.Numeric(15, 2), nullable=False, server_default='0'),
+        sa.Column('deadline', sa.Date(), nullable=True),
+        sa.Column('priority', sa.String(20), nullable=False, server_default='medium'),
+        sa.Column('is_active', sa.Boolean(), nullable=False, server_default=sa.text('true')),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.Column('updated_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.Column('deleted_at', sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('idx_goals_user_id', 'goals', ['user_id'])
+
+    # monthly_reports
+    op.create_table(
+        'monthly_reports',
+        sa.Column('id', sa.UUID(), nullable=False, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('month_key', sa.String(7), nullable=False),
+        sa.Column('total_expense', sa.Numeric(15, 2), nullable=False),
+        sa.Column('total_income', sa.Numeric(15, 2), nullable=True),
+        sa.Column('savings_amount', sa.Numeric(15, 2), nullable=True),
+        sa.Column('savings_rate', sa.Numeric(5, 2), nullable=True),
+        sa.Column('breakdown_by_category', postgresql.JSONB(), nullable=False),
+        sa.Column('vs_previous_month', postgresql.JSONB(), nullable=True),
+        sa.Column('goal_progress', postgresql.JSONB(), nullable=True),
+        sa.Column('report_text', sa.Text(), nullable=True),
+        sa.Column('generated_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('user_id', 'month_key', name='uq_report_user_month'),
+    )
+    op.create_index('idx_reports_user_month', 'monthly_reports', ['user_id', 'month_key'])
+
+    # market_snapshots
+    op.create_table(
+        'market_snapshots',
+        sa.Column('id', sa.UUID(), nullable=False, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('snapshot_date', sa.Date(), nullable=False),
+        sa.Column('asset_code', sa.String(50), nullable=False),
+        sa.Column('asset_type', sa.String(50), nullable=False),
+        sa.Column('asset_name', sa.String(500), nullable=True),
+        sa.Column('price', sa.Numeric(15, 4), nullable=True),
+        sa.Column('change_1d_pct', sa.Numeric(8, 4), nullable=True),
+        sa.Column('change_1w_pct', sa.Numeric(8, 4), nullable=True),
+        sa.Column('change_1m_pct', sa.Numeric(8, 4), nullable=True),
+        sa.Column('extra_data', postgresql.JSONB(), nullable=True),
+        sa.Column('source_url', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('snapshot_date', 'asset_code', name='uq_snapshot_date_asset'),
+    )
+    op.create_index('idx_market_date', 'market_snapshots', ['snapshot_date'], postgresql_ops={'snapshot_date': 'DESC'})
+    op.create_index('idx_market_asset', 'market_snapshots', ['asset_code', 'snapshot_date'], postgresql_ops={'snapshot_date': 'DESC'})
+
+    # investment_logs
+    op.create_table(
+        'investment_logs',
+        sa.Column('id', sa.UUID(), nullable=False, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('user_id', sa.UUID(), nullable=False),
+        sa.Column('log_date', sa.Date(), nullable=False),
+        sa.Column('market_context', postgresql.JSONB(), nullable=False),
+        sa.Column('user_financial_context', postgresql.JSONB(), nullable=False),
+        sa.Column('recommendation', sa.Text(), nullable=False),
+        sa.Column('action_taken', sa.Text(), nullable=True),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id']),
+        sa.PrimaryKeyConstraint('id'),
+    )
+    op.create_index('idx_investment_logs_user', 'investment_logs', ['user_id', 'log_date'])
+
+    # llm_cache
+    op.create_table(
+        'llm_cache',
+        sa.Column('id', sa.UUID(), nullable=False, server_default=sa.text('gen_random_uuid()')),
+        sa.Column('cache_key', sa.String(500), nullable=False),
+        sa.Column('model', sa.String(100), nullable=False),
+        sa.Column('prompt_hash', sa.String(64), nullable=False),
+        sa.Column('response', sa.Text(), nullable=False),
+        sa.Column('tokens_used', sa.Integer(), nullable=True),
+        sa.Column('expires_at', sa.DateTime(timezone=True), nullable=False),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.text('now()')),
+        sa.PrimaryKeyConstraint('id'),
+        sa.UniqueConstraint('cache_key'),
+    )
+    op.create_index('idx_llm_cache_key', 'llm_cache', ['cache_key'])
+    op.create_index('idx_llm_cache_expires', 'llm_cache', ['expires_at'])
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_table('llm_cache')
+    op.drop_table('investment_logs')
+    op.drop_table('market_snapshots')
+    op.drop_table('monthly_reports')
+    op.drop_table('goals')
+    op.drop_table('expenses')
+    op.drop_table('users')

--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,45 @@
+from pydantic_settings import BaseSettings
+from functools import lru_cache
+
+
+class Settings(BaseSettings):
+    # Backend
+    environment: str = "development"
+    port: int = 8000
+    internal_api_key: str = ""
+
+    # Database
+    database_url: str = "postgresql+asyncpg://finance:password@localhost:5432/finance_db"
+
+    # LLM APIs
+    deepseek_api_key: str = ""
+    deepseek_base_url: str = "https://api.deepseek.com"
+    anthropic_api_key: str = ""
+
+    # Gmail OAuth2
+    gmail_client_id: str = ""
+    gmail_client_secret: str = ""
+    gmail_redirect_uri: str = "http://localhost:8000/auth/gmail/callback"
+
+    # Notion
+    notion_api_key: str = ""
+    notion_expenses_db_id: str = ""
+    notion_goals_db_id: str = ""
+    notion_reports_db_id: str = ""
+    notion_market_db_id: str = ""
+    notion_investment_log_db_id: str = ""
+
+    # Telegram
+    telegram_bot_token: str = ""
+    owner_telegram_id: str = ""
+
+    # OpenClaw Skills
+    finance_api_url: str = "http://localhost:8000/api/v1"
+    finance_api_key: str = ""
+
+    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,0 +1,33 @@
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import DeclarativeBase
+
+from backend.config import get_settings
+
+settings = get_settings()
+
+engine = create_async_engine(
+    settings.database_url,
+    echo=settings.environment == "development",
+    pool_size=5,
+    max_overflow=10,
+)
+
+async_session_factory = async_sessionmaker(
+    engine,
+    class_=AsyncSession,
+    expire_on_commit=False,
+)
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+async def get_db() -> AsyncSession:
+    async with async_session_factory() as session:
+        try:
+            yield session
+            await session.commit()
+        except Exception:
+            await session.rollback()
+            raise

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,32 @@
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+from fastapi.responses import JSONResponse
+
+from backend.config import get_settings
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    logger.info("Finance Assistant API starting up")
+    yield
+    logger.info("Finance Assistant API shutting down")
+
+
+app = FastAPI(
+    title="Finance Assistant API",
+    description="Personal finance AI assistant backend",
+    version="0.1.0",
+    lifespan=lifespan,
+)
+
+
+@app.get("/health")
+async def health_check():
+    return JSONResponse(
+        content={"data": {"status": "healthy"}, "error": None}
+    )

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,17 @@
+from backend.models.user import User
+from backend.models.expense import Expense
+from backend.models.goal import Goal
+from backend.models.report import MonthlyReport
+from backend.models.market_snapshot import MarketSnapshot
+from backend.models.investment_log import InvestmentLog
+from backend.models.llm_cache import LLMCache
+
+__all__ = [
+    "User",
+    "Expense",
+    "Goal",
+    "MonthlyReport",
+    "MarketSnapshot",
+    "InvestmentLog",
+    "LLMCache",
+]

--- a/backend/models/expense.py
+++ b/backend/models/expense.py
@@ -1,0 +1,47 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Boolean, Date, DateTime, Index, Numeric, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class Expense(Base):
+    __tablename__ = "expenses"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    amount: Mapped[float] = mapped_column(Numeric(15, 2), nullable=False)
+    currency: Mapped[str] = mapped_column(String(10), default="VND")
+    merchant: Mapped[str | None] = mapped_column(String(500))
+    category: Mapped[str] = mapped_column(String(100), nullable=False)
+    source: Mapped[str] = mapped_column(String(50), nullable=False)
+    expense_date: Mapped[date] = mapped_column(Date, nullable=False)
+    month_key: Mapped[str] = mapped_column(String(7), nullable=False)
+    note: Mapped[str | None] = mapped_column(Text)
+    raw_data: Mapped[dict | None] = mapped_column(JSONB)
+    needs_review: Mapped[bool] = mapped_column(Boolean, default=False)
+    gmail_message_id: Mapped[str | None] = mapped_column(String(255))
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        Index("idx_expenses_month_key", "user_id", "month_key"),
+        Index("idx_expenses_category", "user_id", "category"),
+        Index(
+            "idx_expenses_gmail_id",
+            "gmail_message_id",
+            postgresql_where=text("gmail_message_id IS NOT NULL"),
+        ),
+    )

--- a/backend/models/goal.py
+++ b/backend/models/goal.py
@@ -1,0 +1,32 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Boolean, Date, DateTime, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class Goal(Base):
+    __tablename__ = "goals"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False, index=True
+    )
+    goal_name: Mapped[str] = mapped_column(String(500), nullable=False)
+    target_amount: Mapped[float] = mapped_column(Numeric(15, 2), nullable=False)
+    current_amount: Mapped[float] = mapped_column(Numeric(15, 2), default=0)
+    deadline: Mapped[date | None] = mapped_column(Date)
+    priority: Mapped[str] = mapped_column(String(20), default="medium")
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))

--- a/backend/models/investment_log.py
+++ b/backend/models/investment_log.py
@@ -1,0 +1,31 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, Index, Text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class InvestmentLog(Base):
+    __tablename__ = "investment_logs"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False
+    )
+    log_date: Mapped[date] = mapped_column(Date, nullable=False)
+    market_context: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    user_financial_context: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    recommendation: Mapped[str] = mapped_column(Text, nullable=False)
+    action_taken: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    __table_args__ = (
+        Index("idx_investment_logs_user", "user_id", "log_date"),
+    )

--- a/backend/models/llm_cache.py
+++ b/backend/models/llm_cache.py
@@ -1,0 +1,27 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class LLMCache(Base):
+    __tablename__ = "llm_cache"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    cache_key: Mapped[str] = mapped_column(
+        String(500), unique=True, nullable=False, index=True
+    )
+    model: Mapped[str] = mapped_column(String(100), nullable=False)
+    prompt_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    response: Mapped[str] = mapped_column(Text, nullable=False)
+    tokens_used: Mapped[int | None] = mapped_column(Integer)
+    expires_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), nullable=False, index=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )

--- a/backend/models/market_snapshot.py
+++ b/backend/models/market_snapshot.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import date, datetime
+
+from sqlalchemy import Date, DateTime, Index, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class MarketSnapshot(Base):
+    __tablename__ = "market_snapshots"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    snapshot_date: Mapped[date] = mapped_column(Date, nullable=False)
+    asset_code: Mapped[str] = mapped_column(String(50), nullable=False)
+    asset_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    asset_name: Mapped[str | None] = mapped_column(String(500))
+    price: Mapped[float | None] = mapped_column(Numeric(15, 4))
+    change_1d_pct: Mapped[float | None] = mapped_column(Numeric(8, 4))
+    change_1w_pct: Mapped[float | None] = mapped_column(Numeric(8, 4))
+    change_1m_pct: Mapped[float | None] = mapped_column(Numeric(8, 4))
+    extra_data: Mapped[dict | None] = mapped_column(JSONB)
+    source_url: Mapped[str | None] = mapped_column(Text)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    __table_args__ = (
+        UniqueConstraint("snapshot_date", "asset_code", name="uq_snapshot_date_asset"),
+        Index("idx_market_date", "snapshot_date"),
+        Index("idx_market_asset", "asset_code", "snapshot_date"),
+    )

--- a/backend/models/report.py
+++ b/backend/models/report.py
@@ -1,0 +1,35 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class MonthlyReport(Base):
+    __tablename__ = "monthly_reports"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), nullable=False
+    )
+    month_key: Mapped[str] = mapped_column(String(7), nullable=False)
+    total_expense: Mapped[float] = mapped_column(Numeric(15, 2), nullable=False)
+    total_income: Mapped[float | None] = mapped_column(Numeric(15, 2))
+    savings_amount: Mapped[float | None] = mapped_column(Numeric(15, 2))
+    savings_rate: Mapped[float | None] = mapped_column(Numeric(5, 2))
+    breakdown_by_category: Mapped[dict] = mapped_column(JSONB, nullable=False)
+    vs_previous_month: Mapped[dict | None] = mapped_column(JSONB)
+    goal_progress: Mapped[dict | None] = mapped_column(JSONB)
+    report_text: Mapped[str | None] = mapped_column(Text)
+    generated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+
+    __table_args__ = (
+        UniqueConstraint("user_id", "month_key", name="uq_report_user_month"),
+    )

--- a/backend/models/user.py
+++ b/backend/models/user.py
@@ -1,0 +1,30 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import BigInteger, Boolean, DateTime, Numeric, String
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class User(Base):
+    __tablename__ = "users"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    telegram_id: Mapped[int] = mapped_column(BigInteger, unique=True, nullable=False)
+    telegram_handle: Mapped[str | None] = mapped_column(String(255))
+    display_name: Mapped[str | None] = mapped_column(String(255))
+    timezone: Mapped[str] = mapped_column(String(50), default="Asia/Ho_Chi_Minh")
+    currency: Mapped[str] = mapped_column(String(10), default="VND")
+    monthly_income: Mapped[float | None] = mapped_column(Numeric(15, 2))
+    is_active: Mapped[bool] = mapped_column(Boolean, default=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
+    )
+    deleted_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))


### PR DESCRIPTION
…Bước 2 & 3)

- backend/config.py: pydantic BaseSettings loading from .env
- backend/database.py: async SQLAlchemy engine + session factory
- backend/models/: 7 ORM models (users, expenses, goals, monthly_reports, market_snapshots, investment_logs, llm_cache) matching CLAUDE.md schema
- alembic/: async migration setup with initial schema migration
- backend/main.py: FastAPI app with /health endpoint returning 200

https://claude.ai/code/session_01QD1twTBi9x2bjCwGdn8oM8