### PR TITLE
fix(migration): rename idx_income_user_type to avoid collision

### DIFF
--- a/alembic/versions/k0f1a2b3c4d5_phase38_income_streams_extension.py
+++ b/alembic/versions/k0f1a2b3c4d5_phase38_income_streams_extension.py
@@ -53,8 +53,10 @@ representations. Calling code is updated in the same PR.
 Indexes:
 - ``idx_income_user_active_streams`` (``user_id, is_active``) — kept
   for "list active streams" path.
-- ``idx_income_user_type`` (``user_id, stream_type, is_active``) — new,
-  optimises agent's "thu nhập từ thuê BĐS" / type-filter queries.
+- ``idx_income_streams_user_type`` (``user_id, stream_type, is_active``) — new,
+  optimises agent's "thu nhập từ thuê BĐS" / type-filter queries. Named
+  with the ``_streams_`` infix to avoid colliding with the legacy
+  ``idx_income_user_type`` on ``income_records`` (Phase 2).
 - ``idx_income_source_asset`` (``source_asset_id``) WHERE NOT NULL —
   partial; only rental streams populate this column.
 """
@@ -161,7 +163,7 @@ def upgrade() -> None:
 
     # 5. New indexes for the agent's filtered queries.
     op.create_index(
-        "idx_income_user_type",
+        "idx_income_streams_user_type",
         "income_streams",
         ["user_id", "stream_type", "is_active"],
     )
@@ -181,7 +183,7 @@ def downgrade() -> None:
     and annual streams are converted back to a monthly equivalent
     so downgrade still produces a coherent ``amount_monthly``."""
     op.drop_index("idx_income_source_asset", table_name="income_streams")
-    op.drop_index("idx_income_user_type", table_name="income_streams")
+    op.drop_index("idx_income_streams_user_type", table_name="income_streams")
 
     op.add_column(
         "income_streams",

--- a/backend/wealth/models/income_stream.py
+++ b/backend/wealth/models/income_stream.py
@@ -110,7 +110,7 @@ class IncomeStream(Base):
 
     __table_args__ = (
         Index("idx_income_user_active_streams", "user_id", "is_active"),
-        Index("idx_income_user_type", "user_id", "stream_type", "is_active"),
+        Index("idx_income_streams_user_type", "user_id", "stream_type", "is_active"),
         # Partial index — only rental streams populate source_asset_id.
         Index(
             "idx_income_source_asset",


### PR DESCRIPTION
## Summary

- Phase 3.8 Epic 2 migration `k0f1a2b3c4d5` created `idx_income_user_type` on `income_streams`, but Phase 2 migration `a1b2c3d4e5f6` already used that name on the legacy `income_records` table.
- PostgreSQL index names are schema-scoped, so the migration failed with `DuplicateTable` on every existing DB during `alembic upgrade head`.
- Rename the new index to `idx_income_streams_user_type` in upgrade, downgrade, model `__table_args__`, and the docstring. The legacy index on `income_records` keeps its original name.

## Scope

- `alembic/versions/k0f1a2b3c4d5_phase38_income_streams_extension.py` — rename in `create_index` (upgrade), `drop_index` (downgrade), and the docstring index list.
- `backend/wealth/models/income_stream.py` — match the rename in the SQLAlchemy `Index(...)` declaration on `__table_args__`.
- `backend/models/income_record.py` — untouched; its index name matches the actual physical index in the DB.

## Test plan

- [ ] On a DB at revision `i8d9e0f1a2b3` with the legacy `income_records` table, `alembic upgrade head` runs cleanly through `j9e0f1a2b3c4` → `k0f1a2b3c4d5` → `l1f2a3b4c5d6` → `m2g3h4i5j6k7`.
- [ ] `\d income_streams` in psql shows `idx_income_streams_user_type` on `(user_id, stream_type, is_active)`.
- [ ] `\d income_records` still shows the unchanged `idx_income_user_type`.
- [ ] Backend restarts cleanly; SQLAlchemy doesn't warn about index-name conflicts at startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)