### PR TITLE
fix(report): drop greedy "tháng trước tôi" keyword hijacking expense queries

### DIFF
--- a/backend/services/report_service.py
+++ b/backend/services/report_service.py
@@ -33,7 +33,10 @@ _REPORT_KEYWORDS = frozenset([
     "tôi xài bao", "toi xai bao",
     "tôi đã chi", "toi da chi",
     "spending", "report",
-    "tháng trước tôi", "thang truoc toi",
+    # Removed "tháng trước tôi" / "thang truoc toi": too greedy, swallowed
+    # natural-language expense queries like "tháng trước tôi chi tiêu bao
+    # nhiêu?" that the Phase 3.5 intent pipeline routes to query_expenses
+    # with time_range=last_month.
 ])
 
 

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -57,6 +57,14 @@ class TestIsReportQuery:
     def test_does_not_match_greeting(self):
         assert is_report_query("xin chào") is False
 
+    def test_does_not_match_natural_last_month_expense_query(self):
+        # Regression: this exact phrasing used to be intercepted by the
+        # legacy fast-path keyword "tháng trước tôi" and produce a full
+        # LLM Personal CFO report. It must now fall through to the
+        # Phase 3.5 intent pipeline (query_expenses, time_range=last_month).
+        assert is_report_query("tháng trước tôi chi tiêu bao nhiêu?") is False
+        assert is_report_query("thang truoc toi chi tieu bao nhieu") is False
+
 
 class TestExtractMonthKey:
     def test_defaults_to_current_month(self):


### PR DESCRIPTION
## Summary

Fix bug where "tháng trước tôi chi tiêu bao nhiêu?" produced a full HNW Personal CFO LLM report instead of last month's expense list.

## Root cause

`_REPORT_KEYWORDS` in `backend/services/report_service.py` contained `"tháng trước tôi"` / `"thang truoc toi"` — too greedy. The legacy report fast-path in `backend/bot/handlers/message.py:99-102` runs `is_report_query()` BEFORE the Phase 3.5 intent pipeline, so any natural-language query containing that substring (e.g. "tháng trước tôi chi tiêu bao nhiêu?") was intercepted and sent to `process_report_request → generate_monthly_report` — producing the full LLM CFO report.

Logs at `2026-05-05 17:59:20` confirm the message went directly to `monthly_reports` UPDATE with no `intent_classified` event for that update_id.

## Fix

Drop the two greedy keywords. The remaining keywords (`"báo cáo"`, `"tổng chi tiêu"`, `"chi tiêu tháng"`, `"tôi đã chi"`, etc.) still correctly route legitimate report requests like `"báo cáo tháng trước"`. The natural expense question now falls through to the rule classifier, which classifies it as `query_expenses_by_category` (confidence 0.9, `time_range=last_month`) — handler then returns last month's expense listing.

## Verification

- `RuleBasedClassifier().classify("tháng trước tôi chi tiêu bao nhiêu?")` → `query_expenses_by_category`, conf=0.9, `time_range=last_month` ✅
- `is_report_query("báo cáo tháng trước")` → `True` (still works) ✅
- `is_report_query("tổng chi tiêu tháng trước")` → `True` (still works) ✅
- `is_report_query("tháng trước tôi chi tiêu bao nhiêu?")` → `False` (fixed) ✅

## Test plan

- [x] New regression test `test_does_not_match_natural_last_month_expense_query` in `test_report_service.py`
- [x] All 35 `test_report_service.py` tests pass
- [x] All 320 tests in `test_intent/` + `test_report_service.py` pass
- [ ] Manual verification on Telegram: send "tháng trước tôi chi tiêu bao nhiêu?" → should return expense listing for last month, not the full Personal CFO report

🤖 Generated with [Claude Code](https://claude.com/claude-code)