### PR TITLE
feat(bot): improve /taisan format and add asset intent detection

### DIFF
--- a/backend/bot/formatters/wealth_formatter.py
+++ b/backend/bot/formatters/wealth_formatter.py
@@ -9,13 +9,13 @@ from __future__ import annotations
 from decimal import Decimal
 
 from backend.bot.formatters.money import format_money_full, format_money_short
-from backend.wealth.asset_types import get_icon, get_label
+from backend.wealth.asset_types import get_icon, get_label, get_subtype_icon, get_subtype_label
 from backend.wealth.models.asset import Asset
 
 
 def format_asset_added(asset: Asset, net_worth: Decimal) -> str:
     """Confirmation after a wizard creates an asset."""
-    icon = get_icon(asset.asset_type)
+    icon = get_subtype_icon(asset.asset_type, asset.subtype)
     label = get_label(asset.asset_type)
     return (
         f"✅ Đã ghi {icon} {asset.name}\n"
@@ -34,8 +34,13 @@ def format_asset_list(assets: list[Asset]) -> str:
     total = sum((a.current_value for a in assets), Decimal(0))
     lines: list[str] = [f"📊 <b>Tài sản của bạn</b> ({len(assets)} mục)\n"]
     for asset in assets:
-        icon = get_icon(asset.asset_type)
-        lines.append(f"{icon} {asset.name} — {format_money_short(asset.current_value)}")
+        icon = get_subtype_icon(asset.asset_type, asset.subtype)
+        subtype_label = get_subtype_label(asset.subtype)
+        amount = format_money_short(asset.current_value)
+        if subtype_label:
+            lines.append(f"{icon} {asset.name} — {subtype_label} — {amount}")
+        else:
+            lines.append(f"{icon} {asset.name} — {amount}")
     lines.append(f"\n💎 Tổng: <b>{format_money_short(total)}</b>")
     return "\n".join(lines)
 

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -32,6 +32,18 @@ Chỉ trả về JSON, không giải thích."""
 
 _NOT_REGISTERED = "Bạn chưa đăng ký. Gửi /start để bắt đầu."
 
+_ASSET_QUERY_PATTERNS = (
+    "tài sản của tôi",
+    "danh sách tài sản",
+    "xem tài sản",
+    "tài sản có gì",
+    "tôi có tài sản",
+    "tài sản tôi",
+    "liệt kê tài sản",
+    "tài sản hiện tại",
+    "tôi đang có gì",
+)
+
 
 async def _send_report(db: AsyncSession, chat_id: int, telegram_id: int, text: str = "") -> None:
     """Ask the service for report text and deliver it to the user."""
@@ -76,6 +88,13 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
     user = await get_user_by_telegram_id(db, telegram_id)
     if not user:
         await send_message(chat_id, _NOT_REGISTERED)
+        return True
+
+    # Fast-path: asset list intent.
+    lower = text.lower()
+    if any(pat in lower for pat in _ASSET_QUERY_PATTERNS):
+        from backend.bot.handlers.asset_entry import list_assets
+        await list_assets(db, chat_id, user)
         return True
 
     try:

--- a/backend/wealth/asset_types.py
+++ b/backend/wealth/asset_types.py
@@ -55,3 +55,53 @@ def get_icon(asset_type: str) -> str:
 
 def get_label(asset_type: str) -> str:
     return get_asset_config(asset_type).get("label_vi", asset_type)
+
+
+_SUBTYPE_ICONS: dict[str, str] = {
+    "bank_savings": "🏦",
+    "bank_checking": "💳",
+    "cash": "💵",
+    "e_wallet": "📱",
+    "vn_stock": "📈",
+    "fund": "📊",
+    "etf": "📊",
+    "foreign_stock": "📈",
+}
+
+_SUBTYPE_SHORT_LABELS: dict[str, str] = {
+    "bank_savings": "Tiết kiệm",
+    "bank_checking": "Thanh toán",
+    "cash": "Tiền mặt",
+    "e_wallet": "Ví điện tử",
+    "vn_stock": "Cổ phiếu VN",
+    "fund": "Quỹ đầu tư",
+    "etf": "ETF",
+    "foreign_stock": "Cổ phiếu nước ngoài",
+    "house_primary": "Nhà ở",
+    "land": "Đất",
+    "bitcoin": "BTC",
+    "ethereum": "ETH",
+    "stablecoin": "Stablecoin",
+    "altcoin": "Altcoin",
+    "sjc": "Vàng SJC",
+    "pnj": "Vàng PNJ",
+    "nhan": "Vàng nhẫn",
+    "trang_suc": "Trang sức",
+    "vehicle": "Xe cộ",
+    "collection": "Đồ sưu tầm",
+    "business": "Kinh doanh",
+}
+
+
+def get_subtype_icon(asset_type: str, subtype: str | None) -> str:
+    """Return a subtype-specific icon, falling back to the asset_type icon."""
+    if subtype and subtype in _SUBTYPE_ICONS:
+        return _SUBTYPE_ICONS[subtype]
+    return get_icon(asset_type)
+
+
+def get_subtype_label(subtype: str | None) -> str | None:
+    """Return a short Vietnamese label for the subtype, or None if unknown."""
+    if not subtype:
+        return None
+    return _SUBTYPE_SHORT_LABELS.get(subtype)


### PR DESCRIPTION
## Summary
- **Asset intent detection**: natural-language queries like "tài sản của tôi có gì?" now route directly to `list_assets` without hitting the LLM
- **Subtype-specific icons**: `/taisan` shows distinct icons per subtype (🏦 tiết kiệm, 💳 thanh toán, 💵 tiền mặt, 📱 ví điện tử, 📊 quỹ đầu tư, etc.)
- **Subtype labels**: each asset line now shows the subtype in Vietnamese before the amount — e.g. `🏦 Techcombank — Tiết kiệm — 20tr`

## Files changed
- `backend/wealth/asset_types.py` — `get_subtype_icon`, `get_subtype_label` helpers + lookup dicts
- `backend/bot/formatters/wealth_formatter.py` — `format_asset_list` and `format_asset_added` use new helpers
- `backend/bot/handlers/message.py` — `_ASSET_QUERY_PATTERNS` fast-path before LLM call

## Test plan
- [ ] Send "tài sản của tôi có gì?" → bot responds with asset list (not menu)
- [ ] Send "xem tài sản" → same
- [ ] `/taisan` → each asset shows correct subtype icon and label
- [ ] Expense entry ("50k ăn sáng") still works normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)