### PR TITLE
fix(miniapp): mount StaticFiles on app instead of APIRouter

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,11 @@
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
 
 from backend.config import get_settings
 from backend.miniapp import routes as miniapp_routes
@@ -86,6 +88,14 @@ app = FastAPI(
     lifespan=lifespan,
 )
 
+
+_MINIAPP_STATIC = Path(__file__).parent / "miniapp" / "static"
+if _MINIAPP_STATIC.exists():
+    app.mount(
+        "/miniapp/static",
+        StaticFiles(directory=str(_MINIAPP_STATIC)),
+        name="miniapp-static",
+    )
 
 app.include_router(expenses.router, prefix="/api/v1")
 app.include_router(goals.router, prefix="/api/v1")

--- a/backend/miniapp/routes.py
+++ b/backend/miniapp/routes.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import FileResponse
-from fastapi.staticfiles import StaticFiles
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend import analytics
@@ -24,14 +23,6 @@ _TEMPLATES_DIR = _HERE / "templates"
 _STATIC_DIR = _HERE / "static"
 
 router = APIRouter(prefix="/miniapp", tags=["miniapp"])
-
-# Static assets — CSS + JS
-if _STATIC_DIR.exists():
-    router.mount(
-        "/static",
-        StaticFiles(directory=str(_STATIC_DIR)),
-        name="miniapp-static",
-    )
 
 
 @router.get("/dashboard", include_in_schema=False)


### PR DESCRIPTION
## Summary

- `StaticFiles` mounted on an `APIRouter` is silently ignored — only mounts on the `FastAPI` app instance are registered correctly
- This caused all `/miniapp/static/*` requests to return 404, so the dashboard loaded with no CSS or JS
- Without JS, the page stayed permanently on the default loading-spinner HTML state — appearing as a blank screen to the user

## Changes

- **`backend/miniapp/routes.py`** — removed `router.mount()` and unused `StaticFiles` import
- **`backend/main.py`** — added `app.mount("/miniapp/static", StaticFiles(...))` directly on the app, placed before `include_router` calls

## Test plan

- [x] `curl http://localhost:8002/miniapp/static/css/style.css` → 200
- [x] `curl http://localhost:8002/miniapp/static/js/dashboard.js` → 200
- [x] `GET /miniapp/api/overview` with valid initData → 200 with correct JSON
- [x] User confirmed dashboard renders in Telegram Mini App after fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)