### PR TITLE
feat(bot): user registration, natural language expenses, mini app fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,9 @@ htmlcov/
 
 # Alembic
 alembic/versions/__pycache__/
+
+# Cloudflare Tunnel — credentials contain secret tunnel token
+.cloudflared/*.json
+.cloudflared/config.yml
+# Keep template and hostname hint
+!.cloudflared/config.yml.template

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -1,0 +1,90 @@
+"""Handle free-text Telegram messages — natural language expense entry."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.bot.handlers.transaction import send_transaction_confirmation
+from backend.models.user import User
+from backend.schemas.expense import ExpenseCreate
+from backend.services import expense_service
+from backend.services.llm_service import call_llm
+from backend.services.telegram_service import send_message, send_menu
+
+logger = logging.getLogger(__name__)
+
+_PARSE_PROMPT = """Parse chi tiêu từ text sau và trả về JSON:
+"{text}"
+
+Trả về JSON với format:
+{{"amount": <số>, "merchant": "<tên hoặc mô tả ngắn>", "is_expense": <true|false>}}
+
+Quy tắc:
+- Nếu có số tiền và mô tả → is_expense: true
+- Nếu là câu hỏi, tin nhắn thông thường, không phải chi tiêu → is_expense: false, amount: 0
+- "k" hoặc "K" cuối số = × 1000: 50k = 50000, 150k = 150000
+- merchant = nơi mua hoặc mô tả ngắn gọn nhất
+
+Chỉ trả về JSON, không giải thích."""
+
+
+async def _get_user(db: AsyncSession, telegram_id: int) -> User | None:
+    stmt = select(User).where(
+        User.telegram_id == telegram_id,
+        User.deleted_at.is_(None),
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
+
+
+async def handle_text_message(db: AsyncSession, message: dict) -> bool:
+    """Try to parse a plain-text message as an expense entry.
+
+    Returns True if the message was handled (regardless of parse outcome),
+    so the caller knows whether to fall back to another handler.
+    """
+    text = message.get("text", "").strip()
+    if not text:
+        return False
+
+    chat_id = message["chat"]["id"]
+    from_data = message.get("from") or {}
+    telegram_id = from_data.get("id", chat_id)
+
+    user = await _get_user(db, telegram_id)
+    if not user:
+        await send_message(chat_id, "Bạn chưa đăng ký. Gửi /start để bắt đầu.")
+        return True
+
+    try:
+        raw = await call_llm(
+            _PARSE_PROMPT.format(text=text),
+            task_type="parse_manual",
+            db=db,
+            use_cache=False,
+        )
+        # Strip markdown code fences if present
+        lines = [l for l in raw.splitlines() if not l.startswith("```")]
+        parsed = json.loads("\n".join(lines))
+    except Exception:
+        logger.exception("LLM parse failed for text: %r", text)
+        return False
+
+    if not parsed.get("is_expense") or float(parsed.get("amount", 0)) <= 0:
+        # Not an expense — show menu as fallback
+        await send_menu(chat_id)
+        return True
+
+    expense_data = ExpenseCreate(
+        amount=float(parsed["amount"]),
+        merchant=parsed.get("merchant") or text,
+        note=text,
+        source="manual",
+        expense_date=date.today(),
+    )
+    expense = await expense_service.create_expense(db, user.id, expense_data)
+    await send_transaction_confirmation(db, expense)
+    return True

--- a/backend/miniapp/routes.py
+++ b/backend/miniapp/routes.py
@@ -75,9 +75,14 @@ async def _resolve_user(
     telegram_id = auth.get("user_id")
     if not telegram_id:
         raise HTTPException(status_code=401, detail="Missing Telegram user id")
-    user = await dashboard_service.get_user_by_telegram_id(db, telegram_id)
-    if not user:
-        raise HTTPException(status_code=404, detail="User not registered")
+    # Safety net: user should already exist from /start, but create if missing.
+    user, _ = await dashboard_service.get_or_create_user(
+        db,
+        telegram_id,
+        first_name=auth.get("first_name"),
+        last_name=auth.get("last_name"),
+        username=auth.get("username"),
+    )
     return user
 
 

--- a/backend/miniapp/static/js/dashboard.js
+++ b/backend/miniapp/static/js/dashboard.js
@@ -60,17 +60,23 @@
     }
 
     async function fetchAPI(endpoint) {
+        const controller = new AbortController();
+        const tid = setTimeout(() => controller.abort(), 12000);
         const headers = { 'Content-Type': 'application/json' };
         if (tg && tg.initData) {
             headers['X-Telegram-Init-Data'] = tg.initData;
         }
-        const response = await fetch('/miniapp/api' + endpoint, { headers });
-        if (!response.ok) {
-            throw new Error('API ' + response.status);
+        try {
+            const response = await fetch('/miniapp/api' + endpoint, { headers, signal: controller.signal });
+            if (!response.ok) {
+                throw new Error('API ' + response.status);
+            }
+            const payload = await response.json();
+            if (payload.error) throw new Error(payload.error.message || 'API error');
+            return payload.data;
+        } finally {
+            clearTimeout(tid);
         }
-        const payload = await response.json();
-        if (payload.error) throw new Error(payload.error.message || 'API error');
-        return payload.data;
     }
 
     async function renderDashboard() {
@@ -121,6 +127,7 @@
     }
 
     function buildErrorMessage(err) {
+        if (err && err.name === 'AbortError') return 'Kết nối quá chậm — thử lại nhé.';
         if (err && err.message === 'API 401') return 'Phiên đăng nhập Telegram không hợp lệ.';
         if (err && err.message === 'API 404') return 'Chưa có dữ liệu — hãy ghi giao dịch đầu tiên.';
         return 'Không tải được dữ liệu, thử lại nhé.';

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -12,8 +12,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend import analytics
 from backend.bot.formatters.templates import format_welcome_message
 from backend.bot.handlers.callbacks import handle_transaction_callback
+from backend.bot.handlers.message import handle_text_message
 from backend.config import get_settings
 from backend.database import get_db
+from backend.services import dashboard_service
 from backend.services.menu_service import get_features_json, get_menu_text
 from backend.services.telegram_service import (
     answer_callback,
@@ -60,18 +62,38 @@ async def telegram_webhook(
         command = text.strip().lower()
 
         if command == "/start":
-            display_name = (message.get("from") or {}).get("first_name")
+            from_user = message.get("from") or {}
+            display_name = from_user.get("first_name")
+            telegram_id = from_user.get("id")
+            if telegram_id:
+                user, created = await dashboard_service.get_or_create_user(
+                    db,
+                    telegram_id,
+                    first_name=from_user.get("first_name"),
+                    last_name=from_user.get("last_name"),
+                    username=from_user.get("username"),
+                )
+                analytics.track(
+                    analytics.EventType.BOT_STARTED,
+                    user_id=user.id,
+                    properties={"has_display_name": bool(display_name), "new_user": created},
+                )
+            else:
+                analytics.track(
+                    analytics.EventType.BOT_STARTED,
+                    properties={"has_display_name": bool(display_name), "new_user": False},
+                )
             await send_message(chat_id, format_welcome_message(display_name))
             await send_menu(chat_id)
-            analytics.track(
-                analytics.EventType.BOT_STARTED,
-                properties={"has_display_name": bool(display_name)},
-            )
             return {"ok": True}
 
         if command in ("/menu", "menu"):
             await send_menu(chat_id)
             return {"ok": True}
+
+        # Natural language message — try to parse as expense
+        await handle_text_message(db, message)
+        return {"ok": True}
 
     # Handle inline keyboard callbacks
     callback_query = data.get("callback_query")

--- a/backend/services/dashboard_service.py
+++ b/backend/services/dashboard_service.py
@@ -44,6 +44,29 @@ async def get_user_by_telegram_id(
     return (await db.execute(stmt)).scalar_one_or_none()
 
 
+async def get_or_create_user(
+    db: AsyncSession,
+    telegram_id: int,
+    *,
+    first_name: str | None = None,
+    last_name: str | None = None,
+    username: str | None = None,
+) -> tuple[User, bool]:
+    """Return (user, created). Creates a DB record on first encounter."""
+    user = await get_user_by_telegram_id(db, telegram_id)
+    if user:
+        return user, False
+    user = User(
+        telegram_id=telegram_id,
+        telegram_handle=username,
+        display_name=first_name or last_name,
+    )
+    db.add(user)
+    await db.commit()
+    await db.refresh(user)
+    return user, True
+
+
 async def get_month_total(
     db: AsyncSession, user_id: uuid.UUID, month_key: str | None = None
 ) -> float:

--- a/openclaw-skills/finance-expense/scripts/expense_cli.py
+++ b/openclaw-skills/finance-expense/scripts/expense_cli.py
@@ -5,7 +5,7 @@ Thin wrapper — parse args → call backend API → format response.
 import json
 import os
 import sys
-from datetime import date, datetime
+from datetime import date
 from pathlib import Path
 
 import requests
@@ -16,7 +16,6 @@ if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
 from backend.bot.formatters.money import format_money_full
-from backend.bot.formatters.templates import format_transaction_confirmation
 from backend.config.categories import get_category
 
 API_URL = os.environ.get("FINANCE_API_URL", "")
@@ -68,23 +67,13 @@ def add_expense(amount: float, note: str | None = None, merchant: str | None = N
     }
     resp = requests.post(
         f"{API_URL}/expenses",
-        params={"user_id": USER_ID},
+        params={"user_id": USER_ID, "push_confirmation": "true"},
         headers=_headers(),
         json=payload,
         timeout=30,
     )
     if resp.status_code == 201:
-        data = resp.json()
-        category_code = _normalize_category(data.get("category"))
-        merchant_label = data.get("merchant") or data.get("note") or "Giao dịch"
-        print(
-            format_transaction_confirmation(
-                merchant=merchant_label,
-                amount=float(data["amount"]),
-                category_code=category_code,
-                time=datetime.now(),
-            )
-        )
+        print("ok")
     else:
         print(f"Lỗi: {resp.status_code} — {resp.text}", file=sys.stderr)
         sys.exit(1)

--- a/scripts/launchagent-install.sh
+++ b/scripts/launchagent-install.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+# Install Cloudflare Tunnel as a macOS LaunchAgent so it auto-starts on login.
+# Run AFTER tunnel-named-setup.sh succeeds.
+#
+# Manages two agents:
+#   com.financeassistant.tunnel  — named tunnel (stable URL)
+#   com.financeassistant.backend — FastAPI backend on port 8000
+#
+# Usage:
+#   ./scripts/launchagent-install.sh install   # install & start
+#   ./scripts/launchagent-install.sh uninstall # stop & remove
+#   ./scripts/launchagent-install.sh status    # show status
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+LAUNCH_AGENTS_DIR="${HOME}/Library/LaunchAgents"
+LOGS_DIR="${HOME}/Library/Logs/finance-assistant"
+
+TUNNEL_PLIST="${LAUNCH_AGENTS_DIR}/com.financeassistant.tunnel.plist"
+BACKEND_PLIST="${LAUNCH_AGENTS_DIR}/com.financeassistant.backend.plist"
+
+ACTION="${1:-install}"
+
+mkdir -p "$LAUNCH_AGENTS_DIR" "$LOGS_DIR"
+
+# ── Tunnel LaunchAgent ─────────────────────────────────────────────────────────
+write_tunnel_plist() {
+    local CONFIG_FILE="${PROJECT_ROOT}/.cloudflared/config.yml"
+    if [[ ! -f "$CONFIG_FILE" ]]; then
+        echo "Warning: ${CONFIG_FILE} not found. Run tunnel-named-setup.sh first."
+        echo "Skipping tunnel LaunchAgent."
+        return 0
+    fi
+
+    cat > "$TUNNEL_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.financeassistant.tunnel</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/opt/homebrew/bin/cloudflared</string>
+        <string>tunnel</string>
+        <string>--config</string>
+        <string>${CONFIG_FILE}</string>
+        <string>run</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>${LOGS_DIR}/tunnel.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>${LOGS_DIR}/tunnel.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>
+EOF
+    echo "  Written: $TUNNEL_PLIST"
+}
+
+# ── Backend LaunchAgent ────────────────────────────────────────────────────────
+write_backend_plist() {
+    local VENV_PYTHON="${PROJECT_ROOT}/venv/bin/python"
+    local BACKEND_DIR="${PROJECT_ROOT}/backend"
+    local PORT="${FINANCE_BACKEND_PORT:-8000}"
+
+    cat > "$BACKEND_PLIST" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.financeassistant.backend</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>${VENV_PYTHON}</string>
+        <string>-m</string>
+        <string>uvicorn</string>
+        <string>main:app</string>
+        <string>--host</string>
+        <string>0.0.0.0</string>
+        <string>--port</string>
+        <string>${PORT}</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>${BACKEND_DIR}</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>${LOGS_DIR}/backend.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>${LOGS_DIR}/backend.log</string>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+</dict>
+</plist>
+EOF
+    echo "  Written: $BACKEND_PLIST"
+}
+
+case "$ACTION" in
+install)
+    echo "Installing LaunchAgents..."
+    write_backend_plist
+    write_tunnel_plist
+
+    for plist in "$BACKEND_PLIST" "$TUNNEL_PLIST"; do
+        [[ -f "$plist" ]] || continue
+        label=$(basename "$plist" .plist)
+        launchctl unload "$plist" 2>/dev/null || true
+        launchctl load "$plist"
+        echo "  Loaded: $label"
+    done
+
+    echo ""
+    echo "LaunchAgents installed. They will auto-start on login."
+    echo "Logs: $LOGS_DIR/"
+    ;;
+
+uninstall)
+    echo "Removing LaunchAgents..."
+    for plist in "$BACKEND_PLIST" "$TUNNEL_PLIST"; do
+        [[ -f "$plist" ]] || continue
+        label=$(basename "$plist" .plist)
+        launchctl unload "$plist" 2>/dev/null && echo "  Unloaded: $label"
+        rm -f "$plist" && echo "  Removed: $plist"
+    done
+    ;;
+
+status)
+    echo "LaunchAgent status:"
+    for label in com.financeassistant.backend com.financeassistant.tunnel; do
+        status=$(launchctl list "$label" 2>/dev/null | grep '"PID"' | awk '{print $3}' | tr -d ';' || echo "")
+        if [[ -n "$status" && "$status" != "0" ]]; then
+            echo "  $label: RUNNING (PID $status)"
+        else
+            exit_code=$(launchctl list "$label" 2>/dev/null | grep '"LastExitStatus"' | awk '{print $3}' | tr -d ';' || echo "")
+            if [[ -n "$exit_code" ]]; then
+                echo "  $label: STOPPED (last exit: $exit_code)"
+            else
+                echo "  $label: NOT LOADED"
+            fi
+        fi
+    done
+    ;;
+
+*)
+    echo "Usage: $0 [install|uninstall|status]"
+    exit 1
+    ;;
+esac

--- a/scripts/tunnel-named-setup.sh
+++ b/scripts/tunnel-named-setup.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# Named Cloudflare Tunnel Setup — run ONCE to create the tunnel.
+# Requires: Cloudflare account + a domain managed in Cloudflare DNS.
+#
+# After this script succeeds:
+# 1. A tunnel named "finance-assistant" is created under your CF account.
+# 2. A DNS CNAME is added: <TUNNEL_HOSTNAME> → <tunnel-id>.cfargotunnel.com
+# 3. Config written to .cloudflared/config.yml
+# 4. Then run: ./scripts/tunnel-named-start.sh   (or install LaunchAgent)
+#
+# NOTE on DuckDNS: DuckDNS only supports A/AAAA records, not CNAME.
+# Cloudflare Tunnel needs a CNAME + Cloudflare proxy (orange cloud).
+# DuckDNS domains cannot be added to Cloudflare — use a domain you own
+# (even a free Freenom/.tk domain, or buy a cheap .xyz for ~$1/year),
+# OR use a workers.dev subdomain (see below).
+
+set -euo pipefail
+
+TUNNEL_NAME="finance-assistant"
+BACKEND_PORT="${FINANCE_BACKEND_PORT:-8000}"
+CONFIG_DIR="$(cd "$(dirname "$0")/.." && pwd)/.cloudflared"
+CONFIG_FILE="${CONFIG_DIR}/config.yml"
+CREDENTIALS_DIR="${HOME}/.cloudflared"
+
+# ── Prompt for hostname ────────────────────────────────────────────────────────
+echo ""
+echo "=== Named Cloudflare Tunnel Setup ==="
+echo ""
+echo "This requires:"
+echo "  1. A Cloudflare account (free at cloudflare.com)"
+echo "  2. A domain added to Cloudflare DNS (NOT DuckDNS — see note above)"
+echo ""
+echo "Options for a free stable URL:"
+echo "  A) Use a free domain (e.g. https://dash.cloudflare.com → Workers & Pages"
+echo "     → your-subdomain.workers.dev — set up via Worker route)"
+echo "  B) Buy a cheap .xyz domain (~$1/year) and add it to Cloudflare"
+echo "  C) Use quick tunnel (URL changes on restart) — run tunnel-quick.sh instead"
+echo ""
+read -r -p "Enter your tunnel hostname (e.g. miniapp.yourdomain.com): " TUNNEL_HOSTNAME
+
+if [[ -z "$TUNNEL_HOSTNAME" ]]; then
+    echo "Error: hostname required. Exiting."
+    exit 1
+fi
+
+# ── Step 1: Login ──────────────────────────────────────────────────────────────
+echo ""
+echo "Step 1: Login to Cloudflare (browser will open)..."
+cloudflared login
+
+# ── Step 2: Create tunnel ──────────────────────────────────────────────────────
+echo ""
+echo "Step 2: Creating tunnel '${TUNNEL_NAME}'..."
+cloudflared tunnel create "${TUNNEL_NAME}"
+
+TUNNEL_ID=$(cloudflared tunnel list --output json 2>/dev/null \
+    | python3 -c "import sys,json; data=json.load(sys.stdin); \
+      tunnels=[t for t in data if t['name']=='${TUNNEL_NAME}']; \
+      print(tunnels[0]['id'] if tunnels else '')" 2>/dev/null || echo "")
+
+if [[ -z "$TUNNEL_ID" ]]; then
+    echo "Could not determine tunnel ID. Check: cloudflared tunnel list"
+    exit 1
+fi
+
+echo "  Tunnel ID: ${TUNNEL_ID}"
+
+# ── Step 3: Write config.yml ───────────────────────────────────────────────────
+echo ""
+echo "Step 3: Writing ${CONFIG_FILE}..."
+mkdir -p "${CONFIG_DIR}"
+
+cat > "${CONFIG_FILE}" <<EOF
+tunnel: ${TUNNEL_ID}
+credentials-file: ${CREDENTIALS_DIR}/${TUNNEL_ID}.json
+
+ingress:
+  - hostname: ${TUNNEL_HOSTNAME}
+    service: http://localhost:${BACKEND_PORT}
+    originRequest:
+      connectTimeout: 30s
+      noTLSVerify: false
+  - service: http_status:404
+EOF
+
+echo "  Written: ${CONFIG_FILE}"
+
+# ── Step 4: Create DNS CNAME ───────────────────────────────────────────────────
+echo ""
+echo "Step 4: Creating DNS CNAME ${TUNNEL_HOSTNAME} → ${TUNNEL_ID}.cfargotunnel.com ..."
+cloudflared tunnel route dns "${TUNNEL_NAME}" "${TUNNEL_HOSTNAME}"
+
+# ── Summary ────────────────────────────────────────────────────────────────────
+echo ""
+echo "============================================"
+echo "  Setup complete!"
+echo ""
+echo "  Tunnel:    ${TUNNEL_NAME} (${TUNNEL_ID})"
+echo "  URL:       https://${TUNNEL_HOSTNAME}"
+echo "  Dashboard: https://${TUNNEL_HOSTNAME}/miniapp/dashboard"
+echo ""
+echo "  To start the tunnel:"
+echo "    ./scripts/tunnel-named-start.sh"
+echo ""
+echo "  To install as LaunchAgent (auto-start on login):"
+echo "    ./scripts/launchagent-install.sh"
+echo "============================================"
+
+# Save hostname for other scripts
+echo "${TUNNEL_HOSTNAME}" > "${CONFIG_DIR}/.tunnel-hostname"

--- a/scripts/tunnel-named-start.sh
+++ b/scripts/tunnel-named-start.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Start the named Cloudflare Tunnel using .cloudflared/config.yml
+# Run tunnel-named-setup.sh first if you haven't already.
+
+set -euo pipefail
+
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CONFIG_FILE="${PROJECT_ROOT}/.cloudflared/config.yml"
+LOG_FILE="${HOME}/Library/Logs/finance-assistant/tunnel-named.log"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+    echo "Error: ${CONFIG_FILE} not found."
+    echo "Run ./scripts/tunnel-named-setup.sh first."
+    exit 1
+fi
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+HOSTNAME_FILE="${PROJECT_ROOT}/.cloudflared/.tunnel-hostname"
+if [[ -f "$HOSTNAME_FILE" ]]; then
+    TUNNEL_HOSTNAME=$(cat "$HOSTNAME_FILE")
+    echo "Starting tunnel → https://${TUNNEL_HOSTNAME}"
+    echo "  Dashboard: https://${TUNNEL_HOSTNAME}/miniapp/dashboard"
+else
+    echo "Starting named Cloudflare tunnel..."
+fi
+
+echo "Logs: $LOG_FILE"
+echo "Press Ctrl-C to stop."
+echo ""
+
+cloudflared tunnel --config "${CONFIG_FILE}" run 2>&1 | tee -a "$LOG_FILE"

--- a/scripts/tunnel-quick.sh
+++ b/scripts/tunnel-quick.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Quick Cloudflare Tunnel — no account needed.
+# Gives a free *.trycloudflare.com HTTPS URL that proxies localhost:8000.
+# URL is printed to stdout and saved to /tmp/cf-tunnel-url.txt
+# URL changes every time this script restarts.
+#
+# Use this for: initial testing, local development, demo sessions.
+# For a stable URL, use tunnel-named-start.sh after running tunnel-named-setup.sh.
+
+set -euo pipefail
+
+BACKEND_PORT="${FINANCE_BACKEND_PORT:-8000}"
+LOG_FILE="${HOME}/Library/Logs/finance-assistant/tunnel-quick.log"
+URL_FILE="/tmp/cf-tunnel-url.txt"
+
+mkdir -p "$(dirname "$LOG_FILE")"
+
+echo "Starting Cloudflare quick tunnel → http://localhost:${BACKEND_PORT}"
+echo "Logs: $LOG_FILE"
+echo "URL will appear below (also saved to $URL_FILE):"
+echo "---"
+
+# Run tunnel, tee to log, and extract the URL from output
+cloudflared tunnel --url "http://localhost:${BACKEND_PORT}" 2>&1 | tee "$LOG_FILE" | while IFS= read -r line; do
+    echo "$line"
+    # cloudflared prints: "Your quick Tunnel has been created! Visit it at (it may take some time to be reachable):"
+    # followed by: "https://<random>.trycloudflare.com"
+    if echo "$line" | grep -qE 'https://[a-zA-Z0-9-]+\.trycloudflare\.com'; then
+        url=$(echo "$line" | grep -oE 'https://[a-zA-Z0-9-]+\.trycloudflare\.com')
+        echo "$url" > "$URL_FILE"
+        echo ""
+        echo "============================================"
+        echo "  TUNNEL URL: $url"
+        echo "  Saved to:   $URL_FILE"
+        echo ""
+        echo "  Mini App Dashboard: ${url}/miniapp/dashboard"
+        echo "  API:                ${url}/miniapp/api/"
+        echo "============================================"
+        echo ""
+        echo "  Next: copy the tunnel URL and set it in BotFather:"
+        echo "  /setmenubutton → paste URL/miniapp/dashboard"
+        echo ""
+    fi
+done


### PR DESCRIPTION
## Summary

- **User registration on `/start`**: Bot now creates (or finds) the user record in PostgreSQL when `/start` is received. `get_or_create_user()` in `dashboard_service` is the single source of truth — returns `(user, created)` tuple; `BOT_STARTED` analytics event now carries `user_id` and `new_user` flag.
- **Natural language expense entry**: Any plain-text message that isn't a command is routed through `handle_text_message` (new `backend/bot/handlers/message.py`). LLM classifies whether it's an expense; if yes, creates the expense and sends the confirmation card; if not, falls back to showing the menu.
- **Mini app user resolution**: `_resolve_user` in `miniapp/routes.py` now calls `get_or_create_user` as a safety net — mini app works even if the user somehow skipped `/start`.
- **Mini app fetch timeout**: `dashboard.js` wraps every `fetch()` in an `AbortController` with a 12 s deadline. Prevents the loading spinner from hanging forever when Cloudflare's trycloudflare.com tunnel drops requests from Telegram's WebView user-agent.
- **Cloudflare tunnel scripts**: Four helper scripts in `scripts/` (quick anonymous tunnel, named persistent tunnel setup/start, macOS LaunchAgent install). `.gitignore` now excludes `.cloudflared/*.json` and `config.yml` which contain the tunnel secret token.
- **`expense_cli.py` cleanup**: CLI no longer renders the Telegram confirmation locally — backend sends it directly when `push_confirmation=true`; CLI prints `ok` on success.

## Test plan

- [ ] Send `/start` to the bot → user row appears in `users` table
- [ ] Send `/start` again → same user row (no duplicate), `new_user: false` in analytics
- [ ] Send a plain-text expense (e.g. "ăn trưa 80k") → bot replies with transaction confirmation card
- [ ] Send a non-expense message (e.g. "xin chào") → bot shows the feature menu
- [ ] Open the Dashboard mini app → loads spending data without 404 / infinite spinner
- [ ] Open the Dashboard mini app with Cloudflare tunnel down → loading times out after ~12 s and shows error message "Kết nối quá chậm — thử lại nhé."

🤖 Generated with [Claude Code](https://claude.com/claude-code)