### PR TITLE
fix: remap ports to avoid conflict with taxassistant

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,11 +2,11 @@
 
 # === Backend ===
 ENVIRONMENT=development
-PORT=8000
+PORT=8001
 INTERNAL_API_KEY=               # Random string dài, dùng cho OpenClaw Skills gọi API
 
 # === Database ===
-DATABASE_URL=postgresql+asyncpg://finance:password@localhost:5432/finance_db
+DATABASE_URL=postgresql+asyncpg://finance:password@localhost:5433/finance_db
 
 # === LLM APIs ===
 DEEPSEEK_API_KEY=               # Primary LLM
@@ -31,5 +31,5 @@ TELEGRAM_BOT_TOKEN=
 OWNER_TELEGRAM_ID=              # Telegram user ID của owner
 
 # === OpenClaw Skills ===
-FINANCE_API_URL=http://localhost:8000/api/v1
+FINANCE_API_URL=http://localhost:8001/api/v1
 FINANCE_API_KEY=                # = INTERNAL_API_KEY ở trên

--- a/backend/config.py
+++ b/backend/config.py
@@ -5,11 +5,11 @@ from functools import lru_cache
 class Settings(BaseSettings):
     # Backend
     environment: str = "development"
-    port: int = 8000
+    port: int = 8001
     internal_api_key: str = ""
 
     # Database
-    database_url: str = "postgresql+asyncpg://finance:password@localhost:5432/finance_db"
+    database_url: str = "postgresql+asyncpg://finance:password@localhost:5433/finance_db"
 
     # LLM APIs
     deepseek_api_key: str = ""
@@ -34,7 +34,7 @@ class Settings(BaseSettings):
     owner_telegram_id: str = ""
 
     # OpenClaw Skills
-    finance_api_url: str = "http://localhost:8000/api/v1"
+    finance_api_url: str = "http://localhost:8001/api/v1"
     finance_api_key: str = ""
 
     model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   postgres:
     image: postgres:16-alpine
@@ -9,7 +7,7 @@ services:
       POSTGRES_PASSWORD: password
       POSTGRES_DB: finance_db
     ports:
-      - "5432:5432"
+      - "5433:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     restart: unless-stopped
@@ -23,7 +21,7 @@ services:
     image: redis:7-alpine
     container_name: finance-redis
     ports:
-      - "6379:6379"
+      - "6380:6379"
     volumes:
       - redis_data:/data
     restart: unless-stopped


### PR DESCRIPTION
- PostgreSQL: 5432 → 5433 (host)
- Redis: 6379 → 6380 (host)
- FastAPI: 8000 → 8001
- Remove obsolete docker-compose version attribute

https://claude.ai/code/session_01QD1twTBi9x2bjCwGdn8oM8