### PR TITLE
fix: split scheduler into standalone process

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,17 @@ alembic upgrade head
 uvicorn backend.main:app --reload --port 8000
 ```
 
+### 6. Chạy scheduler (process riêng)
+
+Các job cron (morning report 7h, gmail poll, market snapshot, monthly report)
+chạy ở process riêng để tránh duplicate khi có nhiều uvicorn worker:
+
+```bash
+python -m backend.scheduler
+```
+
+Chỉ chạy **một** instance. Phase 1 sẽ thay bằng Celery worker.
+
 ## Cấu trúc dự án
 
 ```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,6 @@
 import logging
 from contextlib import asynccontextmanager
 
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 
@@ -11,34 +10,14 @@ from backend.routers import expenses, goals, income, ingestion, market, portfoli
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
-scheduler = AsyncIOScheduler()
-
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
+    # Scheduled jobs run in a separate process — see backend/scheduler.py.
+    # Keeping them out of the web server prevents duplicate cron fires when
+    # more than one uvicorn worker is running.
     logger.info("Finance Assistant API starting up")
-
-    # Setup scheduled jobs
-    from backend.jobs.gmail_poller import poll_gmail
-    from backend.jobs.market_poller import poll_market
-    from backend.jobs.monthly_report import generate_all_monthly_reports
-    from backend.jobs.morning_report_job import send_all_morning_reports
-
-    scheduler.add_job(poll_gmail, "cron", minute="*/30", id="gmail_sync")
-    scheduler.add_job(poll_market, "cron", hour=8, minute=0, id="market_snapshot")
-    scheduler.add_job(generate_all_monthly_reports, "cron", day=1, hour=9, minute=0, id="monthly_report")
-    scheduler.add_job(
-        send_all_morning_reports, "cron",
-        hour=7, minute=0, timezone="Asia/Ho_Chi_Minh",
-        id="morning_report",
-    )
-
-    scheduler.start()
-    logger.info("Scheduler started with %d jobs", len(scheduler.get_jobs()))
-
     yield
-
-    scheduler.shutdown()
     logger.info("Finance Assistant API shutting down")
 
 

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -1,0 +1,64 @@
+"""Standalone scheduler process — runs APScheduler outside the web server.
+
+Run with: python -m backend.scheduler
+
+Split from the FastAPI app so starting multiple uvicorn workers (or
+accidentally leaving an old instance running) does not register the
+same cron jobs multiple times. Phase 1 will replace this with Celery
+workers; until then this single-process runner is the source of truth
+for scheduled jobs.
+"""
+import asyncio
+import logging
+import signal
+
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
+
+from backend.jobs.gmail_poller import poll_gmail
+from backend.jobs.market_poller import poll_market
+from backend.jobs.monthly_report import generate_all_monthly_reports
+from backend.jobs.morning_report_job import send_all_morning_reports
+
+logger = logging.getLogger(__name__)
+
+
+def register_jobs(scheduler: AsyncIOScheduler) -> None:
+    scheduler.add_job(poll_gmail, "cron", minute="*/30", id="gmail_sync")
+    scheduler.add_job(poll_market, "cron", hour=8, minute=0, id="market_snapshot")
+    scheduler.add_job(
+        generate_all_monthly_reports, "cron",
+        day=1, hour=9, minute=0, id="monthly_report",
+    )
+    scheduler.add_job(
+        send_all_morning_reports, "cron",
+        hour=7, minute=0, timezone="Asia/Ho_Chi_Minh",
+        id="morning_report",
+    )
+
+
+async def _run() -> None:
+    scheduler = AsyncIOScheduler()
+    register_jobs(scheduler)
+    scheduler.start()
+    logger.info("Scheduler started with %d jobs", len(scheduler.get_jobs()))
+
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, stop.set)
+
+    await stop.wait()
+    scheduler.shutdown()
+    logger.info("Scheduler shutdown complete")
+
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+    )
+    asyncio.run(_run())
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Root cause of the duplicate 7 AM morning report: two `uvicorn backend.main:app` processes were running simultaneously (ports 8000 and 8001), each instantiated its own `AsyncIOScheduler` at module scope and registered the `morning_report` cron job, so every user received the report twice.
- Move all scheduled jobs out of the FastAPI lifespan into a new standalone process: `backend/scheduler.py`, runnable via `python -m backend.scheduler`. Uvicorn no longer starts a scheduler — spawning extra web workers can no longer cause duplicate fires.
- Aligns with the Phase 1 plan in CLAUDE.md ("tách jobs ra worker riêng"); replacing this runner with Celery beat + worker later is a drop-in swap.

## Test plan
- [ ] `python -m backend.scheduler` starts, logs 4 jobs registered (`gmail_sync`, `market_snapshot`, `monthly_report`, `morning_report`)
- [ ] SIGINT/SIGTERM shuts scheduler down cleanly
- [ ] `uvicorn backend.main:app` starts without registering any jobs — `GET /health` still returns 200
- [ ] Kill both stale uvicorn processes (PIDs 22535, 49943) and start one clean web + one scheduler; wait for the 7 AM morning report and confirm a single delivery per user
- [ ] Existing test suite (`pytest backend/tests`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)