### PR TITLE
perf(telegram): scale callback latency for mass users

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -25,6 +25,7 @@ never commits — the worker owns the transaction boundary.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import uuid
 from datetime import date
@@ -781,6 +782,90 @@ async def handle_asset_text_input(
     return True
 
 
+async def _dispatch_asset_action(
+    db: AsyncSession,
+    chat_id: int,
+    user: User,
+    action: str,
+    arg: str | None,
+) -> None:
+    """Body of the asset-callback dispatcher.
+
+    Split out from ``handle_asset_callback`` so we can run it in parallel
+    with ``answer_callback`` via ``asyncio.gather`` — Telegram needs the
+    callback acked to dismiss the loading spinner, but that ack is
+    independent of any send_message/edit_message_text the action produces.
+    Running them sequentially paid one full RTT to api.telegram.org for
+    no business reason; gather halves perceived latency on every tap.
+    """
+    # Top-level entry / restart.
+    if action == "start" or (action == "more"):
+        await start_asset_wizard(db, chat_id, user)
+        return
+
+    if action == "cancel":
+        await wizard_service.clear(db, user.id)
+        analytics.track(AssetEvent.WIZARD_CANCELED, user_id=user.id)
+        await send_message(chat_id=chat_id, text="Đã huỷ. Quay lại lúc nào cũng được 👋")
+        return
+
+    if action == "undo" and arg:
+        await _handle_undo(db, chat_id, user, arg)
+        return
+
+    if action == "done":
+        await wizard_service.clear(db, user.id)
+        # Mark first-asset onboarding step done if this was their first asset.
+        await _mark_onboarding_first_asset_done(db, user)
+        await send_message(
+            chat_id=chat_id,
+            text="✅ Xong! Gõ /menu để xem các tính năng khác.",
+        )
+        return
+
+    if action == "type" and arg:
+        analytics.track(
+            AssetEvent.TYPE_PICKED,
+            user_id=user.id,
+            properties={"asset_type": arg},
+        )
+        starters = {
+            AssetType.CASH.value: _start_cash_subtype_pick,
+            AssetType.STOCK.value: _start_stock_subtype_pick,
+            AssetType.REAL_ESTATE.value: _start_real_estate_subtype_pick,
+        }
+        starter = starters.get(arg)
+        if starter is None:
+            # Crypto / Gold / Other: not yet wired in Epic 1.
+            await send_message(
+                chat_id=chat_id,
+                text=(
+                    "Loại này sẽ có sớm 🙏 Tạm thời bạn dùng "
+                    "💵 / 📈 / 🏠 nhé."
+                ),
+            )
+            return
+        await starter(db, chat_id, user)
+        return
+
+    if action == "cash_subtype" and arg:
+        await _handle_cash_subtype_pick(db, chat_id, user, arg)
+        return
+
+    if action == "stock_subtype" and arg:
+        await _handle_stock_subtype_pick(db, chat_id, user, arg)
+        return
+
+    if action == "re_subtype" and arg:
+        await _handle_re_subtype_pick(db, chat_id, user, arg)
+        return
+
+    if action == "stock_price" and arg in ("same", "new"):
+        draft = wizard_service.get_draft(user.wizard_state)
+        await _handle_stock_current_price_choice(db, chat_id, user, arg, draft)
+        return
+
+
 async def handle_asset_callback(
     db: AsyncSession, callback_query: dict
 ) -> bool:
@@ -806,75 +891,11 @@ async def handle_asset_callback(
     action = parts[0] if parts else "start"
     arg = parts[1] if len(parts) > 1 else None
 
-    await answer_callback(callback_id)
-
-    # Top-level entry / restart.
-    if action == "start" or (action == "more"):
-        await start_asset_wizard(db, chat_id, user)
-        return True
-
-    if action == "cancel":
-        await wizard_service.clear(db, user.id)
-        analytics.track(AssetEvent.WIZARD_CANCELED, user_id=user.id)
-        await send_message(chat_id=chat_id, text="Đã huỷ. Quay lại lúc nào cũng được 👋")
-        return True
-
-    if action == "undo" and arg:
-        await _handle_undo(db, chat_id, user, arg)
-        return True
-
-    if action == "done":
-        await wizard_service.clear(db, user.id)
-        # Mark first-asset onboarding step done if this was their first asset.
-        await _mark_onboarding_first_asset_done(db, user)
-        await send_message(
-            chat_id=chat_id,
-            text="✅ Xong! Gõ /menu để xem các tính năng khác.",
-        )
-        return True
-
-    if action == "type" and arg:
-        analytics.track(
-            AssetEvent.TYPE_PICKED,
-            user_id=user.id,
-            properties={"asset_type": arg},
-        )
-        starters = {
-            AssetType.CASH.value: _start_cash_subtype_pick,
-            AssetType.STOCK.value: _start_stock_subtype_pick,
-            AssetType.REAL_ESTATE.value: _start_real_estate_subtype_pick,
-        }
-        starter = starters.get(arg)
-        if starter is None:
-            # Crypto / Gold / Other: not yet wired in Epic 1.
-            await send_message(
-                chat_id=chat_id,
-                text=(
-                    "Loại này sẽ có sớm 🙏 Tạm thời bạn dùng "
-                    "💵 / 📈 / 🏠 nhé."
-                ),
-            )
-            return True
-        await starter(db, chat_id, user)
-        return True
-
-    if action == "cash_subtype" and arg:
-        await _handle_cash_subtype_pick(db, chat_id, user, arg)
-        return True
-
-    if action == "stock_subtype" and arg:
-        await _handle_stock_subtype_pick(db, chat_id, user, arg)
-        return True
-
-    if action == "re_subtype" and arg:
-        await _handle_re_subtype_pick(db, chat_id, user, arg)
-        return True
-
-    if action == "stock_price" and arg in ("same", "new"):
-        draft = wizard_service.get_draft(user.wizard_state)
-        await _handle_stock_current_price_choice(db, chat_id, user, arg, draft)
-        return True
-
+    # Run the ack and the action in parallel — see _dispatch_asset_action.
+    await asyncio.gather(
+        answer_callback(callback_id),
+        _dispatch_asset_action(db, chat_id, user, action, arg),
+    )
     return True  # consumed (any asset_add:* payload), even if no-op.
 
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -38,6 +38,7 @@ pydantic-settings>=2.0.0
 python-dateutil>=2.8.0
 Pillow>=10.0.0
 httpx>=0.27.0
+h2>=4.1.0
 pyyaml>=6.0
 lunardate>=0.2.0
 

--- a/backend/services/telegram_service.py
+++ b/backend/services/telegram_service.py
@@ -34,11 +34,17 @@ async def _get_client() -> httpx.AsyncClient:
     if _client is None:
         async with _client_lock:
             if _client is None:
+                # HTTP/2 lets one TCP connection multiplex many concurrent
+                # requests to api.telegram.org, which removes the 6-stream
+                # head-of-line bottleneck under callback-storm load (each
+                # callback handler fires answerCallbackQuery + sendMessage,
+                # so 100 concurrent users = 200 in-flight requests).
                 _client = httpx.AsyncClient(
+                    http2=True,
                     timeout=httpx.Timeout(10.0, connect=5.0),
                     limits=httpx.Limits(
-                        max_keepalive_connections=20,
-                        max_connections=50,
+                        max_keepalive_connections=50,
+                        max_connections=100,
                         keepalive_expiry=60.0,
                     ),
                 )


### PR DESCRIPTION
## Root cause / motivation

Under concurrent load (callback storms — every button tap fires two
Telegram API requests), the bot was bottlenecked at the HTTP transport
layer:

- The shared `httpx.AsyncClient` was sized for single-user use
  (`max_connections=50`, `max_keepalive=20`).
- HTTP/1.1 limits one connection to one in-flight request, so under
  burst load requests queued behind the keepalive pool.
- In `asset_entry.handle_asset_callback`, `answerCallbackQuery` was
  awaited *before* the action ran, paying one full round-trip to
  `api.telegram.org` even though the ack has zero business dependency
  on the work that follows.

## What changed

### 1. Connection pool sized for mass users
`backend/services/telegram_service.py` — `max_connections` 50 → 100,
`max_keepalive_connections` 20 → 50. Doubles burst capacity before the
pool starts blocking.

### 2. HTTP/2 enabled on the shared httpx client
Same file — `http2=True`; `h2>=4.1.0` added to `backend/requirements.txt`.
Telegram's API speaks HTTP/2, so one TCP connection now multiplexes
hundreds of concurrent streams instead of opening a fresh socket per
request. Verified against `api.telegram.org`:

```
http_version: HTTP/2 status: 302
```

### 3. Parallel ack + action in callback dispatcher
`backend/bot/handlers/asset_entry.py` — extracted the action body of
`handle_asset_callback` into `_dispatch_asset_action`, then ran the ack
and the dispatch concurrently:

```python
await asyncio.gather(
    answer_callback(callback_id),
    _dispatch_asset_action(db, chat_id, user, action, arg),
)
```

The ack only dismisses Telegram's "loading…" spinner; nothing in the
action depends on it. Running them sequentially was pure latency tax.

## Expected impact

- **Per-tap latency on the asset wizard**: roughly halved on the slow
  path (one Telegram RTT removed from the critical path on every
  callback).
- **Concurrent capacity**: ~2× before pool saturation; HTTP/2
  multiplexing pushes the practical ceiling much higher because TCP
  handshakes stop being per-request.
- **No behavior change** for individual users — the ack still happens,
  the message still sends; they just no longer block on each other.

## Test plan
- [x] Unit tests for `telegram_service` and `asset_entry` handler all pass (30/30)
- [x] Full suite: zero new regressions vs. `main` (pre-existing failures
  in `test_handler_boundary`, `test_portfolio_service`, `test_telegram_dedup`,
  `test_telegram_router` are unchanged on both sides)
- [x] HTTP/2 negotiation verified live against `api.telegram.org`
- [ ] Post-merge: restart backend + scheduler, verify `/health` and a
  live asset-wizard tap

🤖 Generated with [Claude Code](https://claude.com/claude-code)