### PR TITLE
fix(telegram): retry sendMessage as plain text on markdown parse error

### DIFF
--- a/backend/services/telegram_service.py
+++ b/backend/services/telegram_service.py
@@ -57,7 +57,15 @@ async def close_client() -> None:
 
 
 async def send_telegram(method: str, payload: dict) -> dict | None:
-    """Send a request to the Telegram Bot API."""
+    """Send a request to the Telegram Bot API.
+
+    If Telegram returns 400 with "can't parse entities" (the LLM produced
+    a body with unbalanced ``*`` / ``_`` / ``[`` markdown), retry once
+    without ``parse_mode`` so the user still receives the raw text rather
+    than a silently-dropped message. Without this fallback, advisory
+    responses with stray markdown chars look like "no response" — the
+    spinner clears but no message arrives.
+    """
     if not settings.telegram_bot_token:
         logger.warning("TELEGRAM_BOT_TOKEN not configured")
         return None
@@ -67,6 +75,27 @@ async def send_telegram(method: str, payload: dict) -> dict | None:
     resp = await client.post(url, json=payload)
     if resp.status_code == 200:
         return resp.json()
+
+    if (
+        resp.status_code == 400
+        and "can't parse entities" in resp.text
+        and payload.get("parse_mode")
+    ):
+        logger.warning(
+            "Telegram parse_entities error on %s; retrying as plain text",
+            method,
+        )
+        plain = {k: v for k, v in payload.items() if k != "parse_mode"}
+        retry = await client.post(url, json=plain)
+        if retry.status_code == 200:
+            return retry.json()
+        logger.error(
+            "Telegram API error (plain retry): %s %s",
+            retry.status_code,
+            retry.text,
+        )
+        return None
+
     logger.error("Telegram API error: %s %s", resp.status_code, resp.text)
     return None
 

--- a/backend/tests/test_telegram_service.py
+++ b/backend/tests/test_telegram_service.py
@@ -62,6 +62,63 @@ class TestSendTelegram:
         result = await send_telegram("sendMessage", {"chat_id": 123})
         assert result is None
 
+    @pytest.mark.asyncio
+    async def test_retries_without_parse_mode_on_parse_entities_error(
+        self, mock_settings, mock_httpx
+    ):
+        """When Telegram rejects bad markdown, retry as plain text so the
+        user still sees the message instead of a silent "no response"."""
+        from unittest.mock import MagicMock
+
+        bad_response = MagicMock()
+        bad_response.status_code = 400
+        bad_response.text = (
+            '{"ok":false,"error_code":400,'
+            '"description":"Bad Request: can\'t parse entities: '
+            'Can\'t find end of the entity starting at byte offset 1217"}'
+        )
+        good_response = MagicMock()
+        good_response.status_code = 200
+        good_response.json.return_value = {"ok": True, "result": {"message_id": 1}}
+        good_response.text = '{"ok": true}'
+        mock_httpx.post.side_effect = [bad_response, good_response]
+
+        result = await send_telegram(
+            "sendMessage",
+            {"chat_id": 123, "text": "hi *unbalanced", "parse_mode": "Markdown"},
+        )
+
+        assert result == {"ok": True, "result": {"message_id": 1}}
+        assert mock_httpx.post.call_count == 2
+        # Retry payload must NOT carry parse_mode anymore.
+        retry_payload = mock_httpx.post.call_args_list[1][1]["json"]
+        assert "parse_mode" not in retry_payload
+        assert retry_payload["text"] == "hi *unbalanced"
+        assert retry_payload["chat_id"] == 123
+
+    @pytest.mark.asyncio
+    async def test_no_retry_when_400_is_not_parse_entities(
+        self, mock_settings, mock_httpx
+    ):
+        """Other 400s (chat not found, etc.) must not trigger a retry."""
+        from unittest.mock import MagicMock
+
+        bad_response = MagicMock()
+        bad_response.status_code = 400
+        bad_response.text = (
+            '{"ok":false,"error_code":400,"description":"Bad Request: chat not found"}'
+        )
+        mock_httpx.post.side_effect = None
+        mock_httpx.post.return_value = bad_response
+
+        result = await send_telegram(
+            "sendMessage",
+            {"chat_id": 123, "text": "hi", "parse_mode": "Markdown"},
+        )
+
+        assert result is None
+        assert mock_httpx.post.call_count == 1
+
 
 class TestSendMessage:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Bug

Clicking **/menu → Tài sản → Tư vấn tối ưu** produced no response at all. The user saw only the spinner clear; no message arrived.

## Root cause

The advisory handler ran fine — logs at `2026-05-06 16:05:19` and `16:05:50` show:
- `menu:assets:advisor` callback received
- `advisory_response_sent` event tracked (LLM produced 836 chars)
- Then `Telegram API error: 400 Bad Request: can't parse entities: Can't find end of the entity starting at byte offset 1217`

Telegram rejected the `sendMessage` call because the LLM body contained an unbalanced markdown char (stray `*` / `_` / `[`). With `parse_mode="Markdown"`, Telegram's parser fails closed and drops the message. The handler had already returned successfully, the callback was acknowledged, so from the user's POV the bot just went silent.

This is a recurring failure mode for any LLM-routed text — not specific to advisory.

## Fix

In `send_telegram`, if Telegram returns 400 with `can't parse entities`, retry once without `parse_mode`. The user gets the raw text (no italic/bold styling) instead of nothing. Other 400s (e.g. chat not found) still fail fast as before.

## Test plan

- [x] New unit test: retries without `parse_mode` and returns the second response on parse-entities 400
- [x] New unit test: other 400s do **not** trigger the retry
- [x] Existing telegram_service / telegram_worker / advisory tests still pass (32/32)
- [ ] Smoke test on main: tap /menu → Tài sản → Tư vấn tối ưu, confirm a reply arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)