### PR TITLE
fix(config): allow extra env vars so POSTGRES_* keys don't break startup

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -66,7 +66,14 @@ class Settings(BaseSettings):
     # briefing handler falls back to a placeholder message.
     miniapp_base_url: str = ""
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    # ``extra="ignore"`` lets the .env file hold sibling env vars used by
+    # docker-compose (e.g. POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB)
+    # without pydantic-settings 2.x rejecting them as extras.
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
 
 
 @lru_cache


### PR DESCRIPTION
pydantic-settings 2.x defaults to extra="forbid", so adding POSTGRES_USER/PASSWORD/DB to .env (for docker-compose) crashes both backend and scheduler at startup. Set extra="ignore" on the Settings model_config — standard pattern when the .env is shared between Compose and the Python app.