### PR TITLE
fix(ux): auto-exit asset wizard on non-wizard button taps

### DIFF
--- a/backend/tests/test_telegram_worker.py
+++ b/backend/tests/test_telegram_worker.py
@@ -183,6 +183,170 @@ class TestRouteUpdate:
 
 
 # ---------------------------------------------------------------------------
+# _maybe_auto_exit_asset_wizard — UX: button taps that aren't asset_add:*
+# clear an active asset-entry wizard so the user isn't trapped on their
+# next free-text message.
+# ---------------------------------------------------------------------------
+
+
+def _wizard_user(*, flow: str | None, step: str | None = None) -> MagicMock:
+    """Build a fake user with the given wizard_state shape."""
+    import uuid as _uuid
+
+    user = MagicMock()
+    user.id = _uuid.uuid4()
+    user.wizard_state = (
+        {"flow": flow, "step": step, "draft": {}} if flow else None
+    )
+    return user
+
+
+class TestAutoExitAssetWizard:
+    @pytest.mark.asyncio
+    async def test_clears_when_callback_is_menu_and_user_in_asset_wizard(self):
+        """Menu tap mid asset-wizard → wizard_service.clear() called."""
+        user = _wizard_user(flow="asset_add_picker", step="type")
+        fake_db = MagicMock()
+        dashboard_service = MagicMock()
+        dashboard_service.get_user_by_telegram_id = AsyncMock(return_value=user)
+
+        with patch(
+            "backend.services.wizard_service.clear", new_callable=AsyncMock
+        ) as mock_clear:
+            await telegram_worker._maybe_auto_exit_asset_wizard(
+                fake_db,
+                telegram_id=999,
+                callback_data="menu:assets:advisor",
+                dashboard_service=dashboard_service,
+            )
+
+        mock_clear.assert_awaited_once_with(fake_db, user.id)
+
+    @pytest.mark.asyncio
+    async def test_no_clear_for_asset_add_callback(self):
+        """asset_add:* callbacks belong to the wizard itself — never clear."""
+        user = _wizard_user(flow="asset_add_cash", step="amount")
+        fake_db = MagicMock()
+        dashboard_service = MagicMock()
+        dashboard_service.get_user_by_telegram_id = AsyncMock(return_value=user)
+
+        with patch(
+            "backend.services.wizard_service.clear", new_callable=AsyncMock
+        ) as mock_clear:
+            await telegram_worker._maybe_auto_exit_asset_wizard(
+                fake_db,
+                telegram_id=999,
+                callback_data="asset_add:cancel",
+                dashboard_service=dashboard_service,
+            )
+
+        mock_clear.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_clear_when_no_wizard_state(self):
+        user = _wizard_user(flow=None)
+        fake_db = MagicMock()
+        dashboard_service = MagicMock()
+        dashboard_service.get_user_by_telegram_id = AsyncMock(return_value=user)
+
+        with patch(
+            "backend.services.wizard_service.clear", new_callable=AsyncMock
+        ) as mock_clear:
+            await telegram_worker._maybe_auto_exit_asset_wizard(
+                fake_db,
+                telegram_id=999,
+                callback_data="menu:assets:advisor",
+                dashboard_service=dashboard_service,
+            )
+
+        mock_clear.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_clear_for_storytelling_flow(self):
+        """Storytelling state is owned by story:* callbacks and may hold
+        unsaved transactions in draft.pending. Don't touch it."""
+        user = _wizard_user(flow="storytelling", step="confirm_pending")
+        fake_db = MagicMock()
+        dashboard_service = MagicMock()
+        dashboard_service.get_user_by_telegram_id = AsyncMock(return_value=user)
+
+        with patch(
+            "backend.services.wizard_service.clear", new_callable=AsyncMock
+        ) as mock_clear:
+            await telegram_worker._maybe_auto_exit_asset_wizard(
+                fake_db,
+                telegram_id=999,
+                callback_data="menu:assets:advisor",
+                dashboard_service=dashboard_service,
+            )
+
+        mock_clear.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_no_clear_for_pending_intent_flow(self):
+        """intent_pending_action / intent_awaiting_clarify have their own
+        TTL + handlers — leave them alone."""
+        user = _wizard_user(flow="intent_pending_action")
+        fake_db = MagicMock()
+        dashboard_service = MagicMock()
+        dashboard_service.get_user_by_telegram_id = AsyncMock(return_value=user)
+
+        with patch(
+            "backend.services.wizard_service.clear", new_callable=AsyncMock
+        ) as mock_clear:
+            await telegram_worker._maybe_auto_exit_asset_wizard(
+                fake_db,
+                telegram_id=999,
+                callback_data="menu:assets:advisor",
+                dashboard_service=dashboard_service,
+            )
+
+        mock_clear.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_clears_for_briefing_callback(self):
+        """Tapping a briefing button (e.g. "💎 Thêm tài sản") while mid
+        wizard should also exit — the briefing handler will spin up its
+        own flow if needed."""
+        user = _wizard_user(flow="asset_add_stock", step="ticker")
+        fake_db = MagicMock()
+        dashboard_service = MagicMock()
+        dashboard_service.get_user_by_telegram_id = AsyncMock(return_value=user)
+
+        with patch(
+            "backend.services.wizard_service.clear", new_callable=AsyncMock
+        ) as mock_clear:
+            await telegram_worker._maybe_auto_exit_asset_wizard(
+                fake_db,
+                telegram_id=999,
+                callback_data="briefing:add_asset",
+                dashboard_service=dashboard_service,
+            )
+
+        mock_clear.assert_awaited_once_with(fake_db, user.id)
+
+    @pytest.mark.asyncio
+    async def test_no_clear_when_telegram_id_missing(self):
+        """Anonymous callbacks (no `from.id`) can't be tied to a user."""
+        fake_db = MagicMock()
+        dashboard_service = MagicMock()
+        dashboard_service.get_user_by_telegram_id = AsyncMock()
+
+        with patch(
+            "backend.services.wizard_service.clear", new_callable=AsyncMock
+        ) as mock_clear:
+            await telegram_worker._maybe_auto_exit_asset_wizard(
+                fake_db,
+                telegram_id=None,
+                callback_data="menu:main",
+                dashboard_service=dashboard_service,
+            )
+
+        dashboard_service.get_user_by_telegram_id.assert_not_awaited()
+        mock_clear.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
 # recover_orphaned_updates — picks up stuck rows at startup.
 # ---------------------------------------------------------------------------
 

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -321,6 +321,57 @@ async def _handle_message(
     return resolved_user.id if resolved_user else None
 
 
+async def _maybe_auto_exit_asset_wizard(
+    db: AsyncSession,
+    *,
+    telegram_id: int | None,
+    callback_data: str,
+    dashboard_service,
+) -> None:
+    """Clear an active asset-entry wizard when the user taps a non-asset
+    callback (menu / dashboard / briefing / transaction / follow-up).
+
+    Button taps are a deliberate context switch — the user chose to
+    navigate elsewhere. Leaving ``wizard_state`` in place would trap
+    their next free-text message in the asset wizard's
+    "👆 Bạn đang trong wizard thêm tài sản" nudge. Free-text input keeps
+    the existing routing because text mid-wizard is most often the
+    answer to a wizard prompt; only deliberate callback selections exit.
+
+    Scope is intentionally narrow — only the asset-entry wizard
+    (``asset_add_*`` flows). The storytelling confirm-pending step holds
+    unsaved transactions in ``draft.pending`` and is resolved by its own
+    ``story:*`` callbacks; the intent pending-action / awaiting-clarify
+    state has its own 10-minute TTL. Auto-clearing either here would
+    risk dropping in-flight user input.
+    """
+    if not callback_data or callback_data.startswith("asset_add"):
+        return
+    if telegram_id is None:
+        return
+    user = await dashboard_service.get_user_by_telegram_id(db, telegram_id)
+    if user is None:
+        return
+    flow = (user.wizard_state or {}).get("flow") or ""
+    if not flow.startswith("asset_add"):
+        return
+
+    from backend import analytics
+    from backend.services import wizard_service
+
+    step = (user.wizard_state or {}).get("step")
+    await wizard_service.clear(db, user.id)
+    analytics.track(
+        "asset_wizard_auto_exited",
+        user_id=user.id,
+        properties={
+            "flow": flow,
+            "step": step,
+            "callback_data": callback_data,
+        },
+    )
+
+
 async def _handle_callback(
     db: AsyncSession,
     callback_query: dict,
@@ -349,6 +400,16 @@ async def _handle_callback(
             return None
         user = await dashboard_service.get_user_by_telegram_id(db, telegram_id)
         return user.id if user else None
+
+    # UX: tapping a non-asset_add callback while mid-wizard means the
+    # user wants to switch context — exit the asset wizard so we don't
+    # strand them in the "tap a button" nudge on their next message.
+    await _maybe_auto_exit_asset_wizard(
+        db,
+        telegram_id=telegram_id,
+        callback_data=callback_data,
+        dashboard_service=dashboard_service,
+    )
 
     # Onboarding callbacks first — otherwise the menu-callback handler
     # would swallow them.


### PR DESCRIPTION
## Summary

Tapping a menu / dashboard / briefing / transaction / follow-up callback while mid asset-entry wizard now silently clears the wizard state instead of leaving the user trapped on their next free-text message.

## The bug

Today, when a user is inside the **Thêm tài sản** wizard and clicks any non-wizard inline button (e.g. *Tư vấn tối ưu*, *Net worth tổng*, *Mở Dashboard*, briefing's *💎 Thêm tài sản*, etc.), the button action fires correctly, but `users.wizard_state` is left set. The next time the user types anything, [`handle_asset_text_input`](backend/bot/handlers/asset_entry.py:855) consumes the message and replies:

> 👆 Bạn đang trong wizard **thêm tài sản** — vui lòng tap nút phía trên (hoặc ❌ Hủy / gõ /huy để thoát).

…trapping the user in a wizard they thought they had navigated away from.

## UX rationale — why callbacks but not free text

| Input type | Signal | New behavior |
|---|---|---|
| **Callback (button tap)** | Deliberate context switch — the user *chose* to navigate elsewhere | Clear `wizard_state`, then process the callback normally |
| **Free text** | Ambiguous — most often the answer to a wizard prompt (e.g. *VCB 100tr*) | Keep current behavior: route to wizard text dispatch first |

A button tap is intentional. Free text could be the wizard's expected input — silently clearing the wizard on every text message would lose data the user just typed. The asymmetry matches the underlying intent.

## Implementation

A small helper [`_maybe_auto_exit_asset_wizard`](backend/workers/telegram_worker.py) runs at the top of `_handle_callback`, before the per-prefix routing chain:

```python
if not callback_data.startswith("asset_add"):
    # ...if the user has an asset_add_* flow active, clear it
```

- **Scope is narrow on purpose** — only `asset_add_*` flows. Storytelling's `confirm_pending` step holds unsaved transactions in `draft.pending` and is resolved by its own `story:*` callbacks. The intent `pending_action` / `awaiting_clarify` state has its own 10-min TTL. Auto-clearing either here would risk dropping in-flight user input.
- **No user-facing message** when the auto-exit fires — the user tapped a button intentionally; an extra "đã thoát wizard" toast would be friction, not value.
- **Analytics event** `asset_wizard_auto_exited` emitted with `flow`, `step`, `callback_data` so we can see how often this UX path fires and whether it correlates with churn between menu and wizard.

## Layer contract

The helper sits in the worker (`backend/workers/telegram_worker.py`) right where the existing dispatch chain lives. Per CLAUDE.md §0.1, the worker owns the transaction boundary; `wizard_service.clear()` only flushes, the worker commits at the end of `route_update`.

## Cases covered by tests (`backend/tests/test_telegram_worker.py::TestAutoExitAssetWizard`)

- ✅ Menu callback while in `asset_add_picker` → wizard cleared
- ✅ Briefing callback while in `asset_add_stock` → wizard cleared
- ✅ `asset_add:cancel` callback → wizard NOT cleared (handled by wizard's own dispatcher)
- ✅ Menu callback when no wizard active → no-op
- ✅ Menu callback while in `storytelling` flow → NOT cleared (different wizard, has unsaved drafts)
- ✅ Menu callback while in `intent_pending_action` flow → NOT cleared (different state, has its own TTL)
- ✅ Anonymous callback (no `from.id`) → no DB lookup, no clear

All 17 worker tests pass. Wider regression run: 346 wizard-related tests pass (asset_entry, wizard_service, storytelling, intent).

## Test plan
- [ ] Open `/menu` → tap *💎 Tài sản → ➕ Thêm mới* (start wizard)
- [ ] Without exiting, tap *⬅️ Quay lại* → tap *💸 Chi tiêu → 📊 Báo cáo*
- [ ] Confirm: report appears, no wizard nudge fires on next message
- [ ] Repeat from inside a deeper wizard step (e.g. cash subtype picked, amount expected)
- [ ] Sanity check: `asset_add:cancel` still works as the explicit cancel button
- [ ] Sanity check: typing free text mid-wizard still routes to wizard handlers

🤖 Generated with [Claude Code](https://claude.com/claude-code)