### PR TITLE
fix(wealth): parser tách label/số tiền + nút huỷ tài sản vừa nhập

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -26,6 +26,7 @@ never commits — the worker owns the transaction boundary.
 from __future__ import annotations
 
 import logging
+import uuid
 from datetime import date
 from decimal import Decimal
 
@@ -67,6 +68,7 @@ class AssetEvent:
     WIZARD_OPENED = "asset_wizard_opened"
     TYPE_PICKED = "asset_wizard_type_picked"
     ASSET_ADDED = "asset_added"
+    ASSET_UNDONE = "asset_undone"
     WIZARD_CANCELED = "asset_wizard_canceled"
     PARSE_FAILED = "asset_wizard_parse_failed"
 
@@ -612,7 +614,53 @@ async def _post_save(
     await send_message(
         chat_id=chat_id,
         text="Tiếp tục thêm tài sản, hay xong rồi?",
-        reply_markup=add_more_keyboard(),
+        reply_markup=add_more_keyboard(undo_asset_id=asset.id),
+    )
+
+
+async def _handle_undo(
+    db: AsyncSession, chat_id: int, user: User, asset_id_str: str
+) -> None:
+    """Hard-delete the asset referenced by the undo button.
+
+    Distinct from ``soft_delete`` (which is for sales): the user is
+    saying "I never meant to add this", so we remove it cleanly.
+    The undo callback embeds the asset id so we don't have to trust
+    "the most recent asset" — concurrent edits can't trick us.
+    """
+    try:
+        asset_uuid = uuid.UUID(asset_id_str)
+    except ValueError:
+        await send_message(chat_id=chat_id, text="Không tìm thấy tài sản để huỷ.")
+        return
+
+    asset = await asset_service.get_asset_by_id(db, user.id, asset_uuid)
+    if asset is None:
+        await send_message(
+            chat_id=chat_id,
+            text="Tài sản này đã được xử lý rồi 🤔",
+        )
+        return
+
+    asset_name = asset.name
+    deleted = await asset_service.hard_delete(db, user.id, asset_uuid)
+    if not deleted:
+        await send_message(chat_id=chat_id, text="Không tìm thấy tài sản để huỷ.")
+        return
+
+    breakdown = await net_worth_calculator.calculate(db, user.id)
+    await update_user_level(db, user.id, breakdown.total)
+
+    analytics.track(
+        AssetEvent.ASSET_UNDONE,
+        user_id=user.id,
+        properties={"asset_id": str(asset_uuid)},
+    )
+
+    await send_message(
+        chat_id=chat_id,
+        text=f"↩️ Đã huỷ <b>{asset_name}</b>. Tổng tài sản đã được cập nhật.",
+        parse_mode="HTML",
     )
 
 
@@ -705,6 +753,10 @@ async def handle_asset_callback(
         await wizard_service.clear(db, user.id)
         analytics.track(AssetEvent.WIZARD_CANCELED, user_id=user.id)
         await send_message(chat_id=chat_id, text="Đã huỷ. Quay lại lúc nào cũng được 👋")
+        return True
+
+    if action == "undo" and arg:
+        await _handle_undo(db, chat_id, user, arg)
         return True
 
     if action == "done":

--- a/backend/bot/keyboards/asset_keyboard.py
+++ b/backend/bot/keyboards/asset_keyboard.py
@@ -11,10 +11,14 @@ Callback prefix convention (see ``backend/bot/keyboards/common.py``):
     asset_add:more                        — add another asset
     asset_add:done                        — finish wizard
     asset_add:cancel                      — abort wizard
+    asset_add:undo:<asset_uuid>           — undo last save (hard delete)
 
-Total callback bytes stay well under Telegram's 64-byte cap.
+Total callback bytes stay well under Telegram's 64-byte cap
+(``asset_add:undo:`` + 36-char UUID = 51 bytes).
 """
 from __future__ import annotations
+
+import uuid
 
 from backend.bot.keyboards.common import build_callback
 from backend.wealth.asset_types import AssetType, get_subtypes
@@ -146,19 +150,31 @@ def stock_current_price_keyboard() -> InlineKeyboardMarkup:
     }
 
 
-def add_more_keyboard() -> InlineKeyboardMarkup:
-    """Shown after a successful asset save."""
-    return {
-        "inline_keyboard": [
-            [
-                {
-                    "text": "➕ Thêm tài sản khác",
-                    "callback_data": build_callback(CB_ASSET_ADD, "more"),
-                },
-                {
-                    "text": "✅ Xong",
-                    "callback_data": build_callback(CB_ASSET_ADD, "done"),
-                },
-            ]
+def add_more_keyboard(undo_asset_id: uuid.UUID | str | None = None) -> InlineKeyboardMarkup:
+    """Shown after a successful asset save.
+
+    If ``undo_asset_id`` is given, an extra "↩️ Huỷ" row appears so the
+    user can revert a mis-entered asset. The id is embedded in the
+    callback (``asset_add:undo:<uuid>``) so the handler knows exactly
+    which row to roll back without trusting state from elsewhere.
+    """
+    rows = [
+        [
+            {
+                "text": "➕ Thêm tài sản khác",
+                "callback_data": build_callback(CB_ASSET_ADD, "more"),
+            },
+            {
+                "text": "✅ Xong",
+                "callback_data": build_callback(CB_ASSET_ADD, "done"),
+            },
         ]
-    }
+    ]
+    if undo_asset_id is not None:
+        rows.append([
+            {
+                "text": "↩️ Huỷ tài sản vừa nhập",
+                "callback_data": build_callback(CB_ASSET_ADD, "undo", str(undo_asset_id)),
+            },
+        ])
+    return {"inline_keyboard": rows}

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -66,7 +66,14 @@ class Settings(BaseSettings):
     # briefing handler falls back to a placeholder message.
     miniapp_base_url: str = ""
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    # ``extra="ignore"`` lets the .env file hold sibling env vars used by
+    # docker-compose (e.g. POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB)
+    # without pydantic-settings 2.x rejecting them as extras.
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
 
 
 @lru_cache

--- a/backend/tests/test_amount_parser.py
+++ b/backend/tests/test_amount_parser.py
@@ -67,6 +67,32 @@ class TestParseLabelAndAmount:
         # Parser returns positive amounts only; "0 triệu" → None
         assert parse_label_and_amount("0 triệu") is None
 
+    @pytest.mark.parametrize(
+        "raw,expected_label,expected_amount",
+        [
+            # Digits inside the label must NOT be read as the amount.
+            # The bug was "VCB-001 100 triệu" parsing to 1đ because the
+            # search greedily took "001" — the first digit run.
+            ("VCB-001 100 triệu", "VCB-001", Decimal("100000000")),
+            ("VCB-001 100tr", "VCB-001", Decimal("100000000")),
+            ("TK-1234 50tr", "TK-1234", Decimal("50000000")),
+            ("VCB-001 45000", "VCB-001", Decimal("45000")),
+            ("ACB123 2 tỷ", "ACB123", Decimal("2000000000")),
+        ],
+    )
+    def test_digits_in_label_are_not_amounts(
+        self, raw, expected_label, expected_amount
+    ):
+        result = parse_label_and_amount(raw)
+        assert result is not None, f"parser returned None for {raw!r}"
+        label, amount = result
+        assert label == expected_label
+        assert amount == expected_amount
+
+    def test_label_only_no_amount_returns_none(self):
+        # "VCB-001" alone has digits but no free-standing amount — reject.
+        assert parse_label_and_amount("VCB-001") is None
+
 
 class TestHasNegativeSign:
     @pytest.mark.parametrize(

--- a/backend/tests/test_asset_entry_handler.py
+++ b/backend/tests/test_asset_entry_handler.py
@@ -368,6 +368,102 @@ async def test_callback_type_picker_routes_to_starter():
 
 
 @pytest.mark.asyncio
+async def test_callback_undo_hard_deletes_asset_and_recomputes_net_worth():
+    """User taps 'Huỷ tài sản vừa nhập' → hard delete + send confirmation."""
+    user = _user()
+    db = _db(user)
+    target_id = uuid.uuid4()
+    asset = _asset()
+    asset.id = target_id
+    asset.name = "VCB-001"
+
+    with patch.object(asset_entry, "get_user_by_telegram_id",
+                      AsyncMock(return_value=user)), \
+         patch.object(asset_entry.asset_service, "get_asset_by_id",
+                      AsyncMock(return_value=asset)), \
+         patch.object(asset_entry.asset_service, "hard_delete",
+                      AsyncMock(return_value=True)) as delete_mock, \
+         patch.object(asset_entry.net_worth_calculator, "calculate",
+                      AsyncMock(return_value=MagicMock(
+                          total=Decimal("0"), asset_count=0,
+                      ))), \
+         patch.object(asset_entry, "update_user_level",
+                      AsyncMock(return_value=None)), \
+         patch.object(asset_entry, "answer_callback", AsyncMock()), \
+         patch.object(asset_entry, "send_message", AsyncMock()) as send:
+        consumed = await asset_entry.handle_asset_callback(
+            db,
+            {
+                "id": "cb1",
+                "data": f"asset_add:undo:{target_id}",
+                "message": {"chat": {"id": 100}, "message_id": 1},
+                "from": {"id": 100},
+            },
+        )
+    assert consumed is True
+    delete_mock.assert_awaited_once()
+    args = delete_mock.await_args.args
+    assert args[1] == user.id
+    assert args[2] == target_id
+    send.assert_awaited()
+    sent_text = send.await_args.kwargs.get("text") or send.await_args.args[0]
+    assert "Đã huỷ" in sent_text
+    assert "VCB-001" in sent_text
+
+
+@pytest.mark.asyncio
+async def test_callback_undo_handles_invalid_uuid_gracefully():
+    user = _user()
+    db = _db(user)
+    with patch.object(asset_entry, "get_user_by_telegram_id",
+                      AsyncMock(return_value=user)), \
+         patch.object(asset_entry.asset_service, "hard_delete",
+                      AsyncMock()) as delete_mock, \
+         patch.object(asset_entry, "answer_callback", AsyncMock()), \
+         patch.object(asset_entry, "send_message", AsyncMock()) as send:
+        consumed = await asset_entry.handle_asset_callback(
+            db,
+            {
+                "id": "cb1",
+                "data": "asset_add:undo:not-a-uuid",
+                "message": {"chat": {"id": 100}, "message_id": 1},
+                "from": {"id": 100},
+            },
+        )
+    assert consumed is True
+    delete_mock.assert_not_awaited()
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_undo_when_asset_already_gone():
+    """Tapping undo twice (or after another action removed the asset)
+    should not crash — show a friendly message instead."""
+    user = _user()
+    db = _db(user)
+    target_id = uuid.uuid4()
+    with patch.object(asset_entry, "get_user_by_telegram_id",
+                      AsyncMock(return_value=user)), \
+         patch.object(asset_entry.asset_service, "get_asset_by_id",
+                      AsyncMock(return_value=None)), \
+         patch.object(asset_entry.asset_service, "hard_delete",
+                      AsyncMock(return_value=False)) as delete_mock, \
+         patch.object(asset_entry, "answer_callback", AsyncMock()), \
+         patch.object(asset_entry, "send_message", AsyncMock()) as send:
+        await asset_entry.handle_asset_callback(
+            db,
+            {
+                "id": "cb1",
+                "data": f"asset_add:undo:{target_id}",
+                "message": {"chat": {"id": 100}, "message_id": 1},
+                "from": {"id": 100},
+            },
+        )
+    delete_mock.assert_not_awaited()  # bailed before delete
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_text_input_returns_false_when_no_wizard():
     user = _user(state=None)
     db = _db(user)

--- a/backend/tests/test_asset_service.py
+++ b/backend/tests/test_asset_service.py
@@ -48,6 +48,7 @@ def _result_with_scalars(rows: list):
 def _mock_session(execute_side_effect=None) -> MagicMock:
     db = MagicMock()
     db.add = MagicMock()
+    db.delete = AsyncMock()
     db.flush = AsyncMock()
     db.commit = AsyncMock()
     db.execute = AsyncMock()
@@ -261,6 +262,31 @@ class TestSoftDelete:
         db = _mock_session([_result_with_scalar(None)])
         with pytest.raises(ValueError):
             await asset_service.soft_delete(db, uuid.uuid4(), uuid.uuid4())
+
+
+@pytest.mark.asyncio
+class TestHardDelete:
+    async def test_deletes_asset_when_found(self):
+        user_id = uuid.uuid4()
+        asset_id = uuid.uuid4()
+        asset = Asset(id=asset_id, user_id=user_id, asset_type="cash",
+                      name="VCB", initial_value=Decimal(1),
+                      current_value=Decimal(1), acquired_at=date.today())
+        db = _mock_session([_result_with_scalar(asset)])
+
+        result = await asset_service.hard_delete(db, user_id, asset_id)
+
+        assert result is True
+        db.delete.assert_awaited_once_with(asset)
+        _assert_flush_only(db)
+
+    async def test_returns_false_when_not_found(self):
+        db = _mock_session([_result_with_scalar(None)])
+        result = await asset_service.hard_delete(
+            db, uuid.uuid4(), uuid.uuid4()
+        )
+        assert result is False
+        db.delete.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/backend/wealth/amount_parser.py
+++ b/backend/wealth/amount_parser.py
@@ -123,30 +123,51 @@ def parse_amount(text: str) -> Decimal | None:
     return amount
 
 
+# Match an amount candidate that is "free-standing" — i.e. its leading
+# digit sits at start-of-string or right after whitespace. The lookbehind
+# is what stops "001" inside "VCB-001" from being read as the amount:
+# "001" is preceded by '-', not whitespace, so it isn't a candidate.
+# A number with an explicit unit ("100 triệu") is preferred over a bare
+# number, so an account label like "VCB-001" with a unit-less typo never
+# silently gets misread.
+_LABELED_AMOUNT_RE = re.compile(
+    r"""
+    (?:^|(?<=\s))
+    (?P<num>\d{1,3}(?:[.,]\d{3})+|\d+(?:[.,]\d+)?)
+    \s*
+    (?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)?
+    """,
+    re.IGNORECASE | re.VERBOSE,
+)
+
+
 def parse_label_and_amount(text: str) -> tuple[str, Decimal] | None:
     """Split ``"VCB 100 triệu"`` into ``("VCB", 100_000_000)``.
 
     Returns ``None`` if no amount can be extracted. The label is whatever
     sits before the number, stripped — empty string is fine ("100tr"
     alone gives ``("", 100_000_000)``).
+
+    Numbers embedded in identifiers ("001" inside "VCB-001") are NOT
+    candidates: only digits at start-of-string or after whitespace count.
+    Among the free-standing candidates, a number with an explicit unit
+    wins; otherwise the first bare number is used. This way "VCB-001 100
+    triệu" parses correctly even though the string contains "001" first.
     """
     if not text:
         return None
     s = text.strip()
 
-    # Use a forgiving regex: find the first number-with-unit anywhere in
-    # the string and treat everything before it as the label.
-    m = re.search(
-        r"(?P<num>\d{1,3}(?:[.,]\d{3})+|\d+(?:[.,]\d+)?)\s*"
-        r"(?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)?",
-        s,
-        flags=re.IGNORECASE,
-    )
-    if not m:
+    candidates = list(_LABELED_AMOUNT_RE.finditer(s))
+    if not candidates:
         return None
 
-    label = s[: m.start()].strip(" \t\n\r-,.;:")
-    amount = parse_amount(m.group(0))
+    # Prefer a candidate that has a unit attached — it's unambiguously
+    # an amount. Fall back to the first bare-number candidate.
+    chosen = next((m for m in candidates if m.group("unit")), candidates[0])
+
+    label = s[: chosen.start()].strip(" \t\n\r-,.;:")
+    amount = parse_amount(chosen.group(0))
     if amount is None or amount <= 0:
         return None
     return label, amount

--- a/backend/wealth/services/asset_service.py
+++ b/backend/wealth/services/asset_service.py
@@ -219,3 +219,24 @@ async def soft_delete(
 
     await db.flush()
     return asset
+
+
+async def hard_delete(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    asset_id: uuid.UUID,
+) -> bool:
+    """Hard-delete an asset and its snapshots (FK cascades the snapshots).
+
+    Used for "undo" right after a mistaken create — the asset has no
+    history worth preserving and the user wants it to look like it
+    never happened. Distinct from ``soft_delete`` which is for sales.
+
+    Returns True if a row was deleted, False if not found / not owned.
+    """
+    asset = await get_asset_by_id(db, user_id, asset_id)
+    if asset is None:
+        return False
+    await db.delete(asset)
+    await db.flush()
+    return True


### PR DESCRIPTION
## Bug 1 — Parser nuốt số tiền khi label chứa số

**Reproduce:** Trong wizard cash, gõ `VCB-001 100 triệu` → asset bị ghi nhận chỉ **1đ**.

**Root cause:** Trong `parse_label_and_amount`, `re.search` match số đầu tiên xuất hiện trong chuỗi, không phân biệt được "001" (số trong identifier `VCB-001`) với "100" (số tiền thực). Pattern match "001" → trả về amount = 1 → label = "VCB" (mất luôn `-001`).

**Fix (không hardcode pattern):** Yêu cầu candidate phải là **free-standing** — đứng đầu chuỗi hoặc ngay sau whitespace. "001" sau `-` không thoả mãn nên bị loại; "100 triệu" sau khoảng trắng vẫn hợp lệ. Khi nhiều candidate cùng hợp lệ, ưu tiên candidate có unit (`tỷ`/`triệu`/`tr`/`k`/...) trước bare number — tránh trường hợp user gõ thiếu unit thì pick nhầm.

```python
# Cũ: match số đầu tiên ở bất kỳ đâu → "001" thắng
re.search(r"\d+(?:[.,]\d+)?\s*(?:tỷ|triệu|tr|...)?", s)

# Mới: lookbehind yêu cầu start-of-string hoặc whitespace
re.compile(r"(?:^|(?<=\s))\d+(?:[.,]\d+)?\s*(?:tỷ|triệu|tr|...)?")
```

## Feature — Nút huỷ tài sản vừa nhập

Sau khi `_post_save` gửi message "Tiếp tục thêm tài sản, hay xong rồi?", thêm nút **`↩️ Huỷ tài sản vừa nhập`**. Tap → asset bị **hard-delete** (cùng snapshot qua FK cascade) + recompute net worth + wealth level.

- Callback nhúng asset_id (`asset_add:undo:<uuid>`, 51 byte — dưới giới hạn 64) → handler không phải dò "asset gần nhất", an toàn khi user thao tác song song
- Tách `hard_delete` mới khỏi `soft_delete` (vốn dành cho bán tài sản, giữ history)
- Edge case: UUID lỗi / asset đã bị xoá → trả message thân thiện thay vì crash

## Test plan

- [x] `pytest backend/tests/test_amount_parser.py` — 41 pass (thêm 6 case mới: `VCB-001 100 triệu`, `TK-1234 50tr`, `VCB-001 45000`, ...)
- [x] `pytest backend/tests/test_asset_service.py` — 19 pass (thêm `TestHardDelete` class)
- [x] `pytest backend/tests/test_asset_entry_handler.py` — 15 pass (thêm 3 case undo: happy/invalid uuid/already gone)
- [x] Smoke test: `parse_label_and_amount("VCB-001 100 triệu") == ("VCB-001", 100_000_000)` ✓
- [ ] Trên Telegram: gõ `VCB-001 100 triệu` → ghi nhận 100tr, label `VCB-001`
- [ ] Trên Telegram: tap `↩️ Huỷ` → asset biến mất, net worth update

🤖 Generated with [Claude Code](https://claude.com/claude-code)