### PR TITLE
fix: downgrade vnstock version requirement to available 0.2.9

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,7 +24,7 @@ google-api-python-client>=2.120.0
 notion-client>=2.2.0
 
 # Market data
-vnstock>=0.3.0
+vnstock>=0.2.9
 requests>=2.31.0
 beautifulsoup4>=4.12.0
 lxml>=5.0.0


### PR DESCRIPTION
vnstock 0.3.0 does not exist on PyPI; latest is 0.2.9.x

https://claude.ai/code/session_01QD1twTBi9x2bjCwGdn8oM8