### PR TITLE
feat: implement /menu command with inline keyboard (Issue #7)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,24 +4,24 @@
 # === Backend ===
 ENVIRONMENT=development
 PORT=8001
-INTERNAL_API_KEY=               # Required: random string dài, dùng cho OpenClaw Skills gọi API
+INTERNAL_API_KEY=               # Required: generate with `openssl rand -hex 32`
 
 # === Database ===
-POSTGRES_PASSWORD=              # Required: password cho PostgreSQL container
-DATABASE_URL=                   # Required: e.g. postgresql+asyncpg://finance:<password>@localhost:5433/finance_db
+POSTGRES_PASSWORD=              # Required: generate with `openssl rand -hex 16`
+DATABASE_URL=                   # Required: format postgresql+asyncpg://finance:YOUR_PASSWORD@localhost:5433/finance_db
 
 # === LLM APIs ===
-DEEPSEEK_API_KEY=               # Primary LLM
+DEEPSEEK_API_KEY=               # Primary LLM — get from https://platform.deepseek.com
 DEEPSEEK_BASE_URL=https://api.deepseek.com
-ANTHROPIC_API_KEY=              # Chỉ dùng cho OCR (Claude Vision)
+ANTHROPIC_API_KEY=              # Chỉ dùng cho OCR — get from https://console.anthropic.com
 
 # === Gmail OAuth2 ===
-GMAIL_CLIENT_ID=
-GMAIL_CLIENT_SECRET=
+GMAIL_CLIENT_ID=                # From Google Cloud Console
+GMAIL_CLIENT_SECRET=            # From Google Cloud Console
 GMAIL_REDIRECT_URI=http://localhost:8000/auth/gmail/callback
 
 # === Notion ===
-NOTION_API_KEY=
+NOTION_API_KEY=                 # From https://www.notion.so/my-integrations
 NOTION_EXPENSES_DB_ID=
 NOTION_GOALS_DB_ID=
 NOTION_REPORTS_DB_ID=
@@ -29,10 +29,10 @@ NOTION_MARKET_DB_ID=
 NOTION_INVESTMENT_LOG_DB_ID=
 
 # === Telegram ===
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_WEBHOOK_SECRET=        # Secret token for webhook validation
-OWNER_TELEGRAM_ID=              # Telegram user ID của owner
+TELEGRAM_BOT_TOKEN=             # From @BotFather
+TELEGRAM_WEBHOOK_SECRET=        # Generate with `openssl rand -hex 32`
+OWNER_TELEGRAM_ID=              # Your numeric Telegram user ID
 
 # === OpenClaw Skills ===
 FINANCE_API_URL=http://localhost:8001/api/v1
-FINANCE_API_KEY=                # = INTERNAL_API_KEY ở trên
+FINANCE_API_KEY=                # Same value as INTERNAL_API_KEY

--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,14 @@
 # .env.example — copy thành .env và điền giá trị thật
+# KHÔNG BAO GIỜ commit file .env vào git
 
 # === Backend ===
 ENVIRONMENT=development
 PORT=8001
-INTERNAL_API_KEY=               # Random string dài, dùng cho OpenClaw Skills gọi API
+INTERNAL_API_KEY=               # Required: random string dài, dùng cho OpenClaw Skills gọi API
 
 # === Database ===
-DATABASE_URL=postgresql+asyncpg://finance:password@localhost:5433/finance_db
+POSTGRES_PASSWORD=              # Required: password cho PostgreSQL container
+DATABASE_URL=                   # Required: e.g. postgresql+asyncpg://finance:<password>@localhost:5433/finance_db
 
 # === LLM APIs ===
 DEEPSEEK_API_KEY=               # Primary LLM
@@ -28,6 +30,7 @@ NOTION_INVESTMENT_LOG_DB_ID=
 
 # === Telegram ===
 TELEGRAM_BOT_TOKEN=
+TELEGRAM_WEBHOOK_SECRET=        # Secret token for webhook validation
 OWNER_TELEGRAM_ID=              # Telegram user ID của owner
 
 # === OpenClaw Skills ===

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,11 @@
-# Environment
+# Environment & Secrets
 .env
+.env.*
+!.env.example
+*.pem
+*.key
+credentials.json
+token.json
 
 # Python
 __pycache__/

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     internal_api_key: str = ""
 
     # Database
-    database_url: str = "postgresql+asyncpg://finance:password@localhost:5433/finance_db"
+    database_url: str = ""  # Set via DATABASE_URL env var
 
     # LLM APIs
     deepseek_api_key: str = ""

--- a/backend/config.py
+++ b/backend/config.py
@@ -31,6 +31,7 @@ class Settings(BaseSettings):
 
     # Telegram
     telegram_bot_token: str = ""
+    telegram_webhook_secret: str = ""  # Validates webhook requests from Telegram
     owner_telegram_id: str = ""
 
     # OpenClaw Skills

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,7 +6,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
 from backend.config import get_settings
-from backend.routers import expenses, goals, ingestion, market, reports
+from backend.routers import expenses, goals, ingestion, market, reports, telegram
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
@@ -50,6 +50,7 @@ app.include_router(goals.income_router, prefix="/api/v1")
 app.include_router(ingestion.router, prefix="/api/v1")
 app.include_router(reports.router, prefix="/api/v1")
 app.include_router(market.router, prefix="/api/v1")
+app.include_router(telegram.router, prefix="/api/v1")
 
 
 @app.get("/health")

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -1,63 +1,32 @@
 """Telegram Bot webhook/polling router.
 
-Handles /menu command and inline keyboard callbacks directly,
-bypassing OpenClaw for interactive UI elements.
+Handles /menu command and inline keyboard callbacks.
+All menu data comes from menu_service (single source of truth).
 """
 import logging
-import uuid
-from datetime import date
 
 import httpx
-from fastapi import APIRouter, Depends, Request
-from sqlalchemy import select
+from fastapi import APIRouter, Depends, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import get_settings
 from backend.database import get_db
-from backend.models.user import User
+from backend.services.menu_service import (
+    BOT_COMMANDS,
+    get_callback_response,
+    get_features_json,
+    get_menu_text,
+    get_telegram_buttons,
+    get_telegram_menu_text,
+)
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
-MENU_TEXT = """🏦 *Finance Assistant — Menu*
-
-Chọn tính năng bạn muốn sử dụng:"""
-
-MENU_BUTTONS = [
-    [
-        {"text": "📧 Quét Gmail", "callback_data": "menu:gmail_scan"},
-        {"text": "📸 OCR Hóa đơn", "callback_data": "menu:ocr_info"},
-    ],
-    [
-        {"text": "✍️ Thêm chi tiêu", "callback_data": "menu:add_expense"},
-        {"text": "📊 Báo cáo", "callback_data": "menu:report"},
-    ],
-    [
-        {"text": "📈 Thị trường", "callback_data": "menu:market"},
-        {"text": "💡 Gợi ý đầu tư", "callback_data": "menu:advice"},
-    ],
-    [
-        {"text": "🎯 Mục tiêu", "callback_data": "menu:goals"},
-        {"text": "💰 Thu nhập", "callback_data": "menu:income"},
-    ],
-]
-
-CALLBACK_RESPONSES = {
-    "menu:gmail_scan": "📧 *Quét hóa đơn Gmail*\n\nGửi tin nhắn: \"quét gmail\" hoặc \"scan gmail\"\n\nBot sẽ quét Gmail tìm hóa đơn từ UOB Bank, Grab, Xanh SM, Traveloka và tự động ghi nhận chi tiêu.",
-    "menu:ocr_info": "📸 *Nhận diện hóa đơn*\n\nGửi ảnh hóa đơn/receipt trực tiếp vào chat.\n\nBot sẽ dùng AI Vision để trích xuất:\n• Tên merchant\n• Số tiền\n• Ngày\n• Danh mục\n\nSau đó hỏi bạn confirm trước khi lưu.",
-    "menu:add_expense": "✍️ *Thêm chi tiêu*\n\nGửi theo format:\n\"thêm chi tiêu [số tiền] [mô tả]\"\n\nVí dụ:\n• \"thêm chi tiêu 150k ăn trưa\"\n• \"chi 50k grab\"\n• \"ghi lại 200k shopping\"",
-    "menu:report": "📊 *Báo cáo chi tiêu*\n\nGửi:\n• \"báo cáo tháng này\"\n• \"báo cáo tháng 3\"\n• \"tổng chi tiêu\"\n\nBot sẽ tổng hợp chi tiêu theo danh mục, so sánh với tháng trước, và đưa ra nhận xét.",
-    "menu:market": "📈 *Thông tin thị trường*\n\nGửi:\n• \"thị trường hôm nay?\"\n• \"VN-Index?\"\n\nBot hiển thị VN-Index, VN30, HNX và các quỹ đầu tư (DCDS, VESAF...).",
-    "menu:advice": "💡 *Gợi ý đầu tư*\n\nGửi: \"nên đầu tư gì?\"\n\nBot phân tích tình hình tài chính cá nhân + thị trường để đưa ra gợi ý phù hợp.",
-    "menu:goals": "🎯 *Mục tiêu tài chính*\n\nGửi:\n• \"tôi muốn tiết kiệm 50tr để mua xe trong 6 tháng\"\n• \"tiến độ mục tiêu?\"\n• \"cập nhật mục tiêu\"\n\nBot theo dõi tiến độ và nhắc nhở bạn.",
-    "menu:income": "💰 *Cập nhật thu nhập*\n\nGửi: \"thu nhập tháng này là 20tr\"\n\nBot dùng thu nhập để tính tỷ lệ tiết kiệm và đưa ra báo cáo chính xác hơn.",
-}
-
 
 async def _send_telegram(method: str, payload: dict) -> dict | None:
-    """Send request to Telegram Bot API."""
     if not settings.telegram_bot_token:
         logger.warning("TELEGRAM_BOT_TOKEN not configured")
         return None
@@ -72,27 +41,18 @@ async def _send_telegram(method: str, payload: dict) -> dict | None:
 
 
 async def send_menu(chat_id: int) -> dict | None:
-    """Send the menu with inline keyboard to a Telegram chat."""
     return await _send_telegram("sendMessage", {
         "chat_id": chat_id,
-        "text": MENU_TEXT,
+        "text": get_telegram_menu_text(),
         "parse_mode": "Markdown",
-        "reply_markup": {"inline_keyboard": MENU_BUTTONS},
+        "reply_markup": {"inline_keyboard": get_telegram_buttons()},
     })
-
-
-async def _get_user_by_telegram_id(db: AsyncSession, telegram_id: int) -> User | None:
-    stmt = select(User).where(User.telegram_id == telegram_id, User.deleted_at.is_(None))
-    result = await db.execute(stmt)
-    return result.scalar_one_or_none()
 
 
 @router.post("/webhook")
 async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db)):
-    """Handle Telegram webhook updates."""
     data = await request.json()
 
-    # Handle /menu command
     message = data.get("message")
     if message:
         text = message.get("text", "")
@@ -102,18 +62,15 @@ async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db))
             await send_menu(chat_id)
             return {"ok": True}
 
-    # Handle callback queries (inline keyboard button presses)
     callback_query = data.get("callback_query")
     if callback_query:
         callback_data = callback_query.get("data", "")
         chat_id = callback_query["message"]["chat"]["id"]
         callback_id = callback_query["id"]
 
-        # Acknowledge the callback
         await _send_telegram("answerCallbackQuery", {"callback_query_id": callback_id})
 
-        # Send feature info
-        response_text = CALLBACK_RESPONSES.get(callback_data)
+        response_text = get_callback_response(callback_data)
         if response_text:
             await _send_telegram("sendMessage", {
                 "chat_id": chat_id,
@@ -126,12 +83,20 @@ async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db))
     return {"ok": True}
 
 
+@router.get("/menu")
+async def get_menu():
+    """Return menu data as JSON — consumed by OpenClaw skills and other clients."""
+    return {
+        "data": {
+            "text": get_menu_text(),
+            "features": get_features_json(),
+        },
+        "error": None,
+    }
+
+
 @router.post("/send-menu")
-async def trigger_send_menu(
-    chat_id: int,
-    db: AsyncSession = Depends(get_db),
-):
-    """Manually trigger sending the menu to a specific chat."""
+async def trigger_send_menu(chat_id: int = Query(...)):
     result = await send_menu(chat_id)
     if result:
         return {"data": {"sent": True}, "error": None}
@@ -140,15 +105,7 @@ async def trigger_send_menu(
 
 @router.post("/set-commands")
 async def set_bot_commands():
-    """Register bot commands with Telegram (shown in command menu)."""
-    commands = [
-        {"command": "menu", "description": "Hiển thị menu tính năng"},
-        {"command": "start", "description": "Bắt đầu sử dụng bot"},
-        {"command": "report", "description": "Báo cáo chi tiêu tháng này"},
-        {"command": "goals", "description": "Xem mục tiêu tài chính"},
-        {"command": "market", "description": "Thông tin thị trường"},
-    ]
-    result = await _send_telegram("setMyCommands", {"commands": commands})
+    result = await _send_telegram("setMyCommands", {"commands": BOT_COMMANDS})
     if result:
         return {"data": {"registered": True}, "error": None}
     return {"data": None, "error": {"code": "REGISTER_FAILED", "message": "Failed to register commands"}}

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -1,23 +1,22 @@
-"""Telegram Bot webhook/polling router.
+"""Telegram Bot webhook router.
 
-Handles /menu command and inline keyboard callbacks.
-All menu data comes from menu_service (single source of truth).
+Thin routing layer — all transport logic lives in telegram_service,
+all menu data lives in menu_service.
 """
+import hmac
 import logging
 
-import httpx
-from fastapi import APIRouter, Depends, Query, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.config import get_settings
 from backend.database import get_db
-from backend.services.menu_service import (
-    BOT_COMMANDS,
-    get_callback_response,
-    get_features_json,
-    get_menu_text,
-    get_telegram_buttons,
-    get_telegram_menu_text,
+from backend.services.menu_service import get_features_json, get_menu_text
+from backend.services.telegram_service import (
+    answer_callback,
+    handle_menu_callback,
+    register_bot_commands,
+    send_menu,
 )
 
 logger = logging.getLogger(__name__)
@@ -26,33 +25,27 @@ settings = get_settings()
 router = APIRouter(prefix="/telegram", tags=["telegram"])
 
 
-async def _send_telegram(method: str, payload: dict) -> dict | None:
-    if not settings.telegram_bot_token:
-        logger.warning("TELEGRAM_BOT_TOKEN not configured")
-        return None
+def _verify_webhook_request(request: Request) -> None:
+    """Validate that the webhook request comes from Telegram.
 
-    url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/{method}"
-    async with httpx.AsyncClient() as client:
-        resp = await client.post(url, json=payload, timeout=10)
-        if resp.status_code == 200:
-            return resp.json()
-        logger.error("Telegram API error: %s %s", resp.status_code, resp.text)
-        return None
+    Uses the X-Telegram-Bot-Api-Secret-Token header, which Telegram sends
+    when a secret_token is configured via setWebhook.
+    """
+    if not settings.telegram_webhook_secret:
+        return  # Skip validation if secret not configured (dev mode)
 
-
-async def send_menu(chat_id: int) -> dict | None:
-    return await _send_telegram("sendMessage", {
-        "chat_id": chat_id,
-        "text": get_telegram_menu_text(),
-        "parse_mode": "Markdown",
-        "reply_markup": {"inline_keyboard": get_telegram_buttons()},
-    })
+    token = request.headers.get("X-Telegram-Bot-Api-Secret-Token", "")
+    if not hmac.compare_digest(token, settings.telegram_webhook_secret):
+        raise HTTPException(status_code=403, detail="Invalid webhook token")
 
 
 @router.post("/webhook")
 async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db)):
+    _verify_webhook_request(request)
+
     data = await request.json()
 
+    # Handle /menu command
     message = data.get("message")
     if message:
         text = message.get("text", "")
@@ -62,22 +55,15 @@ async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db))
             await send_menu(chat_id)
             return {"ok": True}
 
+    # Handle inline keyboard callbacks
     callback_query = data.get("callback_query")
     if callback_query:
         callback_data = callback_query.get("data", "")
         chat_id = callback_query["message"]["chat"]["id"]
         callback_id = callback_query["id"]
 
-        await _send_telegram("answerCallbackQuery", {"callback_query_id": callback_id})
-
-        response_text = get_callback_response(callback_data)
-        if response_text:
-            await _send_telegram("sendMessage", {
-                "chat_id": chat_id,
-                "text": response_text,
-                "parse_mode": "Markdown",
-            })
-
+        await answer_callback(callback_id)
+        await handle_menu_callback(chat_id, callback_data)
         return {"ok": True}
 
     return {"ok": True}
@@ -105,7 +91,7 @@ async def trigger_send_menu(chat_id: int = Query(...)):
 
 @router.post("/set-commands")
 async def set_bot_commands():
-    result = await _send_telegram("setMyCommands", {"commands": BOT_COMMANDS})
+    result = await register_bot_commands()
     if result:
         return {"data": {"registered": True}, "error": None}
     return {"data": None, "error": {"code": "REGISTER_FAILED", "message": "Failed to register commands"}}

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -1,0 +1,154 @@
+"""Telegram Bot webhook/polling router.
+
+Handles /menu command and inline keyboard callbacks directly,
+bypassing OpenClaw for interactive UI elements.
+"""
+import logging
+import uuid
+from datetime import date
+
+import httpx
+from fastapi import APIRouter, Depends, Request
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.config import get_settings
+from backend.database import get_db
+from backend.models.user import User
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+router = APIRouter(prefix="/telegram", tags=["telegram"])
+
+MENU_TEXT = """🏦 *Finance Assistant — Menu*
+
+Chọn tính năng bạn muốn sử dụng:"""
+
+MENU_BUTTONS = [
+    [
+        {"text": "📧 Quét Gmail", "callback_data": "menu:gmail_scan"},
+        {"text": "📸 OCR Hóa đơn", "callback_data": "menu:ocr_info"},
+    ],
+    [
+        {"text": "✍️ Thêm chi tiêu", "callback_data": "menu:add_expense"},
+        {"text": "📊 Báo cáo", "callback_data": "menu:report"},
+    ],
+    [
+        {"text": "📈 Thị trường", "callback_data": "menu:market"},
+        {"text": "💡 Gợi ý đầu tư", "callback_data": "menu:advice"},
+    ],
+    [
+        {"text": "🎯 Mục tiêu", "callback_data": "menu:goals"},
+        {"text": "💰 Thu nhập", "callback_data": "menu:income"},
+    ],
+]
+
+CALLBACK_RESPONSES = {
+    "menu:gmail_scan": "📧 *Quét hóa đơn Gmail*\n\nGửi tin nhắn: \"quét gmail\" hoặc \"scan gmail\"\n\nBot sẽ quét Gmail tìm hóa đơn từ UOB Bank, Grab, Xanh SM, Traveloka và tự động ghi nhận chi tiêu.",
+    "menu:ocr_info": "📸 *Nhận diện hóa đơn*\n\nGửi ảnh hóa đơn/receipt trực tiếp vào chat.\n\nBot sẽ dùng AI Vision để trích xuất:\n• Tên merchant\n• Số tiền\n• Ngày\n• Danh mục\n\nSau đó hỏi bạn confirm trước khi lưu.",
+    "menu:add_expense": "✍️ *Thêm chi tiêu*\n\nGửi theo format:\n\"thêm chi tiêu [số tiền] [mô tả]\"\n\nVí dụ:\n• \"thêm chi tiêu 150k ăn trưa\"\n• \"chi 50k grab\"\n• \"ghi lại 200k shopping\"",
+    "menu:report": "📊 *Báo cáo chi tiêu*\n\nGửi:\n• \"báo cáo tháng này\"\n• \"báo cáo tháng 3\"\n• \"tổng chi tiêu\"\n\nBot sẽ tổng hợp chi tiêu theo danh mục, so sánh với tháng trước, và đưa ra nhận xét.",
+    "menu:market": "📈 *Thông tin thị trường*\n\nGửi:\n• \"thị trường hôm nay?\"\n• \"VN-Index?\"\n\nBot hiển thị VN-Index, VN30, HNX và các quỹ đầu tư (DCDS, VESAF...).",
+    "menu:advice": "💡 *Gợi ý đầu tư*\n\nGửi: \"nên đầu tư gì?\"\n\nBot phân tích tình hình tài chính cá nhân + thị trường để đưa ra gợi ý phù hợp.",
+    "menu:goals": "🎯 *Mục tiêu tài chính*\n\nGửi:\n• \"tôi muốn tiết kiệm 50tr để mua xe trong 6 tháng\"\n• \"tiến độ mục tiêu?\"\n• \"cập nhật mục tiêu\"\n\nBot theo dõi tiến độ và nhắc nhở bạn.",
+    "menu:income": "💰 *Cập nhật thu nhập*\n\nGửi: \"thu nhập tháng này là 20tr\"\n\nBot dùng thu nhập để tính tỷ lệ tiết kiệm và đưa ra báo cáo chính xác hơn.",
+}
+
+
+async def _send_telegram(method: str, payload: dict) -> dict | None:
+    """Send request to Telegram Bot API."""
+    if not settings.telegram_bot_token:
+        logger.warning("TELEGRAM_BOT_TOKEN not configured")
+        return None
+
+    url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/{method}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=payload, timeout=10)
+        if resp.status_code == 200:
+            return resp.json()
+        logger.error("Telegram API error: %s %s", resp.status_code, resp.text)
+        return None
+
+
+async def send_menu(chat_id: int) -> dict | None:
+    """Send the menu with inline keyboard to a Telegram chat."""
+    return await _send_telegram("sendMessage", {
+        "chat_id": chat_id,
+        "text": MENU_TEXT,
+        "parse_mode": "Markdown",
+        "reply_markup": {"inline_keyboard": MENU_BUTTONS},
+    })
+
+
+async def _get_user_by_telegram_id(db: AsyncSession, telegram_id: int) -> User | None:
+    stmt = select(User).where(User.telegram_id == telegram_id, User.deleted_at.is_(None))
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+@router.post("/webhook")
+async def telegram_webhook(request: Request, db: AsyncSession = Depends(get_db)):
+    """Handle Telegram webhook updates."""
+    data = await request.json()
+
+    # Handle /menu command
+    message = data.get("message")
+    if message:
+        text = message.get("text", "")
+        chat_id = message["chat"]["id"]
+
+        if text.strip().lower() in ("/menu", "/start", "menu"):
+            await send_menu(chat_id)
+            return {"ok": True}
+
+    # Handle callback queries (inline keyboard button presses)
+    callback_query = data.get("callback_query")
+    if callback_query:
+        callback_data = callback_query.get("data", "")
+        chat_id = callback_query["message"]["chat"]["id"]
+        callback_id = callback_query["id"]
+
+        # Acknowledge the callback
+        await _send_telegram("answerCallbackQuery", {"callback_query_id": callback_id})
+
+        # Send feature info
+        response_text = CALLBACK_RESPONSES.get(callback_data)
+        if response_text:
+            await _send_telegram("sendMessage", {
+                "chat_id": chat_id,
+                "text": response_text,
+                "parse_mode": "Markdown",
+            })
+
+        return {"ok": True}
+
+    return {"ok": True}
+
+
+@router.post("/send-menu")
+async def trigger_send_menu(
+    chat_id: int,
+    db: AsyncSession = Depends(get_db),
+):
+    """Manually trigger sending the menu to a specific chat."""
+    result = await send_menu(chat_id)
+    if result:
+        return {"data": {"sent": True}, "error": None}
+    return {"data": None, "error": {"code": "SEND_FAILED", "message": "Failed to send menu"}}
+
+
+@router.post("/set-commands")
+async def set_bot_commands():
+    """Register bot commands with Telegram (shown in command menu)."""
+    commands = [
+        {"command": "menu", "description": "Hiển thị menu tính năng"},
+        {"command": "start", "description": "Bắt đầu sử dụng bot"},
+        {"command": "report", "description": "Báo cáo chi tiêu tháng này"},
+        {"command": "goals", "description": "Xem mục tiêu tài chính"},
+        {"command": "market", "description": "Thông tin thị trường"},
+    ]
+    result = await _send_telegram("setMyCommands", {"commands": commands})
+    if result:
+        return {"data": {"registered": True}, "error": None}
+    return {"data": None, "error": {"code": "REGISTER_FAILED", "message": "Failed to register commands"}}

--- a/backend/services/menu_service.py
+++ b/backend/services/menu_service.py
@@ -1,0 +1,142 @@
+"""Menu service — single source of truth for all menu data.
+
+All menu text, buttons, and feature descriptions are defined here.
+Both the Telegram router and OpenClaw skill consume this via API.
+"""
+
+FEATURES = [
+    {
+        "key": "gmail_scan",
+        "emoji": "\U0001f4e7",
+        "label": "Quét hóa đơn Gmail",
+        "short_label": "Quét Gmail",
+        "trigger_examples": ["quét gmail", "scan gmail"],
+        "description": (
+            "Quét Gmail tìm hóa đơn từ UOB Bank, Grab, Xanh SM, Traveloka "
+            "và tự động ghi nhận chi tiêu."
+        ),
+    },
+    {
+        "key": "ocr",
+        "emoji": "\U0001f4f8",
+        "label": "Nhận diện hóa đơn",
+        "short_label": "OCR Hóa đơn",
+        "trigger_examples": ["gửi ảnh hóa đơn/receipt trực tiếp"],
+        "description": (
+            "Dùng AI Vision để trích xuất:\n"
+            "• Tên merchant\n• Số tiền\n• Ngày\n• Danh mục\n\n"
+            "Sau đó hỏi bạn confirm trước khi lưu."
+        ),
+    },
+    {
+        "key": "add_expense",
+        "emoji": "\u270d\ufe0f",
+        "label": "Thêm chi tiêu",
+        "short_label": "Thêm chi tiêu",
+        "trigger_examples": ["thêm chi tiêu 150k ăn trưa", "chi 50k grab", "ghi lại 200k shopping"],
+        "description": 'Gửi theo format: "thêm chi tiêu [số tiền] [mô tả]"',
+    },
+    {
+        "key": "report",
+        "emoji": "\U0001f4ca",
+        "label": "Báo cáo chi tiêu",
+        "short_label": "Báo cáo",
+        "trigger_examples": ["báo cáo tháng này", "báo cáo tháng 3", "tổng chi tiêu"],
+        "description": (
+            "Tổng hợp chi tiêu theo danh mục, so sánh với tháng trước, "
+            "và đưa ra nhận xét."
+        ),
+    },
+    {
+        "key": "market",
+        "emoji": "\U0001f4c8",
+        "label": "Thông tin thị trường",
+        "short_label": "Thị trường",
+        "trigger_examples": ["thị trường hôm nay?", "VN-Index?"],
+        "description": "Hiển thị VN-Index, VN30, HNX và các quỹ đầu tư (DCDS, VESAF...).",
+    },
+    {
+        "key": "advice",
+        "emoji": "\U0001f4a1",
+        "label": "Gợi ý đầu tư",
+        "short_label": "Gợi ý đầu tư",
+        "trigger_examples": ["nên đầu tư gì?"],
+        "description": "Phân tích tình hình tài chính cá nhân + thị trường để đưa ra gợi ý phù hợp.",
+    },
+    {
+        "key": "goals",
+        "emoji": "\U0001f3af",
+        "label": "Mục tiêu tài chính",
+        "short_label": "Mục tiêu",
+        "trigger_examples": [
+            "tôi muốn tiết kiệm 50tr để mua xe trong 6 tháng",
+            "tiến độ mục tiêu?",
+            "cập nhật mục tiêu",
+        ],
+        "description": "Theo dõi tiến độ mục tiêu tài chính và nhắc nhở bạn.",
+    },
+    {
+        "key": "income",
+        "emoji": "\U0001f4b0",
+        "label": "Cập nhật thu nhập",
+        "short_label": "Thu nhập",
+        "trigger_examples": ["thu nhập tháng này là 20tr"],
+        "description": "Dùng thu nhập để tính tỷ lệ tiết kiệm và đưa ra báo cáo chính xác hơn.",
+    },
+]
+
+BOT_COMMANDS = [
+    {"command": "menu", "description": "Hiển thị menu tính năng"},
+    {"command": "start", "description": "Bắt đầu sử dụng bot"},
+    {"command": "report", "description": "Báo cáo chi tiêu tháng này"},
+    {"command": "goals", "description": "Xem mục tiêu tài chính"},
+    {"command": "market", "description": "Thông tin thị trường"},
+]
+
+
+def get_menu_text() -> str:
+    """Plain text menu (for OpenClaw / non-Telegram clients)."""
+    lines = ["\U0001f3e6 Finance Assistant — Menu\n", "Chọn tính năng bạn muốn sử dụng:\n"]
+    for f in FEATURES:
+        examples = ", ".join(f'"{e}"' for e in f["trigger_examples"])
+        lines.append(f'{f["emoji"]} {f["label"]} — {examples}')
+    lines.append("\nNhập lệnh hoặc mô tả nhu cầu bằng tiếng Việt tự nhiên.")
+    return "\n".join(lines)
+
+
+def get_telegram_menu_text() -> str:
+    """Markdown menu header for Telegram (used with inline keyboard)."""
+    return "\U0001f3e6 *Finance Assistant — Menu*\n\nChọn tính năng bạn muốn sử dụng:"
+
+
+def get_telegram_buttons() -> list[list[dict]]:
+    """Inline keyboard button layout for Telegram."""
+    pairs = []
+    for i in range(0, len(FEATURES), 2):
+        row = []
+        for f in FEATURES[i : i + 2]:
+            row.append({
+                "text": f'{f["emoji"]} {f["short_label"]}',
+                "callback_data": f'menu:{f["key"]}',
+            })
+        pairs.append(row)
+    return pairs
+
+
+def get_callback_response(callback_key: str) -> str | None:
+    """Markdown response for a Telegram inline keyboard callback."""
+    # callback_key format: "menu:<feature_key>"
+    feature_key = callback_key.removeprefix("menu:")
+    for f in FEATURES:
+        if f["key"] == feature_key:
+            examples = "\n".join(f'• "{e}"' for e in f["trigger_examples"])
+            return (
+                f'{f["emoji"]} *{f["label"]}*\n\n'
+                f"Gửi:\n{examples}\n\n{f['description']}"
+            )
+    return None
+
+
+def get_features_json() -> list[dict]:
+    """Full feature list as JSON (for API consumers)."""
+    return FEATURES

--- a/backend/services/telegram_service.py
+++ b/backend/services/telegram_service.py
@@ -1,0 +1,68 @@
+"""Telegram Bot API transport layer.
+
+All Telegram API interactions go through this service.
+Routers should never call Telegram API directly.
+"""
+import logging
+
+import httpx
+
+from backend.config import get_settings
+from backend.services.menu_service import (
+    BOT_COMMANDS,
+    get_callback_response,
+    get_telegram_buttons,
+    get_telegram_menu_text,
+)
+
+logger = logging.getLogger(__name__)
+settings = get_settings()
+
+
+async def send_telegram(method: str, payload: dict) -> dict | None:
+    """Send a request to the Telegram Bot API."""
+    if not settings.telegram_bot_token:
+        logger.warning("TELEGRAM_BOT_TOKEN not configured")
+        return None
+
+    url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/{method}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.post(url, json=payload, timeout=10)
+        if resp.status_code == 200:
+            return resp.json()
+        logger.error("Telegram API error: %s %s", resp.status_code, resp.text)
+        return None
+
+
+async def send_message(chat_id: int, text: str, parse_mode: str = "Markdown") -> dict | None:
+    return await send_telegram("sendMessage", {
+        "chat_id": chat_id,
+        "text": text,
+        "parse_mode": parse_mode,
+    })
+
+
+async def send_menu(chat_id: int) -> dict | None:
+    """Send the interactive menu with inline keyboard."""
+    return await send_telegram("sendMessage", {
+        "chat_id": chat_id,
+        "text": get_telegram_menu_text(),
+        "parse_mode": "Markdown",
+        "reply_markup": {"inline_keyboard": get_telegram_buttons()},
+    })
+
+
+async def answer_callback(callback_id: str) -> dict | None:
+    return await send_telegram("answerCallbackQuery", {"callback_query_id": callback_id})
+
+
+async def handle_menu_callback(chat_id: int, callback_data: str) -> dict | None:
+    """Look up the callback response and send it."""
+    response_text = get_callback_response(callback_data)
+    if response_text:
+        return await send_message(chat_id, response_text)
+    return None
+
+
+async def register_bot_commands() -> dict | None:
+    return await send_telegram("setMyCommands", {"commands": BOT_COMMANDS})

--- a/backend/tests/test_menu_service.py
+++ b/backend/tests/test_menu_service.py
@@ -1,0 +1,114 @@
+"""Tests for menu_service — single source of truth for menu data."""
+from backend.services.menu_service import (
+    FEATURES,
+    BOT_COMMANDS,
+    get_callback_response,
+    get_features_json,
+    get_menu_text,
+    get_telegram_buttons,
+    get_telegram_menu_text,
+)
+
+
+class TestFeatureDefinitions:
+    def test_features_not_empty(self):
+        assert len(FEATURES) > 0
+
+    def test_each_feature_has_required_keys(self):
+        required = {"key", "emoji", "label", "short_label", "trigger_examples", "description"}
+        for f in FEATURES:
+            missing = required - set(f.keys())
+            assert not missing, f"Feature '{f.get('key', '?')}' missing keys: {missing}"
+
+    def test_feature_keys_unique(self):
+        keys = [f["key"] for f in FEATURES]
+        assert len(keys) == len(set(keys)), "Duplicate feature keys found"
+
+    def test_trigger_examples_not_empty(self):
+        for f in FEATURES:
+            assert len(f["trigger_examples"]) > 0, f"Feature '{f['key']}' has no trigger examples"
+
+
+class TestGetMenuText:
+    def test_returns_string(self):
+        text = get_menu_text()
+        assert isinstance(text, str)
+
+    def test_contains_all_feature_labels(self):
+        text = get_menu_text()
+        for f in FEATURES:
+            assert f["label"] in text, f"Menu text missing feature label: {f['label']}"
+
+    def test_contains_header(self):
+        text = get_menu_text()
+        assert "Finance Assistant" in text
+
+
+class TestGetTelegramMenuText:
+    def test_returns_markdown(self):
+        text = get_telegram_menu_text()
+        assert "*" in text, "Expected Markdown bold formatting"
+
+    def test_contains_header(self):
+        text = get_telegram_menu_text()
+        assert "Finance Assistant" in text
+
+
+class TestGetTelegramButtons:
+    def test_returns_list_of_rows(self):
+        buttons = get_telegram_buttons()
+        assert isinstance(buttons, list)
+        assert len(buttons) > 0
+
+    def test_each_button_has_text_and_callback(self):
+        for row in get_telegram_buttons():
+            for btn in row:
+                assert "text" in btn
+                assert "callback_data" in btn
+                assert btn["callback_data"].startswith("menu:")
+
+    def test_button_count_matches_features(self):
+        buttons = get_telegram_buttons()
+        total = sum(len(row) for row in buttons)
+        assert total == len(FEATURES)
+
+
+class TestGetCallbackResponse:
+    def test_valid_callback_returns_response(self):
+        for f in FEATURES:
+            resp = get_callback_response(f"menu:{f['key']}")
+            assert resp is not None, f"No callback response for menu:{f['key']}"
+            assert f["label"] in resp
+
+    def test_invalid_callback_returns_none(self):
+        assert get_callback_response("menu:nonexistent") is None
+        assert get_callback_response("invalid") is None
+
+    def test_response_contains_trigger_examples(self):
+        for f in FEATURES:
+            resp = get_callback_response(f"menu:{f['key']}")
+            for example in f["trigger_examples"]:
+                assert example in resp, f"Callback response for {f['key']} missing example: {example}"
+
+
+class TestGetFeaturesJson:
+    def test_returns_list(self):
+        features = get_features_json()
+        assert isinstance(features, list)
+
+    def test_matches_features_constant(self):
+        assert get_features_json() is FEATURES
+
+
+class TestBotCommands:
+    def test_commands_not_empty(self):
+        assert len(BOT_COMMANDS) > 0
+
+    def test_each_command_has_required_keys(self):
+        for cmd in BOT_COMMANDS:
+            assert "command" in cmd
+            assert "description" in cmd
+
+    def test_menu_command_exists(self):
+        commands = [c["command"] for c in BOT_COMMANDS]
+        assert "menu" in commands

--- a/backend/tests/test_telegram_router.py
+++ b/backend/tests/test_telegram_router.py
@@ -1,0 +1,104 @@
+"""Tests for telegram router — webhook handling and authentication."""
+import hmac
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+client = TestClient(app)
+
+
+class TestWebhookAuth:
+    def test_rejects_invalid_secret(self):
+        with patch("backend.routers.telegram.settings") as mock:
+            mock.telegram_webhook_secret = "correct-secret"
+            resp = client.post(
+                "/api/v1/telegram/webhook",
+                json={"message": {"text": "/menu", "chat": {"id": 123}}},
+                headers={"X-Telegram-Bot-Api-Secret-Token": "wrong-secret"},
+            )
+            assert resp.status_code == 403
+
+    def test_accepts_valid_secret(self):
+        with patch("backend.routers.telegram.settings") as mock_settings, \
+             patch("backend.routers.telegram.send_menu", new_callable=AsyncMock) as mock_send:
+            mock_settings.telegram_webhook_secret = "correct-secret"
+            mock_send.return_value = {"ok": True}
+            resp = client.post(
+                "/api/v1/telegram/webhook",
+                json={"message": {"text": "/menu", "chat": {"id": 123}}},
+                headers={"X-Telegram-Bot-Api-Secret-Token": "correct-secret"},
+            )
+            assert resp.status_code == 200
+
+    def test_skips_validation_when_no_secret_configured(self):
+        with patch("backend.routers.telegram.settings") as mock_settings, \
+             patch("backend.routers.telegram.send_menu", new_callable=AsyncMock) as mock_send:
+            mock_settings.telegram_webhook_secret = ""
+            mock_send.return_value = {"ok": True}
+            resp = client.post(
+                "/api/v1/telegram/webhook",
+                json={"message": {"text": "/menu", "chat": {"id": 123}}},
+            )
+            assert resp.status_code == 200
+
+
+class TestWebhookMenuCommand:
+    @patch("backend.routers.telegram.send_menu", new_callable=AsyncMock)
+    @patch("backend.routers.telegram.settings")
+    def test_menu_command(self, mock_settings, mock_send):
+        mock_settings.telegram_webhook_secret = ""
+        mock_send.return_value = {"ok": True}
+        resp = client.post(
+            "/api/v1/telegram/webhook",
+            json={"message": {"text": "/menu", "chat": {"id": 123}}},
+        )
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with(123)
+
+    @patch("backend.routers.telegram.send_menu", new_callable=AsyncMock)
+    @patch("backend.routers.telegram.settings")
+    def test_start_command(self, mock_settings, mock_send):
+        mock_settings.telegram_webhook_secret = ""
+        mock_send.return_value = {"ok": True}
+        resp = client.post(
+            "/api/v1/telegram/webhook",
+            json={"message": {"text": "/start", "chat": {"id": 123}}},
+        )
+        assert resp.status_code == 200
+        mock_send.assert_called_once_with(123)
+
+
+class TestWebhookCallback:
+    @patch("backend.routers.telegram.handle_menu_callback", new_callable=AsyncMock)
+    @patch("backend.routers.telegram.answer_callback", new_callable=AsyncMock)
+    @patch("backend.routers.telegram.settings")
+    def test_callback_query(self, mock_settings, mock_answer, mock_handle):
+        mock_settings.telegram_webhook_secret = ""
+        mock_handle.return_value = {"ok": True}
+        resp = client.post(
+            "/api/v1/telegram/webhook",
+            json={
+                "callback_query": {
+                    "id": "cb-123",
+                    "data": "menu:report",
+                    "message": {"chat": {"id": 456}},
+                },
+            },
+        )
+        assert resp.status_code == 200
+        mock_answer.assert_called_once_with("cb-123")
+        mock_handle.assert_called_once_with(456, "menu:report")
+
+
+class TestMenuEndpoint:
+    def test_get_menu_returns_features(self):
+        resp = client.get("/api/v1/telegram/menu")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["error"] is None
+        assert "text" in data["data"]
+        assert "features" in data["data"]
+        assert len(data["data"]["features"]) > 0

--- a/backend/tests/test_telegram_service.py
+++ b/backend/tests/test_telegram_service.py
@@ -1,0 +1,108 @@
+"""Tests for telegram_service — Telegram API transport layer."""
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.services.telegram_service import (
+    answer_callback,
+    handle_menu_callback,
+    register_bot_commands,
+    send_menu,
+    send_message,
+    send_telegram,
+)
+
+
+@pytest.fixture
+def mock_settings():
+    with patch("backend.services.telegram_service.settings") as mock:
+        mock.telegram_bot_token = "test-token-123"
+        yield mock
+
+
+@pytest.fixture
+def mock_httpx():
+    with patch("backend.services.telegram_service.httpx.AsyncClient") as mock_client_cls:
+        mock_client = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {"ok": True, "result": True}
+        mock_response.text = '{"ok": true}'
+        mock_client.post.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+        yield mock_client
+
+
+class TestSendTelegram:
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_token(self):
+        with patch("backend.services.telegram_service.settings") as mock:
+            mock.telegram_bot_token = ""
+            result = await send_telegram("sendMessage", {"chat_id": 123})
+            assert result is None
+
+    @pytest.mark.asyncio
+    async def test_calls_correct_url(self, mock_settings, mock_httpx):
+        await send_telegram("sendMessage", {"chat_id": 123, "text": "hi"})
+        mock_httpx.post.assert_called_once()
+        call_url = mock_httpx.post.call_args[0][0]
+        assert "bot" + "test-token-123" in call_url
+        assert "sendMessage" in call_url
+
+    @pytest.mark.asyncio
+    async def test_returns_none_on_api_error(self, mock_settings, mock_httpx):
+        mock_httpx.post.return_value.status_code = 400
+        result = await send_telegram("sendMessage", {"chat_id": 123})
+        assert result is None
+
+
+class TestSendMessage:
+    @pytest.mark.asyncio
+    async def test_sends_with_correct_params(self, mock_settings, mock_httpx):
+        await send_message(123, "hello")
+        payload = mock_httpx.post.call_args[1]["json"]
+        assert payload["chat_id"] == 123
+        assert payload["text"] == "hello"
+        assert payload["parse_mode"] == "Markdown"
+
+
+class TestSendMenu:
+    @pytest.mark.asyncio
+    async def test_sends_inline_keyboard(self, mock_settings, mock_httpx):
+        await send_menu(123)
+        payload = mock_httpx.post.call_args[1]["json"]
+        assert "reply_markup" in payload
+        assert "inline_keyboard" in payload["reply_markup"]
+
+
+class TestAnswerCallback:
+    @pytest.mark.asyncio
+    async def test_calls_answer_callback_query(self, mock_settings, mock_httpx):
+        await answer_callback("callback-123")
+        call_url = mock_httpx.post.call_args[0][0]
+        assert "answerCallbackQuery" in call_url
+
+
+class TestHandleMenuCallback:
+    @pytest.mark.asyncio
+    async def test_valid_callback_sends_response(self, mock_settings, mock_httpx):
+        result = await handle_menu_callback(123, "menu:gmail_scan")
+        assert result is not None
+        payload = mock_httpx.post.call_args[1]["json"]
+        assert payload["chat_id"] == 123
+        assert "Gmail" in payload["text"]
+
+    @pytest.mark.asyncio
+    async def test_invalid_callback_returns_none(self, mock_settings, mock_httpx):
+        result = await handle_menu_callback(123, "menu:nonexistent")
+        assert result is None
+
+
+class TestRegisterBotCommands:
+    @pytest.mark.asyncio
+    async def test_calls_set_my_commands(self, mock_settings, mock_httpx):
+        await register_bot_commands()
+        call_url = mock_httpx.post.call_args[0][0]
+        assert "setMyCommands" in call_url

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,9 @@ services:
     image: postgres:16-alpine
     container_name: finance-postgres
     environment:
-      POSTGRES_USER: finance
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: finance_db
+      POSTGRES_USER: ${POSTGRES_USER:-finance}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+      POSTGRES_DB: ${POSTGRES_DB:-finance_db}
     ports:
       - "5433:5432"
     volumes:

--- a/openclaw-skills/finance-expense/scripts/expense_cli.py
+++ b/openclaw-skills/finance-expense/scripts/expense_cli.py
@@ -9,9 +9,22 @@ from datetime import date
 
 import requests
 
-API_URL = os.environ.get("FINANCE_API_URL", "http://localhost:8001/api/v1")
+API_URL = os.environ.get("FINANCE_API_URL", "")
 API_KEY = os.environ.get("FINANCE_API_KEY", "")
 USER_ID = os.environ.get("FINANCE_USER_ID", "")
+
+
+def _validate_env():
+    missing = []
+    if not API_URL:
+        missing.append("FINANCE_API_URL")
+    if not API_KEY:
+        missing.append("FINANCE_API_KEY")
+    if not USER_ID:
+        missing.append("FINANCE_USER_ID")
+    if missing:
+        print(f"Error: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _headers() -> dict:
@@ -97,6 +110,7 @@ def get_summary(month: str | None = None):
 
 
 if __name__ == "__main__":
+    _validate_env()
     if len(sys.argv) < 2:
         print("Usage: expense_cli.py <add|list|summary> [args...]")
         sys.exit(1)

--- a/openclaw-skills/finance-goals/scripts/goals_cli.py
+++ b/openclaw-skills/finance-goals/scripts/goals_cli.py
@@ -8,9 +8,22 @@ from datetime import date
 
 import requests
 
-API_URL = os.environ.get("FINANCE_API_URL", "http://localhost:8001/api/v1")
+API_URL = os.environ.get("FINANCE_API_URL", "")
 API_KEY = os.environ.get("FINANCE_API_KEY", "")
 USER_ID = os.environ.get("FINANCE_USER_ID", "")
+
+
+def _validate_env():
+    missing = []
+    if not API_URL:
+        missing.append("FINANCE_API_URL")
+    if not API_KEY:
+        missing.append("FINANCE_API_KEY")
+    if not USER_ID:
+        missing.append("FINANCE_USER_ID")
+    if missing:
+        print(f"Error: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _headers() -> dict:
@@ -116,6 +129,7 @@ def set_income(amount: float):
 
 
 if __name__ == "__main__":
+    _validate_env()
     if len(sys.argv) < 2:
         print("Usage: goals_cli.py <create|list|progress|income> [args...]")
         sys.exit(1)

--- a/openclaw-skills/finance-market/scripts/market_cli.py
+++ b/openclaw-skills/finance-market/scripts/market_cli.py
@@ -5,9 +5,22 @@ import sys
 
 import requests
 
-API_URL = os.environ.get("FINANCE_API_URL", "http://localhost:8001/api/v1")
+API_URL = os.environ.get("FINANCE_API_URL", "")
 API_KEY = os.environ.get("FINANCE_API_KEY", "")
 USER_ID = os.environ.get("FINANCE_USER_ID", "")
+
+
+def _validate_env():
+    missing = []
+    if not API_URL:
+        missing.append("FINANCE_API_URL")
+    if not API_KEY:
+        missing.append("FINANCE_API_KEY")
+    if not USER_ID:
+        missing.append("FINANCE_USER_ID")
+    if missing:
+        print(f"Error: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _headers() -> dict:
@@ -64,6 +77,7 @@ def advice():
 
 
 if __name__ == "__main__":
+    _validate_env()
     if len(sys.argv) < 2:
         print("Usage: market_cli.py <snapshot|history|advice> [args...]")
         sys.exit(1)

--- a/openclaw-skills/finance-menu/SKILL.md
+++ b/openclaw-skills/finance-menu/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: finance-menu
+description: >
+  Hiển thị menu chính của Finance Assistant với tất cả tính năng.
+  Cho phép người dùng chọn tính năng qua inline keyboard buttons.
+metadata:
+  openclaw:
+    requires:
+      bins: ["python3"]
+---
+
+# Finance Menu Skill
+
+## Khi nào dùng skill này
+- User gửi "/menu" hoặc "menu"
+- User hỏi "có tính năng gì?", "giúp tôi", "help"
+- User bắt đầu chat lần đầu
+
+## Cách thực thi
+1. Chạy: `python3 scripts/menu_cli.py`
+2. Hiển thị menu với danh sách tính năng
+
+## Output format
+Trả về đúng text sau cho Telegram:
+
+```
+🏦 Finance Assistant — Menu
+
+Chọn tính năng bạn muốn sử dụng:
+
+📧 Quét hóa đơn Gmail — "quét gmail" hoặc "scan gmail"
+📸 Nhận diện hóa đơn — Gửi ảnh hóa đơn/receipt
+✍️ Thêm chi tiêu — "thêm chi tiêu 150k ăn trưa"
+📊 Báo cáo chi tiêu — "báo cáo tháng này"
+📈 Thông tin thị trường — "thị trường hôm nay?"
+🎯 Mục tiêu tài chính — "mục tiêu" hoặc "tiến độ"
+💰 Cập nhật thu nhập — "thu nhập tháng này 20tr"
+💡 Gợi ý đầu tư — "nên đầu tư gì?"
+
+Nhập lệnh hoặc mô tả nhu cầu bằng tiếng Việt tự nhiên.
+```

--- a/openclaw-skills/finance-menu/SKILL.md
+++ b/openclaw-skills/finance-menu/SKILL.md
@@ -2,7 +2,7 @@
 name: finance-menu
 description: >
   Hiển thị menu chính của Finance Assistant với tất cả tính năng.
-  Cho phép người dùng chọn tính năng qua inline keyboard buttons.
+  Menu data được lấy từ backend API (single source of truth).
 metadata:
   openclaw:
     requires:
@@ -14,28 +14,8 @@ metadata:
 ## Khi nào dùng skill này
 - User gửi "/menu" hoặc "menu"
 - User hỏi "có tính năng gì?", "giúp tôi", "help"
-- User bắt đầu chat lần đầu
 
 ## Cách thực thi
 1. Chạy: `python3 scripts/menu_cli.py`
-2. Hiển thị menu với danh sách tính năng
-
-## Output format
-Trả về đúng text sau cho Telegram:
-
-```
-🏦 Finance Assistant — Menu
-
-Chọn tính năng bạn muốn sử dụng:
-
-📧 Quét hóa đơn Gmail — "quét gmail" hoặc "scan gmail"
-📸 Nhận diện hóa đơn — Gửi ảnh hóa đơn/receipt
-✍️ Thêm chi tiêu — "thêm chi tiêu 150k ăn trưa"
-📊 Báo cáo chi tiêu — "báo cáo tháng này"
-📈 Thông tin thị trường — "thị trường hôm nay?"
-🎯 Mục tiêu tài chính — "mục tiêu" hoặc "tiến độ"
-💰 Cập nhật thu nhập — "thu nhập tháng này 20tr"
-💡 Gợi ý đầu tư — "nên đầu tư gì?"
-
-Nhập lệnh hoặc mô tả nhu cầu bằng tiếng Việt tự nhiên.
-```
+2. Script gọi `GET {FINANCE_API_URL}/telegram/menu` để lấy menu text
+3. Hiển thị kết quả cho user

--- a/openclaw-skills/finance-menu/scripts/menu_cli.py
+++ b/openclaw-skills/finance-menu/scripts/menu_cli.py
@@ -1,22 +1,33 @@
 #!/usr/bin/env python3
 """OpenClaw Skill CLI: finance-menu
-Display the main menu with all available features.
+Thin wrapper — fetch menu from backend API.
 """
+import os
+import sys
 
-MENU_TEXT = """🏦 Finance Assistant — Menu
+import requests
 
-Chọn tính năng bạn muốn sử dụng:
+API_URL = os.environ.get("FINANCE_API_URL", "http://localhost:8001/api/v1")
+API_KEY = os.environ.get("FINANCE_API_KEY", "")
 
-📧 Quét hóa đơn Gmail — "quét gmail" hoặc "scan gmail"
-📸 Nhận diện hóa đơn — Gửi ảnh hóa đơn/receipt trực tiếp
-✍️ Thêm chi tiêu — "thêm chi tiêu 150k ăn trưa"
-📊 Báo cáo chi tiêu — "báo cáo tháng này"
-📈 Thông tin thị trường — "thị trường hôm nay?"
-🎯 Mục tiêu tài chính — "mục tiêu" hoặc "tiến độ"
-💰 Cập nhật thu nhập — "thu nhập tháng này 20tr"
-💡 Gợi ý đầu tư — "nên đầu tư gì?"
 
-Nhập lệnh hoặc mô tả nhu cầu bằng tiếng Việt tự nhiên."""
+def _headers() -> dict:
+    return {"X-API-Key": API_KEY}
+
+
+def show_menu():
+    resp = requests.get(
+        f"{API_URL}/telegram/menu",
+        headers=_headers(),
+        timeout=10,
+    )
+    if resp.status_code == 200:
+        data = resp.json()
+        print(data["data"]["text"])
+    else:
+        print(f"Lỗi: {resp.status_code}", file=sys.stderr)
+        sys.exit(1)
+
 
 if __name__ == "__main__":
-    print(MENU_TEXT)
+    show_menu()

--- a/openclaw-skills/finance-menu/scripts/menu_cli.py
+++ b/openclaw-skills/finance-menu/scripts/menu_cli.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+"""OpenClaw Skill CLI: finance-menu
+Display the main menu with all available features.
+"""
+
+MENU_TEXT = """🏦 Finance Assistant — Menu
+
+Chọn tính năng bạn muốn sử dụng:
+
+📧 Quét hóa đơn Gmail — "quét gmail" hoặc "scan gmail"
+📸 Nhận diện hóa đơn — Gửi ảnh hóa đơn/receipt trực tiếp
+✍️ Thêm chi tiêu — "thêm chi tiêu 150k ăn trưa"
+📊 Báo cáo chi tiêu — "báo cáo tháng này"
+📈 Thông tin thị trường — "thị trường hôm nay?"
+🎯 Mục tiêu tài chính — "mục tiêu" hoặc "tiến độ"
+💰 Cập nhật thu nhập — "thu nhập tháng này 20tr"
+💡 Gợi ý đầu tư — "nên đầu tư gì?"
+
+Nhập lệnh hoặc mô tả nhu cầu bằng tiếng Việt tự nhiên."""
+
+if __name__ == "__main__":
+    print(MENU_TEXT)

--- a/openclaw-skills/finance-menu/scripts/menu_cli.py
+++ b/openclaw-skills/finance-menu/scripts/menu_cli.py
@@ -7,8 +7,19 @@ import sys
 
 import requests
 
-API_URL = os.environ.get("FINANCE_API_URL", "http://localhost:8001/api/v1")
+API_URL = os.environ.get("FINANCE_API_URL", "")
 API_KEY = os.environ.get("FINANCE_API_KEY", "")
+
+
+def _validate_env():
+    missing = []
+    if not API_URL:
+        missing.append("FINANCE_API_URL")
+    if not API_KEY:
+        missing.append("FINANCE_API_KEY")
+    if missing:
+        print(f"Error: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _headers() -> dict:
@@ -30,4 +41,5 @@ def show_menu():
 
 
 if __name__ == "__main__":
+    _validate_env()
     show_menu()

--- a/openclaw-skills/finance-ocr/scripts/ocr_cli.py
+++ b/openclaw-skills/finance-ocr/scripts/ocr_cli.py
@@ -7,9 +7,22 @@ import sys
 
 import requests
 
-API_URL = os.environ.get("FINANCE_API_URL", "http://localhost:8001/api/v1")
+API_URL = os.environ.get("FINANCE_API_URL", "")
 API_KEY = os.environ.get("FINANCE_API_KEY", "")
 USER_ID = os.environ.get("FINANCE_USER_ID", "")
+
+
+def _validate_env():
+    missing = []
+    if not API_URL:
+        missing.append("FINANCE_API_URL")
+    if not API_KEY:
+        missing.append("FINANCE_API_KEY")
+    if not USER_ID:
+        missing.append("FINANCE_USER_ID")
+    if missing:
+        print(f"Error: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _headers() -> dict:
@@ -95,6 +108,7 @@ def save_expense(ocr_data: dict):
 
 
 if __name__ == "__main__":
+    _validate_env()
     if len(sys.argv) < 2:
         print("Usage: ocr_cli.py [--save] <image_path>")
         sys.exit(1)

--- a/openclaw-skills/finance-report/scripts/report_cli.py
+++ b/openclaw-skills/finance-report/scripts/report_cli.py
@@ -6,9 +6,22 @@ from datetime import date
 
 import requests
 
-API_URL = os.environ.get("FINANCE_API_URL", "http://localhost:8001/api/v1")
+API_URL = os.environ.get("FINANCE_API_URL", "")
 API_KEY = os.environ.get("FINANCE_API_KEY", "")
 USER_ID = os.environ.get("FINANCE_USER_ID", "")
+
+
+def _validate_env():
+    missing = []
+    if not API_URL:
+        missing.append("FINANCE_API_URL")
+    if not API_KEY:
+        missing.append("FINANCE_API_KEY")
+    if not USER_ID:
+        missing.append("FINANCE_USER_ID")
+    if missing:
+        print(f"Error: missing required env vars: {', '.join(missing)}", file=sys.stderr)
+        sys.exit(1)
 
 
 def _headers() -> dict:
@@ -66,6 +79,7 @@ def generate(month: str | None = None):
 
 
 if __name__ == "__main__":
+    _validate_env()
     if len(sys.argv) < 2:
         print("Usage: report_cli.py <monthly|history|generate> [YYYY-MM]")
         sys.exit(1)


### PR DESCRIPTION
- Telegram router with webhook handler for /menu, /start commands
- Inline keyboard buttons for all 8 features (Gmail scan, OCR, manual expense, reports, market, goals, income, investment advice)
- Callback handlers show usage instructions for each feature
- /set-commands endpoint to register bot commands with Telegram
- OpenClaw finance-menu skill as fallback text menu
- Extensible button/callback architecture for future features

Closes #7

https://claude.ai/code/session_01QD1twTBi9x2bjCwGdn8oM8