### PR TITLE
fix(miniapp): gộp tài sản trùng tên + subtype trên wealth dashboard

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -66,7 +66,14 @@ class Settings(BaseSettings):
     # briefing handler falls back to a placeholder message.
     miniapp_base_url: str = ""
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    # ``extra="ignore"`` lets the .env file hold sibling env vars used by
+    # docker-compose (e.g. POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB)
+    # without pydantic-settings 2.x rejecting them as extras.
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
 
 
 @lru_cache

--- a/backend/miniapp/static/css/wealth.css
+++ b/backend/miniapp/static/css/wealth.css
@@ -216,6 +216,18 @@
     color: var(--text-color);
 }
 
+.asset-card .asset-count {
+    display: inline-block;
+    margin-left: 6px;
+    padding: 1px 7px;
+    border-radius: 8px;
+    background: rgba(78, 205, 196, 0.18);
+    color: var(--primary);
+    font-size: 11px;
+    font-weight: 600;
+    vertical-align: middle;
+}
+
 .asset-card .asset-type {
     font-size: 12px;
     color: var(--text-muted);

--- a/backend/miniapp/static/js/wealth_dashboard.js
+++ b/backend/miniapp/static/js/wealth_dashboard.js
@@ -375,12 +375,23 @@
             const positive = (a.change || 0) >= 0;
             const sign = positive ? '+' : '';
             const cls = positive ? 'positive' : 'negative';
+            // Subtitle composes "<Type> · <Subtype>" so the user can tell
+            // apart e.g. Techcombank Thanh toán vs Techcombank Tiết kiệm.
+            const subtitle = a.subtype_label
+                ? `${escapeHtml(a.type_label)} · ${escapeHtml(a.subtype_label)}`
+                : escapeHtml(a.type_label);
+            // Backend merges rows with the same name+subtype; surface the
+            // bundle count so users know one card represents multiple
+            // entries (e.g. two ``Tiền mặt`` deposits → ``×2``).
+            const countBadge = (a.count || 1) > 1
+                ? `<span class="asset-count">×${a.count}</span>`
+                : '';
             return `
                 <div class="asset-card">
                     <span class="asset-icon">${escapeHtml(a.icon)}</span>
                     <div class="asset-info">
-                        <div class="asset-name">${escapeHtml(a.name)}</div>
-                        <div class="asset-type">${escapeHtml(a.type_label)}</div>
+                        <div class="asset-name">${escapeHtml(a.name)}${countBadge}</div>
+                        <div class="asset-type">${subtitle}</div>
                     </div>
                     <div class="asset-value">
                         <div class="asset-current">${formatMoneyShort(a.current_value)}</div>

--- a/backend/services/wealth_dashboard_service.py
+++ b/backend/services/wealth_dashboard_service.py
@@ -16,13 +16,14 @@ window. For a user with ~10 assets and 365 days this is one round-trip,
 from __future__ import annotations
 
 import uuid
+from collections import defaultdict
 from datetime import date, timedelta
 from decimal import Decimal
 
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from backend.wealth.asset_types import get_asset_config
+from backend.wealth.asset_types import get_asset_config, get_subtype_label
 from backend.wealth.ladder import WealthLevel, detect_level, next_milestone
 from backend.wealth.services import asset_service, net_worth_calculator
 
@@ -38,30 +39,73 @@ _LEVEL_LABELS_VI = {
 }
 
 
-def _serialize_asset(asset) -> dict:
-    """Trim asset ORM object → dashboard JSON shape."""
-    config = get_asset_config(asset.asset_type)
-    initial = Decimal(asset.initial_value or 0)
-    current = Decimal(asset.current_value or 0)
+def _group_key(asset) -> tuple[str, str, str]:
+    """Identity for asset aggregation on the dashboard.
+
+    Same name (case + whitespace insensitive) + same subtype + same
+    asset_type → merged into one card. Different subtypes stay separate
+    even if the name matches: a Techcombank checking and a Techcombank
+    savings are functionally different products and the user benefits
+    from seeing them apart.
+    """
+    name = (asset.name or "").strip().casefold()
+    return (asset.asset_type, asset.subtype or "", name)
+
+
+def _serialize_group(members: list) -> dict:
+    """Aggregate a list of assets sharing the same identity into one card.
+
+    Members must already be pre-grouped by ``_group_key``. Values are
+    summed, ``acquired_at`` is the earliest of any member, and the
+    ``count`` / ``member_ids`` fields let the frontend annotate rows
+    that bundle multiple raw entries (e.g. ``×2`` badge).
+    """
+    first = members[0]
+    asset_type = first.asset_type
+    subtype = first.subtype
+    config = get_asset_config(asset_type)
+
+    initial = sum((Decimal(m.initial_value or 0) for m in members), Decimal(0))
+    current = sum((Decimal(m.current_value or 0) for m in members), Decimal(0))
     change = current - initial
-    if initial > 0:
-        change_pct = float(change / initial * 100)
-    else:
-        change_pct = 0.0
+    change_pct = float(change / initial * 100) if initial > 0 else 0.0
+
+    acquired_dates = [m.acquired_at for m in members if m.acquired_at]
+    earliest = min(acquired_dates) if acquired_dates else None
 
     return {
-        "id": str(asset.id),
-        "name": asset.name,
-        "asset_type": asset.asset_type,
-        "subtype": asset.subtype,
+        "id": str(first.id),
+        "name": first.name,
+        "asset_type": asset_type,
+        "subtype": subtype,
+        "subtype_label": get_subtype_label(subtype),
         "icon": config.get("icon", "📌"),
-        "type_label": config.get("label_vi", asset.asset_type),
+        "type_label": config.get("label_vi", asset_type),
         "current_value": float(current),
         "initial_value": float(initial),
         "change": float(change),
         "change_pct": round(change_pct, 2),
-        "acquired_at": asset.acquired_at.isoformat() if asset.acquired_at else None,
+        "acquired_at": earliest.isoformat() if earliest else None,
+        "count": len(members),
+        "member_ids": [str(m.id) for m in members],
     }
+
+
+def _group_assets(assets: list) -> list[dict]:
+    """Group raw asset rows into dashboard cards, sorted largest-first.
+
+    Two rows with the same name + subtype merge into one card with
+    summed values. Different subtypes stay separate. Sorting by current
+    value puts the user's biggest holdings on top — what they care
+    about glancing at first.
+    """
+    groups: dict[tuple[str, str, str], list] = defaultdict(list)
+    for a in assets:
+        groups[_group_key(a)].append(a)
+
+    serialized = [_serialize_group(members) for members in groups.values()]
+    serialized.sort(key=lambda g: g["current_value"], reverse=True)
+    return serialized
 
 
 def _build_breakdown(
@@ -172,6 +216,7 @@ async def build_overview(
 
     trend = await get_trend(db, user_id, days=trend_days)
     assets = await asset_service.get_user_assets(db, user_id)
+    grouped_assets = _group_assets(assets)
 
     breakdown = _build_breakdown(breakdown_now.by_type, breakdown_now.total)
 
@@ -183,7 +228,10 @@ async def build_overview(
 
     payload = {
         "net_worth": float(breakdown_now.total),
-        "asset_count": breakdown_now.asset_count,
+        # Logical card count, not raw row count: the user thinks of
+        # two ``Tiền mặt`` entries as one bucket, so the hero pill
+        # should match what they see in the asset list below.
+        "asset_count": len(grouped_assets),
         "currency": breakdown_now.currency,
         "level": level.value,
         "level_label": _LEVEL_LABELS_VI.get(level, level.value),
@@ -198,7 +246,7 @@ async def build_overview(
         "breakdown": breakdown,
         "trend": trend,
         "trend_days": trend_days,
-        "assets": [_serialize_asset(a) for a in assets],
+        "assets": grouped_assets,
         "next_milestone": {
             "target": float(target_amount),
             "target_level": target_level.value,

--- a/backend/tests/test_wealth_dashboard_service.py
+++ b/backend/tests/test_wealth_dashboard_service.py
@@ -1,11 +1,14 @@
 """Tests for ``backend.services.wealth_dashboard_service``.
 
 Covers:
-- ``_serialize_asset`` — happy path, missing initial value, unknown type fallback.
+- ``_serialize_group`` — happy path, missing initial value, unknown type fallback.
+- ``_group_assets`` — name+subtype merging, case/whitespace normalization,
+  same-name-different-subtype stays split, sort order, change aggregation.
 - ``_build_breakdown`` — sort order, percentage math, zero-total guard.
 - ``get_trend`` — input validation, row serialization, default end-date,
   query parameter binding (start/end derived from ``days``).
-- ``build_overview`` — payload composition for Starter / empty / HNW.
+- ``build_overview`` — payload composition for Starter / empty / HNW,
+  duplicate rollup behavior end-to-end.
 
 Real Postgres isn't required — we monkeypatch ``net_worth_calculator``
 and ``asset_service`` and stub ``db.execute`` for the trend SQL.
@@ -36,14 +39,16 @@ def _asset(asset_type, name, current, initial=None, subtype=None):
     )
 
 
-class TestSerializeAsset:
-    def test_known_type_attaches_yaml_metadata(self):
+class TestSerializeGroup:
+    def test_single_member_known_type(self):
         a = _asset("cash", "VCB", 5_000_000, initial=4_000_000, subtype="bank_savings")
-        out = svc._serialize_asset(a)
-        # YAML config drives icon + label, so we don't hardcode the
-        # display copy in code — just verify the loader plugged in.
+        out = svc._serialize_group([a])
+        # YAML config drives icon + parent label.
         assert out["asset_type"] == "cash"
         assert out["subtype"] == "bank_savings"
+        # Subtype label surfaces alongside the parent type so users can
+        # distinguish products that share a name but differ in subtype.
+        assert out["subtype_label"] == "Tiết kiệm"
         assert out["icon"] == "💵"
         assert out["type_label"] == "Tiền mặt & Tài khoản"
         assert out["current_value"] == 5_000_000.0
@@ -51,33 +56,115 @@ class TestSerializeAsset:
         assert out["change"] == 1_000_000.0
         assert out["change_pct"] == 25.0
         assert out["acquired_at"] == "2026-01-01"
+        assert out["count"] == 1
+        assert out["member_ids"] == [str(a.id)]
         assert isinstance(out["id"], str)  # UUID stringified
 
     def test_unknown_type_falls_back_to_default_icon_and_label(self):
         a = _asset("widgets", "Magic Bean", 1_000_000)
-        out = svc._serialize_asset(a)
+        out = svc._serialize_group([a])
         # Unknown asset_type → 📌 default + raw type as label.
         assert out["icon"] == "📌"
         assert out["type_label"] == "widgets"
+        assert out["subtype_label"] is None
 
     def test_zero_initial_value_does_not_divide_by_zero(self):
         a = _asset("other", "Gift", 5_000_000, initial=0)
-        out = svc._serialize_asset(a)
+        out = svc._serialize_group([a])
         # Initial 0 → percentage flat 0% rather than infinity.
         assert out["change"] == 5_000_000.0
         assert out["change_pct"] == 0.0
 
     def test_loss_renders_negative_change(self):
         a = _asset("crypto", "BTC", 80_000_000, initial=100_000_000)
-        out = svc._serialize_asset(a)
+        out = svc._serialize_group([a])
         assert out["change"] == -20_000_000.0
         assert out["change_pct"] == -20.0
 
     def test_missing_acquired_at_yields_none(self):
         a = _asset("cash", "VCB", 1_000_000)
         a.acquired_at = None
-        out = svc._serialize_asset(a)
+        out = svc._serialize_group([a])
         assert out["acquired_at"] is None
+
+
+class TestGroupAssets:
+    def test_same_name_and_subtype_merge(self):
+        # User added "Tiền mặt" twice (10tr + 2tr) → one card 12tr.
+        a1 = _asset("cash", "Tiền mặt", 10_000_000, subtype="cash")
+        a2 = _asset("cash", "Tiền mặt", 2_000_000, subtype="cash")
+        out = svc._group_assets([a1, a2])
+        assert len(out) == 1
+        assert out[0]["current_value"] == 12_000_000.0
+        assert out[0]["count"] == 2
+        assert set(out[0]["member_ids"]) == {str(a1.id), str(a2.id)}
+
+    def test_same_name_different_subtypes_stay_separate(self):
+        # Techcombank checking and Techcombank savings are different
+        # products even though the bank name matches. The subtype label
+        # makes the distinction visible to the user.
+        a1 = _asset("cash", "Techcombank", 20_000_000, subtype="bank_checking")
+        a2 = _asset("cash", "Techcombank", 15_000_000, subtype="bank_savings")
+        out = svc._group_assets([a1, a2])
+        assert len(out) == 2
+        # Sorted desc by value: checking (20tr) first.
+        assert out[0]["subtype"] == "bank_checking"
+        assert out[0]["subtype_label"] == "Thanh toán"
+        assert out[0]["current_value"] == 20_000_000.0
+        assert out[1]["subtype"] == "bank_savings"
+        assert out[1]["subtype_label"] == "Tiết kiệm"
+
+    def test_name_match_is_case_and_whitespace_insensitive(self):
+        # Trim + casefold names before grouping — "tiền mặt" and
+        # "Tiền mặt " are obviously the same bucket to a user.
+        a1 = _asset("cash", "Tiền mặt", 5_000_000, subtype="cash")
+        a2 = _asset("cash", "tiền mặt ", 3_000_000, subtype="cash")
+        out = svc._group_assets([a1, a2])
+        assert len(out) == 1
+        assert out[0]["current_value"] == 8_000_000.0
+        assert out[0]["count"] == 2
+
+    def test_sorts_largest_first(self):
+        a1 = _asset("cash", "VCB", 5_000_000, subtype="bank_savings")
+        a2 = _asset("crypto", "BTC", 100_000_000)
+        a3 = _asset("real_estate", "Đất", 1_500_000_000)
+        out = svc._group_assets([a1, a2, a3])
+        assert [g["asset_type"] for g in out] == [
+            "real_estate", "crypto", "cash"
+        ]
+
+    def test_change_pct_aggregated_across_members(self):
+        # Combined initial 10tr (5+5), combined current 12tr (10+2)
+        # → blended +20%.
+        a1 = _asset("cash", "X", 10_000_000, initial=5_000_000, subtype="cash")
+        a2 = _asset("cash", "X", 2_000_000, initial=5_000_000, subtype="cash")
+        out = svc._group_assets([a1, a2])
+        assert out[0]["initial_value"] == 10_000_000.0
+        assert out[0]["current_value"] == 12_000_000.0
+        assert out[0]["change"] == 2_000_000.0
+        assert out[0]["change_pct"] == 20.0
+
+    def test_acquired_at_is_earliest(self):
+        a1 = _asset("cash", "X", 5_000_000, subtype="cash")
+        a1.acquired_at = date(2026, 3, 1)
+        a2 = _asset("cash", "X", 5_000_000, subtype="cash")
+        a2.acquired_at = date(2026, 1, 15)
+        out = svc._group_assets([a1, a2])
+        # Earliest preserves the genuine "since when" the bucket existed.
+        assert out[0]["acquired_at"] == "2026-01-15"
+
+    def test_empty_returns_empty(self):
+        assert svc._group_assets([]) == []
+
+    def test_none_subtype_groups_with_other_none(self):
+        # Crypto / real_estate sometimes have no subtype. Two no-subtype
+        # rows with the same name should still merge.
+        a1 = _asset("crypto", "BTC", 50_000_000)
+        a2 = _asset("crypto", "BTC", 30_000_000)
+        out = svc._group_assets([a1, a2])
+        assert len(out) == 1
+        assert out[0]["count"] == 2
+        assert out[0]["current_value"] == 80_000_000.0
 
 
 class TestBuildBreakdown:
@@ -214,6 +301,53 @@ class TestBuildOverview:
         # User at 0₫ should still see the first milestone — Young Professional.
         assert result["next_milestone"]["target"] == 30_000_000.0
         assert result["next_milestone"]["pct_progress"] == 0.0
+
+    async def test_duplicate_assets_collapse_in_payload(self, monkeypatch):
+        # Mirrors a real user's data: two "Tiền mặt | cash" rows + two
+        # Techcombank rows with different subtypes. Expect three cards:
+        # one merged "Tiền mặt" 12tr + two distinct Techcombank cards.
+        monkeypatch.setattr(
+            "backend.wealth.services.asset_service.get_user_assets",
+            AsyncMock(return_value=[
+                _asset("cash", "Tiền mặt", 10_000_000, subtype="cash"),
+                _asset("cash", "Tiền mặt", 2_000_000, subtype="cash"),
+                _asset("cash", "Techcombank", 20_000_000, subtype="bank_checking"),
+                _asset("cash", "Techcombank", 15_000_000, subtype="bank_savings"),
+            ]),
+        )
+
+        async def fake_change(db, uid, period):
+            return nwc.NetWorthChange(
+                current=Decimal("47_000_000"),
+                previous=Decimal("47_000_000"),
+                change_absolute=Decimal(0),
+                change_percentage=0.0,
+                period_label="",
+            )
+
+        monkeypatch.setattr(nwc, "calculate_change", fake_change)
+        monkeypatch.setattr(svc, "get_trend", AsyncMock(return_value=[]))
+
+        result = await svc.build_overview(MagicMock(), uuid.uuid4())
+
+        # Hero count reflects logical cards, not raw rows.
+        assert result["asset_count"] == 3
+        assert len(result["assets"]) == 3
+
+        # Cards sorted largest-first.
+        names = [(a["name"], a["subtype"]) for a in result["assets"]]
+        assert names == [
+            ("Techcombank", "bank_checking"),
+            ("Techcombank", "bank_savings"),
+            ("Tiền mặt", "cash"),
+        ]
+        # The merged Tiền mặt card sums values and tags count.
+        merged = result["assets"][2]
+        assert merged["current_value"] == 12_000_000.0
+        assert merged["count"] == 2
+        # Techcombank cards stay split (different subtypes).
+        assert result["assets"][0]["count"] == 1
+        assert result["assets"][1]["count"] == 1
 
     async def test_breakdown_sorted_desc(self, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary
- User báo: trên dashboard có 2 entry "Tiền mặt" và 2 entry "Techcombank" hiển thị riêng lẻ; không rõ Techcombank nào là tài khoản thanh toán.
- Root cause: `build_overview()` trả về mỗi row DB thành một card 1:1, không aggregate. Frontend cũng không show `subtype` nên không phân biệt được.
- Fix: group theo `(asset_type, subtype, name)` (case + whitespace insensitive). Cùng tên + cùng subtype → merge thành 1 card với value sum + badge `×N`. Khác subtype → giữ riêng nhưng show subtype label ("Tiền mặt & Tài khoản · Thanh toán" vs "· Tiết kiệm") để user phân biệt được.
- Không thay đổi logic tạo asset — nhiều khoản gửi cùng tên là use case hợp lệ; chỉ fix display.

## Behavior với data thực của user
9 row DB → **7 card hiển thị**:
- "Tiền mặt | cash" 10tr + 2tr → 1 card "Tiền mặt ×2 — 12tr"
- "Techcombank | bank_checking" 20tr → 1 card "Techcombank · Thanh toán — 20tr"
- "Techcombank | bank_savings" 15tr → 1 card "Techcombank · Tiết kiệm — 15tr"
- 4 card còn lại (Momo, BTC, 2 BĐS, TCEF) — không thay đổi

## Test plan
- [x] Unit test grouping (TestGroupAssets — 8 cases): same name+subtype merge, same name khác subtype giữ riêng, name normalize, sort largest-first, change_pct aggregate, earliest acquired_at, empty, none subtype
- [x] End-to-end test với data giống của user (test_duplicate_assets_collapse_in_payload)
- [x] 28/28 tests trong test_wealth_dashboard_service.py PASS
- [x] 49/49 tests trong test_miniapp_wealth_routes / test_net_worth_calculator / test_briefing_formatter / test_asset_service PASS
- [ ] Manual: mở miniapp dashboard → verify 7 card thay vì 9, badge ×2 trên Tiền mặt, subtype label trên 2 Techcombank

🤖 Generated with [Claude Code](https://claude.com/claude-code)