### PR TITLE
fix(config): allow extra env vars in Settings

### DIFF
--- a/backend/miniapp/routes.py
+++ b/backend/miniapp/routes.py
@@ -230,6 +230,27 @@ async def get_wealth_overview(
     return {"data": payload, "error": None}
 
 
+@router.post("/api/wealth/start-asset-wizard")
+async def start_asset_wizard_route(
+    auth: dict = Depends(require_miniapp_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Trigger the asset-add wizard from the Mini App "+ Thêm tài sản" button.
+
+    Posts the type-picker message into the user's private chat with the
+    bot, so when the WebApp closes the user lands on a chat that is
+    already mid-flow. Private-chat ``chat_id`` equals ``telegram_id``.
+    """
+    user = await _resolve_user(auth, db)
+    # Lazy import — asset_entry pulls in the wizard graph; keep the
+    # miniapp module light and avoid any chance of a circular import
+    # at process start.
+    from backend.bot.handlers.asset_entry import start_asset_wizard
+
+    await start_asset_wizard(db, user.telegram_id, user)
+    return {"data": {"ok": True}, "error": None}
+
+
 @router.get("/api/wealth/trend")
 async def get_wealth_trend(
     days: int = Query(

--- a/backend/miniapp/static/js/wealth_dashboard.js
+++ b/backend/miniapp/static/js/wealth_dashboard.js
@@ -449,9 +449,27 @@
 
     // -- Misc -------------------------------------------------------------
 
-    function closeAndAddAsset() {
-        // The bot listens for /add_asset — closing the WebApp surfaces the
-        // chat where the user types/taps it. Future: deep-link directly.
+    async function closeAndAddAsset() {
+        // Disable both buttons to prevent a double-tap firing the wizard
+        // twice — a second call would just reset the flow but it's wasted
+        // work and a wasted Telegram message.
+        if (els.addAssetBtn) els.addAssetBtn.disabled = true;
+        if (els.addFirstAssetBtn) els.addFirstAssetBtn.disabled = true;
+
+        try {
+            const headers = { 'Content-Type': 'application/json' };
+            if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+            // Wait for the bot to post the type-picker before closing
+            // the WebApp — otherwise the user lands on an empty chat
+            // and assumes the button did nothing.
+            await fetch('/miniapp/api/wealth/start-asset-wizard', {
+                method: 'POST',
+                headers,
+            });
+        } catch (_err) {
+            // Best-effort: even on failure we still close so the user
+            // isn't stuck staring at the dashboard.
+        }
         if (tg && tg.close) tg.close();
     }
 

--- a/backend/tests/test_miniapp_wealth_routes.py
+++ b/backend/tests/test_miniapp_wealth_routes.py
@@ -222,6 +222,53 @@ class TestWealthTrendEndpoint:
             assert data[0]["value"] == 5_000_000.0
 
 
+class TestStartAssetWizardRoute:
+    def teardown_method(self):
+        _clear_overrides()
+
+    def test_invokes_wizard_with_user_telegram_id_as_chat_id(self):
+        _override_auth()
+        user = _fake_user(telegram_id=98765)
+
+        async def _fake_resolve(auth, db):
+            return user
+
+        wizard_mock = AsyncMock()
+        # Patch the symbol where it's imported — the route does a lazy
+        # import inside the handler, so we patch the source module.
+        with patch.object(miniapp_routes, "_resolve_user", _fake_resolve), \
+             patch(
+                 "backend.bot.handlers.asset_entry.start_asset_wizard",
+                 wizard_mock,
+             ):
+            resp = client.post(
+                "/miniapp/api/wealth/start-asset-wizard",
+                headers={"X-Telegram-Init-Data": "stub"},
+            )
+            assert resp.status_code == 200
+            assert resp.json() == {"data": {"ok": True}, "error": None}
+
+            wizard_mock.assert_awaited_once()
+            args = wizard_mock.await_args.args
+            # (db, chat_id, user) — chat_id must equal user.telegram_id
+            # so the bot posts the type-picker into the user's private chat.
+            assert args[1] == 98765
+            assert args[2] is user
+
+    def test_requires_auth(self):
+        # No auth override — the real require_miniapp_auth dependency
+        # rejects the missing/invalid initData.
+        app.dependency_overrides[get_db] = _stub_db
+        try:
+            resp = client.post(
+                "/miniapp/api/wealth/start-asset-wizard",
+                headers={"X-Telegram-Init-Data": "invalid"},
+            )
+            assert resp.status_code == 401
+        finally:
+            app.dependency_overrides.pop(get_db, None)
+
+
 class TestWealthDashboardPage:
     def test_serves_html(self):
         resp = client.get("/miniapp/wealth")


### PR DESCRIPTION
## Summary
- `.env` was edited to add `POSTGRES_USER/PASSWORD/DB` for docker-compose; pydantic-settings 2.13 defaults to `extra="forbid"` so backend + scheduler crash at startup.
- Set `extra="ignore"` on the Settings `model_config` — standard pattern when an `.env` file is shared between Compose and the Python app.
- Surfaced while restarting services after the miniapp button fix in [#107](https://github.com/phuongphh/FinanceAssistant/pull/107).

## Test plan
- [x] `python -c "from backend.config import get_settings; get_settings()"` no longer raises
- [ ] Restart backend + scheduler launchd services and confirm startup