### PR TITLE
fix(brand): replace remaining "Personal CFO" with "Trợ lý Tài sản"

### DIFF
--- a/backend/agent/tier3/prompts.py
+++ b/backend/agent/tier3/prompts.py
@@ -50,7 +50,7 @@ _LEVEL_FOCUS = {
     WealthLevel.HIGH_NET_WORTH: (
         "User HNW. Focus portfolio allocation %, passive income / "
         "chi tiêu coverage, dòng tiền BĐS/cổ tức/lãi, rebalancing "
-        "thresholds, tax planning. Tone Personal CFO strategic. "
+        "thresholds, tax planning. Tone Trợ lý Tài sản strategic. "
         "TUYỆT ĐỐI tránh dùng monthly_income − expenses làm proxy "
         "cho 'tiền dư đầu tư'."
     ),
@@ -72,7 +72,7 @@ def build_reasoning_prompt(
     code path complexity until we see it in profiling."""
     level_focus = _LEVEL_FOCUS[wealth_level]
 
-    return f"""Bạn là Bé Tiền — Personal CFO cá nhân cho người Việt.
+    return f"""Bạn là Bé Tiền — Trợ lý Tài sản cho người Việt.
 
 VAI TRÒ:
 Bạn giúp user thông qua reasoning multi-step về tài chính cá nhân.

--- a/backend/intent/handlers/meta.py
+++ b/backend/intent/handlers/meta.py
@@ -20,7 +20,7 @@ class GreetingHandler(IntentHandler):
         name = user.display_name or "bạn"
         return (
             f"Chào {name}! 👋\n\n"
-            "Mình là Bé Tiền — Personal CFO của bạn. Hôm nay mình giúp gì được?\n"
+            f"Mình là Bé Tiền — Trợ lý Tài sản của {name}. Hôm nay mình giúp gì được?\n"
             "• 'tài sản của tôi'\n"
             "• 'chi tiêu tháng này'\n"
             "• 'VNM giá bao nhiêu'\n\n"

--- a/backend/services/market_service.py
+++ b/backend/services/market_service.py
@@ -190,7 +190,7 @@ _INVEST_LEVEL_GUIDANCE = {
         "với user này, investable wealth là cash position trong tài sản."
     ),
     WealthLevel.HIGH_NET_WORTH: (
-        "Tone: Personal CFO advisor strategic.\n"
+        "Tone: Trợ lý Tài sản advisor strategic.\n"
         "Focus: portfolio allocation (% theo asset class), passive "
         "income / chi tiêu coverage, dòng tiền từ BĐS/cổ tức/lãi, "
         "rebalancing thresholds, tax planning.\n"
@@ -306,7 +306,7 @@ Hồ sơ tài chính:
   • Chi tiêu tháng này: {float(total_expense):,.0f} VND
   • Mục tiêu: {', '.join(f'{g.goal_name} ({float(g.current_amount):,.0f}/{float(g.target_amount):,.0f})' for g in goals) if goals else 'Chưa có'}"""
 
-    prompt = f"""Bạn là Personal CFO advisor. Dựa trên context dưới đây, đưa ra gợi ý đầu tư cho user tại Việt Nam.
+    prompt = f"""Bạn là Trợ lý Tài sản advisor. Dựa trên context dưới đây, đưa ra gợi ý đầu tư cho user tại Việt Nam.
 
 {context}
 

--- a/backend/services/report_service.py
+++ b/backend/services/report_service.py
@@ -150,7 +150,7 @@ _LEVEL_GUIDANCE = {
         "passive income, fill data gap)."
     ),
     WealthLevel.HIGH_NET_WORTH: (
-        "Tone: Personal CFO advisor, strategic, không 'nhắc nhở'.\n"
+        "Tone: Trợ lý Tài sản advisor, strategic, không 'nhắc nhở'.\n"
         "Focus: portfolio allocation %, passive income coverage, "
         "tỷ lệ chi tiêu / net worth, gaps trong data (passive income, "
         "cổ tức, lãi BĐS chưa được ghi nhận).\n"
@@ -248,7 +248,7 @@ def _build_report_prompt(report_context: str, wealth_ctx: dict) -> str:
     )
 
     return (
-        "Bạn là Personal CFO — không phải finance app cho người mới đi làm.\n"
+        "Bạn là Trợ lý Tài sản — không phải finance app cho người mới đi làm.\n"
         "Viết báo cáo tài chính tháng cho user Telegram dưới đây.\n\n"
         "=== HỒ SƠ USER ===\n"
         f"Wealth level: {wealth_ctx['level_label_vi']}\n"

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -216,7 +216,7 @@ class TestBuildReportPrompt:
         # Must explicitly forbid the "rất lớn" framing that issue #153
         # cited as broken.
         assert "rất lớn" in prompt
-        assert "Personal CFO" in prompt
+        assert "Trợ lý Tài sản" in prompt
         assert "% tổng tài sản" in prompt or "% net worth" in prompt
 
     def test_hnw_prompt_forbids_paternalistic_reminder(self):


### PR DESCRIPTION
## Summary

PR #198 only fixed `content/menu_copy.yaml`. A typo `/startp` surfaced
a separate code path that still echoes the old brand:

- Telegram exact-match dispatch in `backend/workers/telegram_worker.py`
  only matches `"/start"`, so `/startp` falls through to the text intent
  classifier.
- The classifier labels it `greeting` → `GreetingHandler` in
  [`backend/intent/handlers/meta.py`](backend/intent/handlers/meta.py),
  which hardcoded `"Mình là Bé Tiền — Personal CFO của bạn..."`.

Reproduced in production logs (`logs/backend.log:70227`):
```
'/startp', 'greeting', ..., "Chào Bệ hạ! 👋\n\nMình là Bé Tiền — Personal CFO của bạn. ..."
```

## Changes

**User-facing (the bug):**
- `backend/intent/handlers/meta.py:23` — `"Personal CFO của bạn"` →
  `"Trợ lý Tài sản của {name}"`. Now interpolates `user.display_name`
  the same way the menu_copy.yaml convention does.

**LLM personas (so model doesn't echo off-brand naming):**
- `backend/agent/tier3/prompts.py` — Tier 3 reasoning agent system prompt
- `backend/services/market_service.py` — investment-advice prompt
- `backend/services/report_service.py` — monthly-report prompt
- 1 line each, persona/tone descriptor only

**Test:**
- `backend/tests/test_report_service.py:219` — assert updated to match
  new prompt string.

**Left alone (intentional):** internal docstrings/comments that
reference "Personal CFO" as historical product-positioning context
(e.g. issue #153 framing notes, module docstrings). They describe
design history, not user-visible text.

## Test plan

- [x] `pytest backend/tests/test_report_service.py` — 35 passed
- [x] `pytest backend/tests/test_intent/test_out_of_scope.py` — 15 passed
- [x] `pytest backend/tests/test_agent/test_reasoning_agent.py` — 9 passed
- [x] `grep -rn "Personal CFO\|CFO cá nhân\|CFO của bạn" backend/ content/`
  shows only intentional docstring/comment references remain
- [ ] After merge: verify `/startp` (or any greeting) shows
  "Trợ lý Tài sản của Phuong" in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)