### PR TITLE
feat(data): migrate portfolio_assets → assets (single source of truth)

### DIFF
--- a/alembic/versions/g6b7c8d9e0f1_migrate_portfolio_to_assets.py
+++ b/alembic/versions/g6b7c8d9e0f1_migrate_portfolio_to_assets.py
@@ -1,0 +1,153 @@
+"""migrate_portfolio_to_assets: copy active portfolio_assets rows into assets.
+
+Revision ID: g6b7c8d9e0f1
+Revises: f5a6b7c8d9e0
+Create Date: 2026-04-29
+
+Data-only migration — no schema changes.
+
+Maps portfolio_assets → assets:
+  - asset_type: 'stocks'/'mutual_fund'/'fund' → 'stock';
+                'life_insurance' → 'other'; others unchanged.
+  - subtype:    'stocks' → 'vn_stock';
+                'mutual_fund'/'fund' → 'fund'; else NULL.
+  - initial_value: quantity * purchase_price  (or just purchase_price when
+                   quantity is NULL, as for real-estate total-value entries).
+  - current_value: quantity * current_price   (fallback chain through
+                   purchase_price so the field is always non-NULL).
+  - acquired_at:   created_at::date  (best-effort; no original purchase date).
+  - extra:         original metadata merged with {quantity, avg_price} for
+                   quantifiable assets so portfolio_service can reconstruct
+                   the old API response shape.
+
+After inserting assets, creates today's asset_snapshot for each migrated
+asset (source='user_input') so net_worth_calculator.calculate_historical()
+has a baseline from day-one.
+
+Idempotent: both INSERT statements use NOT EXISTS guards so re-running on
+an already-migrated database is safe.
+"""
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = 'g6b7c8d9e0f1'
+down_revision: Union[str, Sequence[str], None] = 'f5a6b7c8d9e0'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # ------------------------------------------------------------------
+    # 1. Copy active portfolio_assets rows into assets
+    # ------------------------------------------------------------------
+    op.execute("""
+        INSERT INTO assets (
+            id, user_id,
+            asset_type, subtype,
+            name,
+            initial_value, current_value,
+            acquired_at, last_valued_at,
+            extra,
+            is_active,
+            created_at, updated_at
+        )
+        SELECT
+            pa.id,
+            pa.user_id,
+
+            -- Normalise asset_type to Phase 3A enum values
+            CASE pa.asset_type
+                WHEN 'stocks'         THEN 'stock'
+                WHEN 'mutual_fund'    THEN 'stock'
+                WHEN 'fund'           THEN 'stock'
+                WHEN 'life_insurance' THEN 'other'
+                ELSE pa.asset_type          -- real_estate, crypto, gold, cash, other
+            END,
+
+            -- Derive subtype from old asset_type
+            CASE pa.asset_type
+                WHEN 'stocks'      THEN 'vn_stock'
+                WHEN 'mutual_fund' THEN 'fund'
+                WHEN 'fund'        THEN 'fund'
+                ELSE NULL
+            END,
+
+            pa.name,
+
+            -- initial_value = qty * purchase_price (unit_price when no qty)
+            CASE
+                WHEN pa.quantity IS NOT NULL AND pa.purchase_price IS NOT NULL
+                    THEN ROUND((pa.quantity * pa.purchase_price)::numeric, 2)
+                WHEN pa.purchase_price IS NOT NULL
+                    THEN ROUND(pa.purchase_price::numeric, 2)
+                ELSE 0
+            END,
+
+            -- current_value: prefer qty * current_price, fall back through chain
+            CASE
+                WHEN pa.quantity IS NOT NULL AND pa.current_price IS NOT NULL
+                    THEN ROUND((pa.quantity * pa.current_price)::numeric, 2)
+                WHEN pa.current_price IS NOT NULL
+                    THEN ROUND(pa.current_price::numeric, 2)
+                WHEN pa.quantity IS NOT NULL AND pa.purchase_price IS NOT NULL
+                    THEN ROUND((pa.quantity * pa.purchase_price)::numeric, 2)
+                WHEN pa.purchase_price IS NOT NULL
+                    THEN ROUND(pa.purchase_price::numeric, 2)
+                ELSE 0
+            END,
+
+            pa.created_at::date,    -- best-effort acquired_at
+            NOW(),
+
+            -- Merge original metadata with quantity/avg_price so that
+            -- portfolio_service.enrich_asset_response() can reconstruct
+            -- the legacy API response without extra DB queries.
+            CASE
+                WHEN pa.quantity IS NOT NULL
+                    THEN COALESCE(pa.metadata, '{}')::jsonb
+                         || jsonb_build_object(
+                                'quantity',  pa.quantity,
+                                'avg_price', pa.purchase_price
+                            )
+                ELSE COALESCE(pa.metadata, '{}')::jsonb
+            END,
+
+            true,               -- is_active
+            pa.created_at,
+            pa.updated_at
+
+        FROM portfolio_assets pa
+        WHERE pa.deleted_at IS NULL
+          AND NOT EXISTS (SELECT 1 FROM assets a WHERE a.id = pa.id)
+    """)
+
+    # ------------------------------------------------------------------
+    # 2. Create today's snapshot for every migrated asset so that
+    #    net_worth_calculator.calculate_historical() has a starting point.
+    # ------------------------------------------------------------------
+    op.execute("""
+        INSERT INTO asset_snapshots (asset_id, user_id, snapshot_date, value, source)
+        SELECT
+            a.id,
+            a.user_id,
+            CURRENT_DATE,
+            a.current_value,
+            'user_input'
+        FROM assets a
+        WHERE a.id IN (SELECT id FROM portfolio_assets WHERE deleted_at IS NULL)
+          AND NOT EXISTS (
+              SELECT 1 FROM asset_snapshots s
+              WHERE s.asset_id = a.id
+                AND s.snapshot_date = CURRENT_DATE
+          )
+    """)
+
+
+def downgrade() -> None:
+    # Cascade on asset_snapshots FK handles snapshot removal automatically.
+    op.execute("""
+        DELETE FROM assets
+        WHERE id IN (SELECT id FROM portfolio_assets WHERE deleted_at IS NULL)
+    """)

--- a/backend/services/chart_generator.py
+++ b/backend/services/chart_generator.py
@@ -31,15 +31,17 @@ _MUTED   = "#99a6b3"
 _GREEN   = "#4CAF50"
 _RED     = "#E15759"
 
-# Asset type catalogue
+# Asset type catalogue — includes both Phase 3A names and legacy V1 names
 _ASSET_CFG: dict[str, dict] = {
     "real_estate":    {"label": "Bất động sản",   "color": "#4ECDC4"},
-    "stocks":         {"label": "Chứng khoán",    "color": "#F28E2B"},
-    "mutual_fund":    {"label": "Chứng chỉ quỹ", "color": "#E15759"},
+    "stock":          {"label": "Chứng khoán",    "color": "#F28E2B"},  # Phase 3A
+    "stocks":         {"label": "Chứng khoán",    "color": "#F28E2B"},  # V1 legacy
+    "mutual_fund":    {"label": "Chứng chỉ quỹ", "color": "#E15759"},  # V1 legacy
     "crypto":         {"label": "Tiền số",         "color": "#76B7B2"},
     "life_insurance": {"label": "Bảo hiểm",       "color": "#59A14F"},
     "gold":           {"label": "Vàng",            "color": "#EDC948"},
     "cash":           {"label": "Tiền mặt",        "color": "#B07AA1"},
+    "other":          {"label": "Khác",            "color": "#BAB0AC"},
 }
 _EXTRA_COLORS = ["#FF6B6B", "#A8E6CF", "#FFD93D", "#C3B1E1", "#FAD7A0"]
 _DEFAULT_CFG  = {"label": "Khác", "color": "#BAB0AC"}

--- a/backend/services/morning_report_service.py
+++ b/backend/services/morning_report_service.py
@@ -7,15 +7,13 @@ import logging
 import uuid
 from datetime import date, datetime, timedelta
 
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.models.portfolio_asset import PortfolioAsset
 from backend.models.user import User
-from backend.services.chart_generator import generate_portfolio_chart
-from backend.services.chart_service import ASSET_TYPE_CONFIG
-from backend.services.portfolio_service import _compute_asset_fields, list_assets
 from backend.ports.notifier import get_notifier
+from backend.services.chart_generator import generate_portfolio_chart
+from backend.wealth.asset_types import get_icon, get_label
+from backend.wealth.services import asset_service, net_worth_calculator
 
 logger = logging.getLogger(__name__)
 
@@ -49,37 +47,15 @@ def _format_vnd_text(amount: float) -> str:
 async def _get_previous_month_total(
     db: AsyncSession, user_id: uuid.UUID
 ) -> float | None:
-    """Estimate previous month's total portfolio value.
+    """Net worth at end of last month, sourced from asset_snapshots.
 
-    Uses the oldest snapshot approach: if assets existed last month,
-    approximate by using purchase_price * quantity for assets created
-    before last month, plus current_price for newer ones.
-    This is a best-effort estimate.
+    Returns None when no snapshots exist before this month (new user or
+    first run after data migration — show no change rather than wrong data).
     """
     first_of_month = date.today().replace(day=1)
     last_month_end = first_of_month - timedelta(days=1)
-    last_month_start = last_month_end.replace(day=1)
-
-    # Get assets that existed before this month
-    stmt = select(PortfolioAsset).where(
-        PortfolioAsset.user_id == user_id,
-        PortfolioAsset.deleted_at.is_(None),
-        PortfolioAsset.created_at < first_of_month,
-    )
-    result = await db.execute(stmt)
-    assets = list(result.scalars().all())
-
-    if not assets:
-        return None
-
-    total = 0.0
-    for asset in assets:
-        quantity = float(asset.quantity) if asset.quantity is not None else 0.0
-        # Use purchase_price as estimate for last month
-        price = float(asset.purchase_price) if asset.purchase_price is not None else 0.0
-        total += quantity * price
-
-    return total if total > 0 else None
+    total = await net_worth_calculator.calculate_historical(db, user_id, last_month_end)
+    return float(total) if total > 0 else None
 
 
 async def build_morning_report(
@@ -89,20 +65,19 @@ async def build_morning_report(
 
     Returns:
         (chart_png_bytes, text_summary, has_assets)
-        chart_png_bytes is None if user has no assets.
+        chart_png_bytes is None if user has no assets or chart fails.
     """
-    assets = await list_assets(db, user_id, limit=500)
+    assets = await asset_service.get_user_assets(db, user_id)
 
     if not assets:
         return None, "", False
 
-    # Aggregate by asset type
+    # Aggregate by asset type using current_value directly (no qty × price)
     allocation_values: dict[str, float] = {}
     total_value = 0.0
 
     for asset in assets:
-        computed = _compute_asset_fields(asset)
-        mv = computed["market_value"] or 0.0
+        mv = float(asset.current_value or 0)
         total_value += mv
         allocation_values[asset.asset_type] = (
             allocation_values.get(asset.asset_type, 0.0) + mv
@@ -126,7 +101,7 @@ async def build_morning_report(
     now = datetime.now()
     timestamp = now.strftime("%H:%M %d/%m/%Y")
 
-    # Render chart via new generator (fallback to None on failure)
+    # Render chart (fallback to None on failure)
     assets_data = [
         {"asset_type": t, "value": v}
         for t, v in allocation_values.items()
@@ -141,7 +116,6 @@ async def build_morning_report(
         logger.exception("Chart generation failed for user %s — will send text only", user_id)
         chart_bytes = None
 
-    # Build text summary
     text = _build_text_summary(
         allocation_values=allocation_values,
         allocation_pct=allocation_pct,
@@ -149,7 +123,7 @@ async def build_morning_report(
         change_pct=change_pct,
     )
 
-    return chart_bytes, text, True  # chart_bytes may be None if rendering failed
+    return chart_bytes, text, True
 
 
 def _build_text_summary(
@@ -178,12 +152,11 @@ def _build_text_summary(
     )
 
     for asset_type in sorted_types:
-        cfg = ASSET_TYPE_CONFIG.get(asset_type, {"emoji": "📦", "label": asset_type})
+        icon = get_icon(asset_type)
+        label = get_label(asset_type)
         value = allocation_values[asset_type]
         pct = allocation_pct.get(asset_type, 0)
-        lines.append(
-            f'{cfg["emoji"]} {cfg["label"]}: {_format_vnd_text(value)} ({pct:.1f}%)'
-        )
+        lines.append(f"{icon} {label}: {_format_vnd_text(value)} ({pct:.1f}%)")
 
     return "\n".join(lines)
 
@@ -243,7 +216,6 @@ async def send_morning_report(
             reply_markup={"inline_keyboard": MORNING_REPORT_BUTTONS},
         )
     else:
-        # Send chart with greeting as caption
         caption = f"{greeting}\n\n{text_summary}"
         # Telegram caption limit is 1024 chars; if too long, send separately
         if len(caption) > 1024:

--- a/backend/services/portfolio_service.py
+++ b/backend/services/portfolio_service.py
@@ -1,41 +1,146 @@
+"""portfolio_service — legacy API adapter over wealth/services/asset_service.
+
+Bridges the V1 /portfolio router (PortfolioAsset schema with quantity,
+purchase_price, current_price) to the Phase 3A Asset model so that the
+old API keeps working while all data lives in the ``assets`` table.
+
+Mapping convention (stored in asset.extra JSONB):
+  extra["quantity"]  ↔  old quantity field
+  extra["avg_price"] ↔  old purchase_price field
+  (current_price is derived: current_value / quantity)
+"""
 import uuid
 from datetime import datetime
+from decimal import Decimal
 
-from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.models.portfolio_asset import PortfolioAsset
+from backend.wealth.models.asset import Asset
+from backend.wealth.services import asset_service
 from backend.schemas.portfolio import PortfolioAssetCreate, PortfolioAssetUpdate
 
 
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _compute_asset_fields(asset: Asset) -> dict:
+    """Compute P&L and market value from Asset.current_value / initial_value."""
+    mv = float(asset.current_value or 0)
+    cost = float(asset.initial_value or 0)
+    unrealized_pnl = mv - cost
+    unrealized_pnl_pct = round((unrealized_pnl / cost) * 100, 2) if cost > 0 else None
+    return {
+        "market_value": mv,
+        "unrealized_pnl": unrealized_pnl,
+        "unrealized_pnl_pct": unrealized_pnl_pct,
+    }
+
+
+def enrich_asset_response(asset: Asset) -> dict:
+    """Adapt Asset to the legacy PortfolioAssetResponse shape.
+
+    Reconstructs quantity / purchase_price / current_price from
+    extra JSONB so callers that expect the old API shape keep working.
+    """
+    extra = asset.extra or {}
+    quantity = extra.get("quantity")
+    avg_price = extra.get("avg_price")
+
+    # Derive current_price from current_value ÷ quantity when available
+    if quantity and float(quantity) > 0:
+        current_price = float(
+            Decimal(str(asset.current_value or 0)) / Decimal(str(quantity))
+        )
+    else:
+        current_price = float(asset.current_value or 0)
+
+    # Strip internal fields from metadata so the response stays clean
+    _internal = {"quantity", "avg_price"}
+    metadata = {k: v for k, v in extra.items() if k not in _internal} or None
+
+    data = {
+        "id": asset.id,
+        "user_id": asset.user_id,
+        "asset_type": asset.asset_type,
+        "name": asset.name,
+        "quantity": float(quantity) if quantity is not None else None,
+        "purchase_price": float(avg_price) if avg_price is not None else float(asset.initial_value or 0),
+        "current_price": current_price,
+        "metadata": metadata,
+        "created_at": asset.created_at,
+        "updated_at": asset.updated_at,
+    }
+    data.update(_compute_asset_fields(asset))
+    return data
+
+
+def _initial_from(
+    quantity: float | None,
+    purchase_price: float | None,
+) -> Decimal:
+    """Compute initial_value from (optional) quantity × purchase_price."""
+    if quantity is not None and purchase_price is not None:
+        return Decimal(str(quantity)) * Decimal(str(purchase_price))
+    if purchase_price is not None:
+        return Decimal(str(purchase_price))
+    return Decimal(0)
+
+
+def _current_from(
+    quantity: float | None,
+    current_price: float | None,
+    initial_value: Decimal,
+) -> Decimal:
+    """Compute current_value with a fallback chain to initial_value."""
+    if quantity is not None and current_price is not None:
+        return Decimal(str(quantity)) * Decimal(str(current_price))
+    if current_price is not None:
+        return Decimal(str(current_price))
+    return initial_value
+
+
+def _build_extra(
+    quantity: float | None,
+    purchase_price: float | None,
+    metadata: dict | None,
+) -> dict | None:
+    """Build the extra JSONB dict from V1 fields."""
+    extra: dict = {}
+    if quantity is not None:
+        extra["quantity"] = quantity
+    if purchase_price is not None:
+        extra["avg_price"] = purchase_price
+    if metadata:
+        extra.update(metadata)
+    return extra or None
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
 async def create_asset(
     db: AsyncSession, user_id: uuid.UUID, data: PortfolioAssetCreate
-) -> PortfolioAsset:
-    asset = PortfolioAsset(
-        user_id=user_id,
+) -> Asset:
+    initial_value = _initial_from(data.quantity, data.purchase_price)
+    current_value = _current_from(data.quantity, data.current_price, initial_value)
+    extra = _build_extra(data.quantity, data.purchase_price, data.metadata)
+    return await asset_service.create_asset(
+        db,
+        user_id,
         asset_type=data.asset_type,
         name=data.name,
-        quantity=data.quantity,
-        purchase_price=data.purchase_price,
-        current_price=data.current_price,
-        metadata_=data.metadata,
+        initial_value=initial_value,
+        current_value=current_value,
+        extra=extra,
     )
-    db.add(asset)
-    await db.flush()
-    await db.refresh(asset)
-    return asset
 
 
 async def get_asset(
     db: AsyncSession, user_id: uuid.UUID, asset_id: uuid.UUID
-) -> PortfolioAsset | None:
-    stmt = select(PortfolioAsset).where(
-        PortfolioAsset.id == asset_id,
-        PortfolioAsset.user_id == user_id,
-        PortfolioAsset.deleted_at.is_(None),
-    )
-    result = await db.execute(stmt)
-    return result.scalar_one_or_none()
+) -> Asset | None:
+    return await asset_service.get_asset_by_id(db, user_id, asset_id)
 
 
 async def list_assets(
@@ -44,16 +149,9 @@ async def list_assets(
     asset_type: str | None = None,
     limit: int = 50,
     offset: int = 0,
-) -> list[PortfolioAsset]:
-    stmt = select(PortfolioAsset).where(
-        PortfolioAsset.user_id == user_id,
-        PortfolioAsset.deleted_at.is_(None),
-    )
-    if asset_type:
-        stmt = stmt.where(PortfolioAsset.asset_type == asset_type)
-    stmt = stmt.order_by(PortfolioAsset.created_at.desc()).limit(limit).offset(offset)
-    result = await db.execute(stmt)
-    return list(result.scalars().all())
+) -> list[Asset]:
+    assets = await asset_service.get_user_assets(db, user_id, asset_type=asset_type)
+    return assets[offset : offset + limit]
 
 
 async def update_asset(
@@ -61,16 +159,55 @@ async def update_asset(
     user_id: uuid.UUID,
     asset_id: uuid.UUID,
     data: PortfolioAssetUpdate,
-) -> PortfolioAsset | None:
-    asset = await get_asset(db, user_id, asset_id)
-    if not asset:
+) -> Asset | None:
+    asset = await asset_service.get_asset_by_id(db, user_id, asset_id)
+    if asset is None:
         return None
+
     update_data = data.model_dump(exclude_unset=True)
-    for field, value in update_data.items():
-        if field == "metadata":
-            setattr(asset, "metadata_", value)
-        else:
-            setattr(asset, field, value)
+
+    # Simple field updates (direct ORM mutation — service owns the flush)
+    if "name" in update_data:
+        asset.name = update_data["name"]
+    if "asset_type" in update_data:
+        asset.asset_type = update_data["asset_type"]
+
+    # Value updates: recompute initial_value / current_value and refresh extra
+    has_value_change = any(
+        k in update_data for k in ("quantity", "purchase_price", "current_price")
+    )
+    if has_value_change:
+        existing = asset.extra or {}
+        quantity = update_data.get("quantity", existing.get("quantity"))
+        avg_price = update_data.get("purchase_price", existing.get("avg_price"))
+        current_price = update_data.get("current_price")
+
+        new_initial = _initial_from(quantity, avg_price)
+        new_current = _current_from(quantity, current_price, new_initial)
+
+        asset.initial_value = new_initial
+        asset.current_value = new_current
+        asset.last_valued_at = datetime.utcnow()
+
+        # Rebuild extra: preserve non-internal keys, then update quantity/avg_price
+        _internal = {"quantity", "avg_price"}
+        new_extra = {k: v for k, v in existing.items() if k not in _internal}
+        if quantity is not None:
+            new_extra["quantity"] = quantity
+        if avg_price is not None:
+            new_extra["avg_price"] = avg_price
+        if "metadata" in update_data and update_data["metadata"]:
+            new_extra.update(update_data["metadata"])
+        asset.extra = new_extra or None
+
+    elif "metadata" in update_data:
+        existing = asset.extra or {}
+        _internal = {"quantity", "avg_price"}
+        base = {k: v for k, v in existing.items() if k in _internal}
+        if update_data["metadata"]:
+            base.update(update_data["metadata"])
+        asset.extra = base or None
+
     await db.flush()
     await db.refresh(asset)
     return asset
@@ -79,62 +216,17 @@ async def update_asset(
 async def delete_asset(
     db: AsyncSession, user_id: uuid.UUID, asset_id: uuid.UUID
 ) -> bool:
-    asset = await get_asset(db, user_id, asset_id)
-    if not asset:
+    try:
+        await asset_service.soft_delete(db, user_id, asset_id)
+        return True
+    except ValueError:
         return False
-    asset.deleted_at = datetime.utcnow()
-    await db.flush()
-    return True
-
-
-def _compute_asset_fields(asset: PortfolioAsset) -> dict:
-    """Compute P&L and market value for an asset."""
-    market_value = None
-    unrealized_pnl = None
-    unrealized_pnl_pct = None
-
-    quantity = float(asset.quantity) if asset.quantity is not None else None
-    current_price = float(asset.current_price) if asset.current_price is not None else None
-    purchase_price = float(asset.purchase_price) if asset.purchase_price is not None else None
-
-    if quantity is not None and current_price is not None:
-        market_value = quantity * current_price
-
-    if market_value is not None and purchase_price is not None and quantity is not None:
-        cost = quantity * purchase_price
-        unrealized_pnl = market_value - cost
-        if cost > 0:
-            unrealized_pnl_pct = round((unrealized_pnl / cost) * 100, 2)
-
-    return {
-        "market_value": market_value,
-        "unrealized_pnl": unrealized_pnl,
-        "unrealized_pnl_pct": unrealized_pnl_pct,
-    }
-
-
-def enrich_asset_response(asset: PortfolioAsset) -> dict:
-    """Convert asset to response dict with computed P&L fields."""
-    data = {
-        "id": asset.id,
-        "user_id": asset.user_id,
-        "asset_type": asset.asset_type,
-        "name": asset.name,
-        "quantity": float(asset.quantity) if asset.quantity is not None else None,
-        "purchase_price": float(asset.purchase_price) if asset.purchase_price is not None else None,
-        "current_price": float(asset.current_price) if asset.current_price is not None else None,
-        "metadata": asset.metadata_,
-        "created_at": asset.created_at,
-        "updated_at": asset.updated_at,
-    }
-    data.update(_compute_asset_fields(asset))
-    return data
 
 
 async def get_portfolio_summary(
     db: AsyncSession, user_id: uuid.UUID
 ) -> dict:
-    assets = await list_assets(db, user_id, limit=500)
+    assets = await asset_service.get_user_assets(db, user_id)
 
     total_market_value = 0.0
     total_cost = 0.0
@@ -142,20 +234,15 @@ async def get_portfolio_summary(
     asset_count = len(assets)
 
     for asset in assets:
-        computed = _compute_asset_fields(asset)
-        mv = computed["market_value"] or 0.0
+        mv = float(asset.current_value or 0)
+        cost = float(asset.initial_value or 0)
         total_market_value += mv
-
-        quantity = float(asset.quantity) if asset.quantity is not None else 0.0
-        pp = float(asset.purchase_price) if asset.purchase_price is not None else 0.0
-        total_cost += quantity * pp
-
+        total_cost += cost
         allocation[asset.asset_type] = allocation.get(asset.asset_type, 0.0) + mv
 
     total_pnl = total_market_value - total_cost
     total_pnl_pct = round((total_pnl / total_cost) * 100, 2) if total_cost > 0 else None
 
-    # Convert allocation to percentages
     if total_market_value > 0:
         allocation = {
             k: round((v / total_market_value) * 100, 2)


### PR DESCRIPTION
## Summary
- Alembic migration copies all active `portfolio_assets` rows into the Phase 3A `assets` table with type normalisation (`stocks`→`stock`, `fund`→`stock/fund`), computes `initial_value`/`current_value` from quantity×price, and seeds today's `asset_snapshots` as a net-worth baseline
- `portfolio_service` rewritten as a thin adapter over `wealth/asset_service` — all DB reads/writes now hit `assets`; the legacy `/portfolio` API response shape is reconstructed from `extra` JSONB for backwards compat
- `morning_report_service` drops `PortfolioAsset`/`portfolio_service` imports and uses `asset_service.get_user_assets` + `net_worth_calculator.calculate_historical` for month-over-month delta
- `chart_generator` gains `"stock"` and `"other"` entries in `_ASSET_CFG` so migrated assets show Vietnamese labels ("Chứng khoán") in the donut chart

## Test plan
- [ ] Run `alembic upgrade head` — migration applies cleanly, no errors
- [ ] `/taisan` shows 7 assets: 2 real_estate + 1 crypto + 1 stock/fund + 3 cash
- [ ] Morning report renders chart with correct Vietnamese labels for all asset types
- [ ] `/portfolio/summary` API still returns correct allocation breakdown
- [ ] `portfolio_assets` table remains intact (soft deprecation — not dropped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)