### PR TITLE
fix(wealth): portfolio report shows funds as 'ccq', not 'cổ'

### DIFF
--- a/backend/intent/handlers/query_portfolio.py
+++ b/backend/intent/handlers/query_portfolio.py
@@ -10,6 +10,7 @@ from backend.intent.handlers.base import IntentHandler
 from backend.intent.intents import IntentResult
 from backend.intent.wealth_adapt import LevelStyle, decorate, resolve_style
 from backend.models.user import User
+from backend.wealth.asset_types import get_quantity_unit
 from backend.wealth.services import asset_service
 
 
@@ -55,7 +56,8 @@ class QueryPortfolioHandler(IntentHandler):
         for asset in ordered:
             ticker = (asset.extra or {}).get("ticker") or asset.name
             quantity = (asset.extra or {}).get("quantity")
-            qty_str = f" ({quantity:g} cổ)" if isinstance(quantity, (int, float)) else ""
+            unit = get_quantity_unit(asset.asset_type, asset.subtype)
+            qty_str = f" ({quantity:g} {unit})" if isinstance(quantity, (int, float)) else ""
             value = format_money_short(asset.current_value)
             # Hide P&L percentage for Starter — too much information for
             # a user with their first few thousand VND in stocks.

--- a/backend/tests/test_intent/test_handlers.py
+++ b/backend/tests/test_intent/test_handlers.py
@@ -37,6 +37,7 @@ def _fake_asset(
     *,
     name: str = "VCB tiết kiệm",
     asset_type: str = "cash",
+    subtype: str | None = None,
     current_value: Decimal = Decimal("100000000"),
     initial_value: Decimal | None = None,
     extra: dict | None = None,
@@ -45,7 +46,7 @@ def _fake_asset(
     asset.id = uuid.uuid4()
     asset.name = name
     asset.asset_type = asset_type
-    asset.subtype = None
+    asset.subtype = subtype
     asset.current_value = current_value
     asset.initial_value = initial_value if initial_value is not None else current_value
     asset.extra = extra or {}
@@ -218,6 +219,49 @@ async def test_query_portfolio_handler_shows_positions_and_pnl():
     assert "100 cổ" in response
     # P&L was +12.5% so the green emoji should appear.
     assert "🟢" in response
+
+
+@pytest.mark.asyncio
+async def test_query_portfolio_handler_renders_funds_with_ccq_unit():
+    """Funds (subtype='fund') must show 'ccq', not 'cổ'."""
+    from backend.intent.handlers.query_portfolio import QueryPortfolioHandler
+
+    holdings = [
+        _fake_asset(
+            name="TCEF",
+            asset_type="stock",
+            subtype="fund",
+            current_value=Decimal("21599500"),
+            initial_value=Decimal("20000000"),
+            extra={"ticker": "TCEF", "quantity": 21599.5},
+        ),
+        _fake_asset(
+            name="VNM",
+            asset_type="stock",
+            subtype="vn_stock",
+            current_value=Decimal("4500000"),
+            initial_value=Decimal("4000000"),
+            extra={"ticker": "VNM", "quantity": 100},
+        ),
+    ]
+    with patch(
+        "backend.intent.handlers.query_portfolio.asset_service.get_user_assets",
+        AsyncMock(return_value=holdings),
+    ), patch(
+        "backend.intent.handlers.query_portfolio.resolve_style",
+        AsyncMock(return_value=_young_prof_style()),
+    ):
+        intent = IntentResult(
+            intent=IntentType.QUERY_PORTFOLIO,
+            confidence=0.95,
+            raw_text="portfolio",
+        )
+        response = await QueryPortfolioHandler().handle(intent, _user(), _fake_db())
+
+    assert "21599.5 ccq" in response
+    assert "21599.5 cổ" not in response
+    # Stocks still use "cổ".
+    assert "100 cổ" in response
 
 
 @pytest.mark.asyncio

--- a/backend/wealth/asset_types.py
+++ b/backend/wealth/asset_types.py
@@ -105,3 +105,16 @@ def get_subtype_label(subtype: str | None) -> str | None:
     if not subtype:
         return None
     return _SUBTYPE_SHORT_LABELS.get(subtype)
+
+
+def get_quantity_unit(asset_type: str, subtype: str | None) -> str:
+    """Return the unit shown after a quantity in portfolio listings.
+
+    Funds trade in chứng chỉ quỹ (CCQ), regular stocks in cổ phiếu —
+    the wizard prompts and the portfolio report must agree on wording.
+    Defaults to "cổ" so unknown stock-like subtypes still render
+    sensibly.
+    """
+    if asset_type == "stock" and subtype == "fund":
+        return "ccq"
+    return "cổ"


### PR DESCRIPTION
## Summary

- Portfolio report (`/dautu`, "danh mục đầu tư") was rendering fund holdings with the unit "cổ", e.g. `TCEF (21599.5 cổ)`. Funds are chứng chỉ quỹ, not shares of stock — should show "ccq".
- PR #150 fixed the wizard prompts to use "chứng chỉ quỹ" / `/ccq` for the fund subtype, but the portfolio formatter was missed.
- Adds `get_quantity_unit(asset_type, subtype)` in `wealth/asset_types.py` (next to the existing label/icon helpers). Returns `"ccq"` when `subtype == "fund"`, `"cổ"` otherwise. `query_portfolio` reads the unit from this helper instead of hardcoding.
- Default falls through to "cổ" so unknown stock subtypes still render sensibly.

## Files

- `backend/wealth/asset_types.py` — new `get_quantity_unit()` helper.
- `backend/intent/handlers/query_portfolio.py:58` — replace hardcoded `cổ` with helper call.
- `backend/tests/test_intent/test_handlers.py` — adds `subtype` arg to `_fake_asset` fixture; new test renders a fund + a stock in the same portfolio and asserts each gets the right unit.

## Test plan

- [x] `pytest backend/tests/test_intent/ backend/tests/test_asset_entry_handler.py backend/tests/test_wealth_formatter.py` — 319 passed.
- [x] Existing `test_query_portfolio_handler_shows_positions_and_pnl` still passes (stocks still render "cổ").
- [x] New `test_query_portfolio_handler_renders_funds_with_ccq_unit` covers the fund case + verifies stocks aren't affected.
- [ ] Manual verify after deploy: query portfolio that contains a fund — should render `(N ccq)` instead of `(N cổ)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)