### PR TITLE
fix(bot): route report queries to report handler instead of showing menu

### DIFF
--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -3,15 +3,13 @@ from __future__ import annotations
 
 import json
 import logging
-import re
 from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.bot.handlers.transaction import send_transaction_confirmation
-from backend.models.user import User
 from backend.schemas.expense import ExpenseCreate
-from backend.services import expense_service
+from backend.services import expense_service, report_service
 from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.llm_service import call_llm
 from backend.services.telegram_service import send_message, send_menu
@@ -32,89 +30,28 @@ Quy tắc:
 
 Chỉ trả về JSON, không giải thích."""
 
-# Keywords that signal the user wants a spending report, not to log an expense.
-_REPORT_KEYWORDS = frozenset([
-    "báo cáo", "bao cao",
-    "tổng chi tiêu", "tong chi tieu",
-    "chi tiêu tháng", "chi tieu thang",
-    "xài bao nhiêu", "xai bao nhieu",
-    "tôi xài bao", "toi xai bao",
-    "tôi đã chi", "toi da chi",
-    "spending", "report",
-    "tháng trước tôi", "thang truoc toi",
-])
-
-
-def _looks_like_report_query(text: str) -> bool:
-    lower = text.lower()
-    return any(kw in lower for kw in _REPORT_KEYWORDS)
-
-
-def _extract_month_key(text: str) -> str:
-    """Best-effort month extraction from natural language. Defaults to current month."""
-    today = date.today()
-    lower = text.lower()
-
-    if "tháng trước" in lower or "thang truoc" in lower:
-        m = today.month - 1 or 12
-        y = today.year if today.month > 1 else today.year - 1
-        return f"{y}-{m:02d}"
-
-    # "tháng 3" or "tháng 03"
-    match = re.search(r"tháng\s+(\d{1,2})", lower)
-    if match:
-        month = int(match.group(1))
-        if 1 <= month <= 12:
-            year = today.year if month <= today.month else today.year - 1
-            return f"{year}-{month:02d}"
-
-    # Explicit "2026-03"
-    match = re.search(r"(\d{4})-(\d{2})", text)
-    if match:
-        return f"{match.group(1)}-{match.group(2)}"
-
-    return today.strftime("%Y-%m")
-
-
 _NOT_REGISTERED = "Bạn chưa đăng ký. Gửi /start để bắt đầu."
 
 
-async def handle_report_request(db: AsyncSession, chat_id: int, user: User, text: str) -> None:
-    """Generate and send a monthly spending report."""
-    from backend.services.report_service import generate_monthly_report
-
-    month_key = _extract_month_key(text)
+async def _send_report(db: AsyncSession, chat_id: int, telegram_id: int, text: str = "") -> None:
+    """Ask the service for report text and deliver it to the user."""
     await send_message(chat_id, "⏳ Đang tổng hợp báo cáo...")
-    try:
-        report = await generate_monthly_report(db, user.id, month_key)
-        await send_message(chat_id, report.report_text or "Không có dữ liệu chi tiêu.")
-    except Exception:
-        logger.exception("Report generation failed for user %s month %s", user.id, month_key)
-        await send_message(chat_id, "❌ Không thể tổng hợp báo cáo. Thử lại sau nhé.")
+    result = await report_service.process_report_request(db, telegram_id, text)
+    await send_message(chat_id, result)
 
 
 async def handle_report_command(db: AsyncSession, message: dict) -> None:
-    """Handle /report command — router delegates here, keeping logic out of the router."""
+    """Handle /report command — extracts Telegram data, delegates to service."""
     chat_id = message["chat"]["id"]
-    from_data = message.get("from") or {}
-    telegram_id = from_data.get("id", chat_id)
-    user = await get_user_by_telegram_id(db, telegram_id)
-    if not user:
-        await send_message(chat_id, _NOT_REGISTERED)
-        return
-    await handle_report_request(db, chat_id, user, "")
+    telegram_id = (message.get("from") or {}).get("id", chat_id)
+    await _send_report(db, chat_id, telegram_id)
 
 
 async def handle_report_callback(db: AsyncSession, callback_query: dict) -> None:
-    """Handle menu:report callback — router delegates here, keeping logic out of the router."""
+    """Handle menu:report callback — extracts Telegram data, delegates to service."""
     chat_id = callback_query["message"]["chat"]["id"]
-    from_data = callback_query.get("from") or {}
-    telegram_id = from_data.get("id", chat_id)
-    user = await get_user_by_telegram_id(db, telegram_id)
-    if not user:
-        await send_message(chat_id, _NOT_REGISTERED)
-        return
-    await handle_report_request(db, chat_id, user, "")
+    telegram_id = (callback_query.get("from") or {}).get("id", chat_id)
+    await _send_report(db, chat_id, telegram_id)
 
 
 async def handle_text_message(db: AsyncSession, message: dict) -> bool:
@@ -131,14 +68,14 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
     from_data = message.get("from") or {}
     telegram_id = from_data.get("id", chat_id)
 
+    # Fast-path: report intent — service handles all orchestration.
+    if report_service.is_report_query(text):
+        await _send_report(db, chat_id, telegram_id, text)
+        return True
+
     user = await get_user_by_telegram_id(db, telegram_id)
     if not user:
         await send_message(chat_id, _NOT_REGISTERED)
-        return True
-
-    # Fast-path: report intent detected without an LLM call.
-    if _looks_like_report_query(text):
-        await handle_report_request(db, chat_id, user, text)
         return True
 
     try:

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -6,13 +6,13 @@ import logging
 import re
 from datetime import date
 
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.bot.handlers.transaction import send_transaction_confirmation
 from backend.models.user import User
 from backend.schemas.expense import ExpenseCreate
 from backend.services import expense_service
+from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.llm_service import call_llm
 from backend.services.telegram_service import send_message, send_menu
 
@@ -76,6 +76,9 @@ def _extract_month_key(text: str) -> str:
     return today.strftime("%Y-%m")
 
 
+_NOT_REGISTERED = "Bạn chưa đăng ký. Gửi /start để bắt đầu."
+
+
 async def handle_report_request(db: AsyncSession, chat_id: int, user: User, text: str) -> None:
     """Generate and send a monthly spending report."""
     from backend.services.report_service import generate_monthly_report
@@ -90,12 +93,28 @@ async def handle_report_request(db: AsyncSession, chat_id: int, user: User, text
         await send_message(chat_id, "❌ Không thể tổng hợp báo cáo. Thử lại sau nhé.")
 
 
-async def _get_user(db: AsyncSession, telegram_id: int) -> User | None:
-    stmt = select(User).where(
-        User.telegram_id == telegram_id,
-        User.deleted_at.is_(None),
-    )
-    return (await db.execute(stmt)).scalar_one_or_none()
+async def handle_report_command(db: AsyncSession, message: dict) -> None:
+    """Handle /report command — router delegates here, keeping logic out of the router."""
+    chat_id = message["chat"]["id"]
+    from_data = message.get("from") or {}
+    telegram_id = from_data.get("id", chat_id)
+    user = await get_user_by_telegram_id(db, telegram_id)
+    if not user:
+        await send_message(chat_id, _NOT_REGISTERED)
+        return
+    await handle_report_request(db, chat_id, user, "")
+
+
+async def handle_report_callback(db: AsyncSession, callback_query: dict) -> None:
+    """Handle menu:report callback — router delegates here, keeping logic out of the router."""
+    chat_id = callback_query["message"]["chat"]["id"]
+    from_data = callback_query.get("from") or {}
+    telegram_id = from_data.get("id", chat_id)
+    user = await get_user_by_telegram_id(db, telegram_id)
+    if not user:
+        await send_message(chat_id, _NOT_REGISTERED)
+        return
+    await handle_report_request(db, chat_id, user, "")
 
 
 async def handle_text_message(db: AsyncSession, message: dict) -> bool:
@@ -112,9 +131,9 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
     from_data = message.get("from") or {}
     telegram_id = from_data.get("id", chat_id)
 
-    user = await _get_user(db, telegram_id)
+    user = await get_user_by_telegram_id(db, telegram_id)
     if not user:
-        await send_message(chat_id, "Bạn chưa đăng ký. Gửi /start để bắt đầu.")
+        await send_message(chat_id, _NOT_REGISTERED)
         return True
 
     # Fast-path: report intent detected without an LLM call.

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from datetime import date
 
 from sqlalchemy import select
@@ -31,6 +32,63 @@ Quy tắc:
 
 Chỉ trả về JSON, không giải thích."""
 
+# Keywords that signal the user wants a spending report, not to log an expense.
+_REPORT_KEYWORDS = frozenset([
+    "báo cáo", "bao cao",
+    "tổng chi tiêu", "tong chi tieu",
+    "chi tiêu tháng", "chi tieu thang",
+    "xài bao nhiêu", "xai bao nhieu",
+    "tôi xài bao", "toi xai bao",
+    "tôi đã chi", "toi da chi",
+    "spending", "report",
+    "tháng trước tôi", "thang truoc toi",
+])
+
+
+def _looks_like_report_query(text: str) -> bool:
+    lower = text.lower()
+    return any(kw in lower for kw in _REPORT_KEYWORDS)
+
+
+def _extract_month_key(text: str) -> str:
+    """Best-effort month extraction from natural language. Defaults to current month."""
+    today = date.today()
+    lower = text.lower()
+
+    if "tháng trước" in lower or "thang truoc" in lower:
+        m = today.month - 1 or 12
+        y = today.year if today.month > 1 else today.year - 1
+        return f"{y}-{m:02d}"
+
+    # "tháng 3" or "tháng 03"
+    match = re.search(r"tháng\s+(\d{1,2})", lower)
+    if match:
+        month = int(match.group(1))
+        if 1 <= month <= 12:
+            year = today.year if month <= today.month else today.year - 1
+            return f"{year}-{month:02d}"
+
+    # Explicit "2026-03"
+    match = re.search(r"(\d{4})-(\d{2})", text)
+    if match:
+        return f"{match.group(1)}-{match.group(2)}"
+
+    return today.strftime("%Y-%m")
+
+
+async def handle_report_request(db: AsyncSession, chat_id: int, user: User, text: str) -> None:
+    """Generate and send a monthly spending report."""
+    from backend.services.report_service import generate_monthly_report
+
+    month_key = _extract_month_key(text)
+    await send_message(chat_id, "⏳ Đang tổng hợp báo cáo...")
+    try:
+        report = await generate_monthly_report(db, user.id, month_key)
+        await send_message(chat_id, report.report_text or "Không có dữ liệu chi tiêu.")
+    except Exception:
+        logger.exception("Report generation failed for user %s month %s", user.id, month_key)
+        await send_message(chat_id, "❌ Không thể tổng hợp báo cáo. Thử lại sau nhé.")
+
 
 async def _get_user(db: AsyncSession, telegram_id: int) -> User | None:
     stmt = select(User).where(
@@ -57,6 +115,11 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
     user = await _get_user(db, telegram_id)
     if not user:
         await send_message(chat_id, "Bạn chưa đăng ký. Gửi /start để bắt đầu.")
+        return True
+
+    # Fast-path: report intent detected without an LLM call.
+    if _looks_like_report_query(text):
+        await handle_report_request(db, chat_id, user, text)
         return True
 
     try:

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -7,16 +7,18 @@ import hmac
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend import analytics
 from backend.bot.formatters.templates import format_welcome_message
 from backend.bot.handlers.callbacks import handle_transaction_callback
-from backend.bot.handlers.message import handle_report_request, handle_text_message
+from backend.bot.handlers.message import (
+    handle_report_callback,
+    handle_report_command,
+    handle_text_message,
+)
 from backend.config import get_settings
 from backend.database import get_db
-from backend.models.user import User
 from backend.services import dashboard_service
 from backend.services.menu_service import get_features_json, get_menu_text
 from backend.services.telegram_service import (
@@ -31,14 +33,6 @@ logger = logging.getLogger(__name__)
 settings = get_settings()
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
-
-
-async def _get_user_by_telegram_id(db: AsyncSession, telegram_id: int) -> User | None:
-    stmt = select(User).where(
-        User.telegram_id == telegram_id,
-        User.deleted_at.is_(None),
-    )
-    return (await db.execute(stmt)).scalar_one_or_none()
 
 
 def _verify_webhook_request(request: Request) -> None:
@@ -102,13 +96,7 @@ async def telegram_webhook(
             return {"ok": True}
 
         if command == "/report":
-            from_user = message.get("from") or {}
-            telegram_id = from_user.get("id", chat_id)
-            user = await _get_user_by_telegram_id(db, telegram_id)
-            if user:
-                await handle_report_request(db, chat_id, user, "")
-            else:
-                await send_message(chat_id, "Bạn chưa đăng ký. Gửi /start để bắt đầu.")
+            await handle_report_command(db, message)
             return {"ok": True}
 
         # Natural language message — try to parse as expense
@@ -131,13 +119,7 @@ async def telegram_webhook(
 
         # "Báo cáo" button → generate report immediately instead of showing help text.
         if callback_data == "menu:report":
-            from_user = callback_query.get("from") or {}
-            telegram_id = from_user.get("id", chat_id)
-            user = await _get_user_by_telegram_id(db, telegram_id)
-            if user:
-                await handle_report_request(db, chat_id, user, "")
-            else:
-                await send_message(chat_id, "Bạn chưa đăng ký. Gửi /start để bắt đầu.")
+            await handle_report_callback(db, callback_query)
             return {"ok": True}
 
         await handle_menu_callback(chat_id, callback_data)

--- a/backend/routers/telegram.py
+++ b/backend/routers/telegram.py
@@ -7,14 +7,16 @@ import hmac
 import logging
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend import analytics
 from backend.bot.formatters.templates import format_welcome_message
 from backend.bot.handlers.callbacks import handle_transaction_callback
-from backend.bot.handlers.message import handle_text_message
+from backend.bot.handlers.message import handle_report_request, handle_text_message
 from backend.config import get_settings
 from backend.database import get_db
+from backend.models.user import User
 from backend.services import dashboard_service
 from backend.services.menu_service import get_features_json, get_menu_text
 from backend.services.telegram_service import (
@@ -29,6 +31,14 @@ logger = logging.getLogger(__name__)
 settings = get_settings()
 
 router = APIRouter(prefix="/telegram", tags=["telegram"])
+
+
+async def _get_user_by_telegram_id(db: AsyncSession, telegram_id: int) -> User | None:
+    stmt = select(User).where(
+        User.telegram_id == telegram_id,
+        User.deleted_at.is_(None),
+    )
+    return (await db.execute(stmt)).scalar_one_or_none()
 
 
 def _verify_webhook_request(request: Request) -> None:
@@ -91,6 +101,16 @@ async def telegram_webhook(
             await send_menu(chat_id)
             return {"ok": True}
 
+        if command == "/report":
+            from_user = message.get("from") or {}
+            telegram_id = from_user.get("id", chat_id)
+            user = await _get_user_by_telegram_id(db, telegram_id)
+            if user:
+                await handle_report_request(db, chat_id, user, "")
+            else:
+                await send_message(chat_id, "Bạn chưa đăng ký. Gửi /start để bắt đầu.")
+            return {"ok": True}
+
         # Natural language message — try to parse as expense
         await handle_text_message(db, message)
         return {"ok": True}
@@ -108,6 +128,18 @@ async def telegram_webhook(
             return {"ok": True}
 
         await answer_callback(callback_id)
+
+        # "Báo cáo" button → generate report immediately instead of showing help text.
+        if callback_data == "menu:report":
+            from_user = callback_query.get("from") or {}
+            telegram_id = from_user.get("id", chat_id)
+            user = await _get_user_by_telegram_id(db, telegram_id)
+            if user:
+                await handle_report_request(db, chat_id, user, "")
+            else:
+                await send_message(chat_id, "Bạn chưa đăng ký. Gửi /start để bắt đầu.")
+            return {"ok": True}
+
         await handle_menu_callback(chat_id, callback_data)
         return {"ok": True}
 

--- a/backend/services/report_service.py
+++ b/backend/services/report_service.py
@@ -1,4 +1,5 @@
 import logging
+import re
 import uuid
 from datetime import date, datetime
 
@@ -9,10 +10,81 @@ from backend.models.expense import Expense
 from backend.models.goal import Goal
 from backend.models.report import MonthlyReport
 from backend.models.user import User
+from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.llm_service import call_llm
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Intent detection + month parsing (consumed by the bot handler layer)
+# ---------------------------------------------------------------------------
+
+_REPORT_KEYWORDS = frozenset([
+    "báo cáo", "bao cao",
+    "tổng chi tiêu", "tong chi tieu",
+    "chi tiêu tháng", "chi tieu thang",
+    "xài bao nhiêu", "xai bao nhieu",
+    "tôi xài bao", "toi xai bao",
+    "tôi đã chi", "toi da chi",
+    "spending", "report",
+    "tháng trước tôi", "thang truoc toi",
+])
+
+
+def is_report_query(text: str) -> bool:
+    """Return True when text looks like a spending-report request, not an expense entry."""
+    lower = text.lower()
+    return any(kw in lower for kw in _REPORT_KEYWORDS)
+
+
+def extract_month_key(text: str) -> str:
+    """Best-effort month extraction from natural language. Defaults to current month."""
+    today = date.today()
+    lower = text.lower()
+
+    if "tháng trước" in lower or "thang truoc" in lower:
+        m = today.month - 1 or 12
+        y = today.year if today.month > 1 else today.year - 1
+        return f"{y}-{m:02d}"
+
+    # "tháng 3" or "tháng 03"
+    match = re.search(r"tháng\s+(\d{1,2})", lower)
+    if match:
+        month = int(match.group(1))
+        if 1 <= month <= 12:
+            year = today.year if month <= today.month else today.year - 1
+            return f"{year}-{month:02d}"
+
+    # Explicit "2026-03"
+    match = re.search(r"(\d{4})-(\d{2})", text)
+    if match:
+        return f"{match.group(1)}-{match.group(2)}"
+
+    return today.strftime("%Y-%m")
+
+
+async def process_report_request(db: AsyncSession, telegram_id: int, text: str) -> str:
+    """Full orchestration: user lookup → month parsing → report generation → text.
+
+    Returns a ready-to-send Telegram message string in all cases (including
+    errors and unregistered users), so callers never need to catch exceptions.
+    """
+    user = await get_user_by_telegram_id(db, telegram_id)
+    if not user:
+        return "Bạn chưa đăng ký. Gửi /start để bắt đầu."
+
+    month_key = extract_month_key(text)
+    try:
+        report = await generate_monthly_report(db, user.id, month_key)
+        return report.report_text or "Không có dữ liệu chi tiêu."
+    except Exception:
+        logger.exception("Report generation failed for user %s month %s", user.id, month_key)
+        return "❌ Không thể tổng hợp báo cáo. Thử lại sau nhé."
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
 
 def _prev_month_key(month_key: str) -> str:
     year, month = int(month_key[:4]), int(month_key[5:7])

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -1,0 +1,168 @@
+"""Tests for report_service — intent detection, month parsing, and orchestration."""
+from datetime import date
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.services.report_service import extract_month_key, is_report_query, process_report_request
+
+
+class TestIsReportQuery:
+    def test_detects_bao_cao(self):
+        assert is_report_query("báo cáo tháng này") is True
+
+    def test_detects_tong_chi_tieu_lowercase(self):
+        assert is_report_query("tổng chi tiêu") is True
+
+    def test_detects_tong_chi_tieu_capitalized(self):
+        # User sent "Tổng chi tiêu" from the menu prompt — must match
+        assert is_report_query("Tổng chi tiêu") is True
+
+    def test_detects_chi_tieu_thang(self):
+        assert is_report_query("chi tiêu tháng này bao nhiêu?") is True
+
+    def test_detects_xai_bao_nhieu(self):
+        assert is_report_query("tôi xài bao nhiêu tháng 3?") is True
+
+    def test_detects_english_report(self):
+        assert is_report_query("spending this month") is True
+
+    def test_detects_english_report_keyword(self):
+        assert is_report_query("show me a report") is True
+
+    def test_detects_da_chi(self):
+        assert is_report_query("tháng này tôi đã chi bao nhiêu") is True
+
+    def test_does_not_match_plain_expense_entry(self):
+        assert is_report_query("ăn trưa 50k") is False
+
+    def test_does_not_match_amount_only(self):
+        assert is_report_query("150000") is False
+
+    def test_does_not_match_empty_string(self):
+        assert is_report_query("") is False
+
+    def test_does_not_match_menu_command(self):
+        assert is_report_query("menu") is False
+
+    def test_does_not_match_greeting(self):
+        assert is_report_query("xin chào") is False
+
+
+class TestExtractMonthKey:
+    def test_defaults_to_current_month(self):
+        today = date.today()
+        assert extract_month_key("tổng chi tiêu") == today.strftime("%Y-%m")
+
+    def test_empty_text_defaults_to_current_month(self):
+        today = date.today()
+        assert extract_month_key("") == today.strftime("%Y-%m")
+
+    def test_previous_month_mid_year(self):
+        with patch("backend.services.report_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 4, 22)
+            result = extract_month_key("báo cáo tháng trước")
+        assert result == "2026-03"
+
+    def test_previous_month_january_wraps_to_december(self):
+        with patch("backend.services.report_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 1, 15)
+            result = extract_month_key("tháng trước")
+        assert result == "2025-12"
+
+    def test_specific_month_in_past(self):
+        with patch("backend.services.report_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 4, 22)
+            result = extract_month_key("báo cáo tháng 3")
+        assert result == "2026-03"
+
+    def test_specific_month_in_future_uses_previous_year(self):
+        with patch("backend.services.report_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 4, 22)
+            result = extract_month_key("báo cáo tháng 12")
+        assert result == "2025-12"
+
+    def test_specific_month_current_month(self):
+        with patch("backend.services.report_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 4, 22)
+            result = extract_month_key("tháng 4")
+        assert result == "2026-04"
+
+    def test_explicit_year_month_format(self):
+        result = extract_month_key("báo cáo 2026-03 cho tôi")
+        assert result == "2026-03"
+
+    def test_explicit_year_month_no_surrounding_text(self):
+        result = extract_month_key("2025-11")
+        assert result == "2025-11"
+
+    def test_thang_truoc_unaccented(self):
+        with patch("backend.services.report_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 4, 22)
+            result = extract_month_key("thang truoc")
+        assert result == "2026-03"
+
+
+class TestProcessReportRequest:
+    @pytest.mark.asyncio
+    async def test_returns_not_registered_when_no_user(self):
+        db = AsyncMock()
+        with patch("backend.services.report_service.get_user_by_telegram_id", return_value=None):
+            result = await process_report_request(db, telegram_id=12345, text="báo cáo")
+        assert "chưa đăng ký" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_report_text_on_success(self):
+        db = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.id = "user-uuid"
+        mock_report = MagicMock()
+        mock_report.report_text = "📊 Báo cáo tháng 4: bạn đã chi 5,000,000 VND"
+
+        with patch("backend.services.report_service.get_user_by_telegram_id", return_value=mock_user), \
+             patch("backend.services.report_service.generate_monthly_report", return_value=mock_report):
+            result = await process_report_request(db, telegram_id=99, text="tổng chi tiêu")
+
+        assert result == mock_report.report_text
+
+    @pytest.mark.asyncio
+    async def test_returns_fallback_text_when_report_text_is_none(self):
+        db = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.id = "user-uuid"
+        mock_report = MagicMock()
+        mock_report.report_text = None
+
+        with patch("backend.services.report_service.get_user_by_telegram_id", return_value=mock_user), \
+             patch("backend.services.report_service.generate_monthly_report", return_value=mock_report):
+            result = await process_report_request(db, telegram_id=99, text="")
+
+        assert "Không có dữ liệu" in result
+
+    @pytest.mark.asyncio
+    async def test_returns_error_string_on_exception(self):
+        db = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.id = "user-uuid"
+
+        with patch("backend.services.report_service.get_user_by_telegram_id", return_value=mock_user), \
+             patch("backend.services.report_service.generate_monthly_report", side_effect=RuntimeError("db down")):
+            result = await process_report_request(db, telegram_id=99, text="báo cáo")
+
+        assert "Không thể tổng hợp" in result
+
+    @pytest.mark.asyncio
+    async def test_passes_extracted_month_to_generate(self):
+        db = AsyncMock()
+        mock_user = MagicMock()
+        mock_user.id = "user-uuid"
+        mock_report = MagicMock()
+        mock_report.report_text = "ok"
+
+        with patch("backend.services.report_service.get_user_by_telegram_id", return_value=mock_user), \
+             patch("backend.services.report_service.generate_monthly_report", return_value=mock_report) as mock_gen, \
+             patch("backend.services.report_service.date") as mock_date:
+            mock_date.today.return_value = date(2026, 4, 22)
+            await process_report_request(db, telegram_id=99, text="báo cáo tháng trước")
+
+        mock_gen.assert_called_once_with(db, mock_user.id, "2026-03")

--- a/backend/tests/test_telegram_router.py
+++ b/backend/tests/test_telegram_router.py
@@ -75,7 +75,7 @@ class TestWebhookCallback:
     @patch("backend.routers.telegram.handle_menu_callback", new_callable=AsyncMock)
     @patch("backend.routers.telegram.answer_callback", new_callable=AsyncMock)
     @patch("backend.routers.telegram.settings")
-    def test_callback_query(self, mock_settings, mock_answer, mock_handle):
+    def test_generic_callback_query(self, mock_settings, mock_answer, mock_handle):
         mock_settings.telegram_webhook_secret = ""
         mock_handle.return_value = {"ok": True}
         resp = client.post(
@@ -83,14 +83,33 @@ class TestWebhookCallback:
             json={
                 "callback_query": {
                     "id": "cb-123",
-                    "data": "menu:report",
+                    "data": "menu:market",
                     "message": {"chat": {"id": 456}},
                 },
             },
         )
         assert resp.status_code == 200
         mock_answer.assert_called_once_with("cb-123")
-        mock_handle.assert_called_once_with(456, "menu:report")
+        mock_handle.assert_called_once_with(456, "menu:market")
+
+    @patch("backend.routers.telegram.handle_report_callback", new_callable=AsyncMock)
+    @patch("backend.routers.telegram.answer_callback", new_callable=AsyncMock)
+    @patch("backend.routers.telegram.settings")
+    def test_report_callback_delegates_to_handler(self, mock_settings, mock_answer, mock_report):
+        mock_settings.telegram_webhook_secret = ""
+        mock_report.return_value = None
+        payload = {
+            "callback_query": {
+                "id": "cb-456",
+                "data": "menu:report",
+                "from": {"id": 999},
+                "message": {"chat": {"id": 456}},
+            },
+        }
+        resp = client.post("/api/v1/telegram/webhook", json=payload)
+        assert resp.status_code == 200
+        mock_answer.assert_called_once_with("cb-456")
+        mock_report.assert_called_once()
 
 
 class TestMenuEndpoint:


### PR DESCRIPTION
## Summary

- **Root cause**: When user tapped "📊 Báo cáo" then typed "Tổng chi tiêu", `handle_text_message` sent it to the LLM expense parser → LLM returned `is_expense: false` → fell through to `send_menu()` — showing the main menu again instead of a report.
- Add keyword-based report intent detection in `handle_text_message` (fast-path, no LLM call) so phrases like "tổng chi tiêu", "báo cáo tháng trước", "report", etc. immediately trigger `generate_monthly_report`.
- Make the "📊 Báo cáo" inline button generate the report right away instead of showing "send one of these phrases" help text.
- Add `/report` command handler (was listed in `BOT_COMMANDS` but had no handler).

## Files changed

- `backend/bot/handlers/message.py` — `_REPORT_KEYWORDS`, `_looks_like_report_query`, `_extract_month_key`, `handle_report_request`
- `backend/routers/telegram.py` — `/report` command, `menu:report` callback shortcut, `_get_user_by_telegram_id` helper

## Test plan

- [ ] Tap "📊 Báo cáo" button → bot replies with this month's report immediately
- [ ] Send "tổng chi tiêu" as free text → report generated, not the menu
- [ ] Send "báo cáo tháng trước" → previous month's report
- [ ] Send "báo cáo tháng 3" → March report
- [ ] Send `/report` command → report generated
- [ ] Send "150k ăn trưa" → still creates an expense (regression check)
- [ ] Send unknown text → still shows menu (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)