### PR TITLE
fix(wealth): chặn rò chữ vào expense parser khi đang chọn loại tài sản

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -74,6 +74,9 @@ class AssetEvent:
 
 
 # Flow names persisted in wizard_state.
+# All start with "asset_add" so the text dispatcher can detect "user is mid
+# asset-wizard" with a single prefix check (see ``handle_asset_text_input``).
+FLOW_PICKER = "asset_add_picker"  # 6-button type picker shown, nothing chosen
 FLOW_CASH = "asset_add_cash"
 FLOW_STOCK = "asset_add_stock"
 FLOW_REAL_ESTATE = "asset_add_real_estate"
@@ -84,8 +87,17 @@ FLOW_REAL_ESTATE = "asset_add_real_estate"
 async def start_asset_wizard(
     db: AsyncSession, chat_id: int, user: User
 ) -> None:
-    """Show the 6-button asset-type picker. First step of every flow."""
-    await wizard_service.clear(db, user.id)
+    """Show the 6-button asset-type picker. First step of every flow.
+
+    Sets ``wizard_state`` to a picker sentinel rather than clearing it, so
+    that text typed while the picker (or a downstream subtype keyboard) is
+    on screen gets caught by ``handle_asset_text_input`` and answered with
+    a "tap a button" nudge — instead of falling through to the NL expense
+    parser and being silently saved as a transaction.
+    """
+    await wizard_service.start_flow(
+        db, user.id, FLOW_PICKER, step="type", draft={},
+    )
     await send_message(
         chat_id=chat_id,
         text=(
@@ -96,6 +108,26 @@ async def start_asset_wizard(
         reply_markup=asset_type_picker_keyboard(),
     )
     analytics.track(AssetEvent.WIZARD_OPENED, user_id=user.id)
+
+
+async def cancel_wizard(
+    db: AsyncSession, chat_id: int, user: User
+) -> bool:
+    """Clear an active asset-wizard state and acknowledge.
+
+    Returns True if there was an asset wizard to cancel. Used by the
+    ``/huy`` and ``/cancel`` commands so the user has a text-based escape
+    hatch in addition to the inline ❌ Hủy button.
+    """
+    flow = (user.wizard_state or {}).get("flow") or ""
+    if not flow.startswith("asset_add"):
+        return False
+    await wizard_service.clear(db, user.id)
+    analytics.track(AssetEvent.WIZARD_CANCELED, user_id=user.id)
+    await send_message(
+        chat_id=chat_id, text="Đã huỷ. Quay lại lúc nào cũng được 👋"
+    )
+    return True
 
 
 async def list_assets(
@@ -683,7 +715,17 @@ _TEXT_DISPATCH = {
 async def handle_asset_text_input(
     db: AsyncSession, message: dict
 ) -> bool:
-    """Consume free text if the user is mid-wizard. Return True if so."""
+    """Consume free text if the user is mid-wizard. Return True if so.
+
+    Returns True for *any* asset-wizard flow — including the picker /
+    subtype / stock-price-choice steps that don't accept text input. In
+    those cases we send a "tap a button" nudge rather than letting the
+    text fall through to the NL expense parser, which would silently
+    record it as a transaction. The previous behaviour caused a real
+    incident: user tapped "+Thêm tài sản khác" then typed
+    "VCB-002 20 triệu" without picking a subtype, and the bot saved it
+    as an expense (see commit message / PR).
+    """
     text = (message.get("text") or "").strip()
     if not text or text.startswith("/"):
         return False
@@ -699,9 +741,31 @@ async def handle_asset_text_input(
 
     flow = wizard_service.get_flow(user.wizard_state)
     step = wizard_service.get_step(user.wizard_state)
+
+    # Only intercept asset-wizard flows. Storytelling and any future
+    # wizards have their own routers earlier in the dispatch chain.
+    if not (flow or "").startswith("asset_add"):
+        return False
+
     handler = _TEXT_DISPATCH.get((flow, step))
     if handler is None:
-        return False
+        # Wizard is at a step that expects a button tap, not free text.
+        # Consume the text with a nudge so it can't reach the NL expense
+        # parser and be misclassified.
+        analytics.track(
+            AssetEvent.PARSE_FAILED,
+            user_id=user.id,
+            properties={"flow": flow, "step": step, "reason": "text_at_button_step"},
+        )
+        await send_message(
+            chat_id=chat_id,
+            text=(
+                "👆 Bạn đang trong wizard <b>thêm tài sản</b> — "
+                "vui lòng tap nút phía trên (hoặc ❌ Hủy / gõ /huy để thoát)."
+            ),
+            parse_mode="HTML",
+        )
+        return True
 
     draft = wizard_service.get_draft(user.wizard_state)
     try:

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -66,7 +66,14 @@ class Settings(BaseSettings):
     # briefing handler falls back to a placeholder message.
     miniapp_base_url: str = ""
 
-    model_config = {"env_file": ".env", "env_file_encoding": "utf-8"}
+    # ``extra="ignore"`` lets the .env file hold sibling env vars used by
+    # docker-compose (e.g. POSTGRES_USER, POSTGRES_PASSWORD, POSTGRES_DB)
+    # without pydantic-settings 2.x rejecting them as extras.
+    model_config = {
+        "env_file": ".env",
+        "env_file_encoding": "utf-8",
+        "extra": "ignore",
+    }
 
 
 @lru_cache

--- a/backend/tests/test_asset_entry_handler.py
+++ b/backend/tests/test_asset_entry_handler.py
@@ -474,3 +474,121 @@ async def test_text_input_returns_false_when_no_wizard():
             {"text": "anything", "chat": {"id": 100}, "from": {"id": 100}},
         )
     assert consumed is False
+
+
+@pytest.mark.asyncio
+async def test_text_input_returns_false_for_non_asset_flow():
+    """Storytelling and other non-asset flows must NOT be intercepted —
+    they have their own router earlier in the dispatch chain."""
+    user = _user({"flow": "storytelling", "step": "awaiting_story", "draft": {}})
+    db = _db(user)
+    with patch.object(asset_entry, "get_user_by_telegram_id",
+                      AsyncMock(return_value=user)):
+        consumed = await asset_entry.handle_asset_text_input(
+            db,
+            {"text": "anything", "chat": {"id": 100}, "from": {"id": 100}},
+        )
+    assert consumed is False
+
+
+@pytest.mark.asyncio
+async def test_text_input_at_picker_step_nudges_instead_of_leaking():
+    """Regression for the VCB-002 incident.
+
+    User taps "+Thêm tài sản" → wizard at FLOW_PICKER:type. Then types
+    "VCB-002 20 triệu" without picking a type. Must be CONSUMED with a
+    nudge — not fall through to the NL expense parser.
+    """
+    user = _user({
+        "flow": asset_entry.FLOW_PICKER,
+        "step": "type",
+        "draft": {},
+    })
+    db = _db(user)
+    with patch.object(asset_entry, "get_user_by_telegram_id",
+                      AsyncMock(return_value=user)), \
+         patch.object(asset_entry, "send_message", AsyncMock()) as send, \
+         patch.object(asset_entry.wizard_service, "clear", AsyncMock()) as clear:
+        consumed = await asset_entry.handle_asset_text_input(
+            db,
+            {"text": "VCB-002 20 triệu", "chat": {"id": 100},
+             "from": {"id": 100}},
+        )
+    assert consumed is True
+    clear.assert_not_awaited()  # picker stays open so user can still tap
+    send.assert_awaited_once()
+    sent_text = send.await_args.kwargs.get("text") or send.await_args.args[0]
+    assert "tap nút" in sent_text
+
+
+@pytest.mark.asyncio
+async def test_text_input_at_subtype_step_nudges_instead_of_leaking():
+    """Same incident class, second leaky step: user picked Cash type but
+    typed text instead of picking a subtype. Must be consumed."""
+    user = _user({
+        "flow": asset_entry.FLOW_CASH,
+        "step": "subtype",
+        "draft": {"asset_type": "cash"},
+    })
+    db = _db(user)
+    with patch.object(asset_entry, "get_user_by_telegram_id",
+                      AsyncMock(return_value=user)), \
+         patch.object(asset_entry, "send_message", AsyncMock()) as send:
+        consumed = await asset_entry.handle_asset_text_input(
+            db,
+            {"text": "VCB-002 20 triệu", "chat": {"id": 100},
+             "from": {"id": 100}},
+        )
+    assert consumed is True
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_asset_wizard_sets_picker_state():
+    """After starting the wizard, wizard_state must be the picker
+    sentinel — NOT null. That's what closes the leak window."""
+    user = _user(state={"flow": "asset_add_cash", "step": "amount", "draft": {}})
+    db = _db(user)
+    with patch.object(asset_entry.wizard_service, "start_flow",
+                      AsyncMock()) as start_flow, \
+         patch.object(asset_entry, "send_message", AsyncMock()):
+        await asset_entry.start_asset_wizard(db, 100, user)
+    start_flow.assert_awaited_once()
+    args = start_flow.await_args.args
+    kwargs = start_flow.await_args.kwargs
+    # Signature: start_flow(db, user_id, flow, step=, draft=)
+    assert args[2] == asset_entry.FLOW_PICKER
+    assert kwargs["step"] == "type"
+    assert kwargs["draft"] == {}
+
+
+@pytest.mark.asyncio
+async def test_cancel_wizard_clears_active_asset_flow():
+    user = _user({
+        "flow": asset_entry.FLOW_CASH,
+        "step": "amount",
+        "draft": {"asset_type": "cash"},
+    })
+    db = _db(user)
+    with patch.object(asset_entry.wizard_service, "clear",
+                      AsyncMock()) as clear, \
+         patch.object(asset_entry, "send_message", AsyncMock()) as send:
+        cancelled = await asset_entry.cancel_wizard(db, 100, user)
+    assert cancelled is True
+    clear.assert_awaited_once()
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_cancel_wizard_noop_when_other_flow_active():
+    """If the user is in storytelling (or no flow), cancel_wizard must
+    return False so the caller can fall back to the right canceller."""
+    user = _user({"flow": "storytelling", "step": "x", "draft": {}})
+    db = _db(user)
+    with patch.object(asset_entry.wizard_service, "clear",
+                      AsyncMock()) as clear, \
+         patch.object(asset_entry, "send_message", AsyncMock()) as send:
+        cancelled = await asset_entry.cancel_wizard(db, 100, user)
+    assert cancelled is False
+    clear.assert_not_awaited()
+    send.assert_not_awaited()

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -227,14 +227,18 @@ async def _handle_message(
             return resolved_user.id
         return None
 
-    # /huy or /cancel — drop the storytelling mode if active. Doesn't
-    # touch the asset wizard (it has its own cancel button) — only here
-    # because storytelling mode otherwise blocks NL expense parsing.
+    # /huy or /cancel — escape hatch out of any active wizard. Tries the
+    # asset wizard first; if that wasn't active, falls back to
+    # storytelling. Either flow's text mode otherwise blocks NL parsing,
+    # so the user needs a non-button way to bail.
     if command in ("/huy", "/cancel"):
         if resolved_user is not None:
-            await storytelling_handlers.cancel_storytelling(
+            if not await asset_entry_handlers.cancel_wizard(
                 db, chat_id, resolved_user
-            )
+            ):
+                await storytelling_handlers.cancel_storytelling(
+                    db, chat_id, resolved_user
+                )
             return resolved_user.id
         return None
 


### PR DESCRIPTION
## Summary

Khi user tap **+Thêm tài sản** rồi gõ thẳng `VCB-002 20 triệu` mà chưa tap nút loại / subtype, bot lưu nhầm thành **expense** thay vì asset (xem incident log 00:59:15-37).

**Root cause:**
- `start_asset_wizard()` clear `wizard_state` về `null` khi hiện 6-button picker → có khoảng "limbo" lúc picker đang hiện nhưng wizard_state null.
- Step `subtype` (sau khi user tap loại) cũng không có entry trong `_TEXT_DISPATCH`.
- Cả 2 trường hợp text rơi xuống NL expense parser → ghi nhận thành expense.

**Fix:**
- Thêm sentinel `FLOW_PICKER` — `start_asset_wizard()` giờ set wizard_state thay vì clear.
- `handle_asset_text_input` giờ consume mọi text khi `flow` bắt đầu bằng `asset_add` — nếu (flow, step) không có handler thì nhắc user tap nút thay vì để text rơi qua expense parser.
- `/huy` và `/cancel` giờ huỷ được asset wizard (trước đó chỉ huỷ storytelling).

## Test plan

- [x] `pytest backend/tests/test_asset_entry_handler.py` — 21 pass (4 test mới cho regression)
- [x] `pytest` các file liên quan worker/storytelling/wizard/briefing — 81 pass tổng
- [ ] Manual: tap +Thêm tài sản → gõ `VCB 100tr` (không tap loại) → bot phải nhắc tap nút, KHÔNG ghi expense
- [ ] Manual: full flow tap +Thêm tài sản → 💵 → 🏦 → `VCB 100tr` → asset created OK
- [ ] Manual: gõ `/huy` khi đang ở picker → wizard huỷ

🤖 Generated with [Claude Code](https://claude.com/claude-code)