### PR TITLE
fix(menu): "Trợ lý Tài sản" + drop "anh/chị" in HNW copy

### DIFF
--- a/content/menu_copy.yaml
+++ b/content/menu_copy.yaml
@@ -31,8 +31,8 @@ main_menu:
   title:
     starter: "👋 Bé Tiền — Trợ lý tài chính của {name}"
     young_prof: "👋 Bé Tiền — Trợ lý tài chính của {name}"
-    mass_affluent: "👋 Bé Tiền — Trợ lý CFO cá nhân của {name}"
-    hnw: "👋 Bé Tiền — Trợ lý CFO cá nhân của anh/chị {name}"
+    mass_affluent: "👋 Bé Tiền — Trợ lý Tài sản của {name}"
+    hnw: "👋 Bé Tiền — Trợ lý Tài sản của {name}"
 
   intro:
     starter: |-
@@ -54,9 +54,9 @@ main_menu:
       Bạn muốn làm gì hôm nay?
 
     hnw: |-
-      Tổng quan tài chính cá nhân của anh/chị {name}.
+      Tổng quan tài chính cá nhân của {name}.
 
-      Anh/chị muốn xem mục nào?
+      {name} muốn xem mục nào?
 
   buttons:
     - label: "💎 Tài sản"
@@ -103,7 +103,7 @@ submenu_assets:
       Bao gồm tư vấn tái cân bằng dựa trên danh mục hiện tại.
 
     hnw: |-
-      Tổng quan tài sản và chỉ số hiệu quả của anh/chị.
+      Tổng quan tài sản và chỉ số hiệu quả của {name}.
 
       Bao gồm tư vấn tối ưu hóa phân bổ.
 


### PR DESCRIPTION
## Summary
- Replace **"Trợ lý CFO cá nhân"** with **"Trợ lý Tài sản"** in both the
  `mass_affluent` and `hnw` main-menu titles.
- Stop double-addressing HNW users: drop the literal `anh/chị` in the HNW
  intro lines so rendering with `{name} = "Bệ hạ"` produces just
  "Bệ hạ" instead of "anh/chị Bệ hạ".
- Touched: [content/menu_copy.yaml](content/menu_copy.yaml) — 5 lines.

Before / after (HNW band):
- Title: `Bé Tiền — Trợ lý CFO cá nhân của anh/chị Bệ hạ` → `Bé Tiền — Trợ lý Tài sản của Bệ hạ`
- Intro: `Tổng quan tài chính cá nhân của anh/chị Bệ hạ.` → `Tổng quan tài chính cá nhân của Bệ hạ.`
- Intro: `Anh/chị muốn xem mục nào?` → `Bệ hạ muốn xem mục nào?`
- Asset sub-menu: `Tổng quan tài sản và chỉ số hiệu quả của anh/chị.` → `… của Bệ hạ.`

Mass-affluent band: only the title changes ("Trợ lý CFO cá nhân" → "Trợ lý Tài sản"); intro had no "anh/chị" already.

Starter / young_prof: untouched (still "Trợ lý tài chính" — a different string the user didn't ask to change).

## Test plan
- [x] `pytest backend/tests/test_menu_v2.py` — 50 passed
- [x] `pytest backend/tests/test_briefing_formatter.py` — 12 passed
- [x] `python -c 'import yaml; yaml.safe_load(open("content/menu_copy.yaml"))'` parses cleanly
- [x] `grep -rn "anh/chị\|CFO cá nhân" content/menu_copy.yaml` returns no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)