### PR TITLE
fix(telegram): sanitize LLM markdown pre-send (root-cause follow-up to #230)

### DIFF
--- a/backend/services/telegram_service.py
+++ b/backend/services/telegram_service.py
@@ -9,9 +9,22 @@ import logging
 import httpx
 
 from backend.config import get_settings
+from backend.utils.markdown_sanitizer import sanitize_markdown
 
 logger = logging.getLogger(__name__)
 settings = get_settings()
+
+# Telegram methods whose payload carries user-facing body text we may
+# need to sanitize. ``sendMessage`` / ``editMessageText`` use ``text``;
+# ``sendPhoto`` / ``editMessageCaption`` use ``caption``. Anything else
+# (answerCallbackQuery, sendChatAction, getFile, setMyCommands…) is
+# either structured or short enough that sanitization isn't relevant.
+_MARKDOWN_TEXT_FIELDS = {
+    "sendMessage": "text",
+    "editMessageText": "text",
+    "sendPhoto": "caption",
+    "editMessageCaption": "caption",
+}
 
 # Singleton httpx client. Creating a fresh AsyncClient per request paid the
 # full TCP+TLS handshake to api.telegram.org every time (~300-500ms per call
@@ -56,19 +69,49 @@ async def close_client() -> None:
             _client = None
 
 
+def _sanitize_payload(method: str, payload: dict) -> dict:
+    """Pre-process Markdown bodies so Telegram's parser doesn't reject them.
+
+    Only touches payloads where ``parse_mode == "Markdown"`` — HTML mode
+    has its own escaping rules (handled at the formatter layer), and
+    bodies without ``parse_mode`` are plain text already. Returns a
+    shallow copy with the relevant text field replaced; the input dict
+    is not mutated so callers can safely re-use it.
+    """
+    if payload.get("parse_mode") != "Markdown":
+        return payload
+    field = _MARKDOWN_TEXT_FIELDS.get(method)
+    if not field:
+        return payload
+    body = payload.get(field)
+    if not isinstance(body, str) or not body:
+        return payload
+    sanitized = sanitize_markdown(body)
+    if sanitized == body:
+        return payload
+    return {**payload, field: sanitized}
+
+
 async def send_telegram(method: str, payload: dict) -> dict | None:
     """Send a request to the Telegram Bot API.
 
-    If Telegram returns 400 with "can't parse entities" (the LLM produced
-    a body with unbalanced ``*`` / ``_`` / ``[`` markdown), retry once
-    without ``parse_mode`` so the user still receives the raw text rather
-    than a silently-dropped message. Without this fallback, advisory
-    responses with stray markdown chars look like "no response" — the
-    spinner clears but no message arrives.
+    Two layers of protection against the "can't parse entities" failure
+    where unbalanced LLM-generated markdown silently drops the message:
+
+    1. **Sanitize on the way out.** When ``parse_mode`` is ``Markdown``,
+       we run the body through :func:`sanitize_markdown` to escape any
+       unbalanced ``*`` / ``_`` / ``[`` / ``\\``` so Telegram parses
+       cleanly the first time. This is the root-cause fix.
+    2. **Plain-text retry on 400.** If a malformed body slips past the
+       sanitizer and Telegram still rejects it, retry once without
+       ``parse_mode`` so the user sees the raw text instead of nothing.
+       Other 400s (chat not found, etc.) still fail fast.
     """
     if not settings.telegram_bot_token:
         logger.warning("TELEGRAM_BOT_TOKEN not configured")
         return None
+
+    payload = _sanitize_payload(method, payload)
 
     url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/{method}"
     client = await _get_client()
@@ -132,6 +175,11 @@ async def send_photo(
     url = f"https://api.telegram.org/bot{settings.telegram_bot_token}/sendPhoto"
     data: dict = {"chat_id": str(chat_id)}
     if caption:
+        # Mirror send_telegram's sanitization for the multipart path so
+        # captions with LLM-generated markdown (e.g. briefing photos)
+        # don't silently fail with "can't parse entities".
+        if parse_mode == "Markdown":
+            caption = sanitize_markdown(caption)
         data["caption"] = caption
         data["parse_mode"] = parse_mode
     if reply_markup:

--- a/backend/tests/test_markdown_sanitizer.py
+++ b/backend/tests/test_markdown_sanitizer.py
@@ -1,0 +1,175 @@
+"""Tests for markdown_sanitizer — root-cause fix for #231."""
+import pytest
+
+from backend.utils.markdown_sanitizer import sanitize_markdown
+
+
+class TestSanitizeMarkdownBasic:
+    def test_empty_string(self):
+        assert sanitize_markdown("") == ""
+
+    def test_plain_text_unchanged(self):
+        text = "Đây là chữ thường, không có markdown."
+        assert sanitize_markdown(text) == text
+
+    def test_balanced_bold_unchanged(self):
+        text = "Hôm nay *quan trọng* lắm nhé."
+        assert sanitize_markdown(text) == text
+
+    def test_balanced_italic_unchanged(self):
+        text = "Đây là _gợi ý_ thôi."
+        assert sanitize_markdown(text) == text
+
+    def test_balanced_code_span_unchanged(self):
+        text = "Lệnh `git status` để xem."
+        assert sanitize_markdown(text) == text
+
+    def test_complete_link_unchanged(self):
+        text = "Xem thêm [tại đây](https://example.com) để biết."
+        assert sanitize_markdown(text) == text
+
+    def test_idempotent_on_already_balanced(self):
+        text = "*bold* and _italic_ and `code` and [link](https://x.com)"
+        once = sanitize_markdown(text)
+        twice = sanitize_markdown(once)
+        assert once == text
+        assert twice == once
+
+
+class TestUnbalancedBold:
+    def test_truncated_mid_bold(self):
+        # LLM ran out of tokens mid-emphasis.
+        result = sanitize_markdown("Hãy đầu tư vào *VinHomes")
+        assert result == "Hãy đầu tư vào \\*VinHomes"
+
+    def test_stray_asterisk_at_end(self):
+        result = sanitize_markdown("Cẩn thận nhé*")
+        assert result == "Cẩn thận nhé\\*"
+
+    def test_three_asterisks_balances_first_pair(self):
+        # *foo* * — three `*` total. Greedy match: first two pair up,
+        # third is stray.
+        result = sanitize_markdown("*foo* *")
+        assert result == "*foo* \\*"
+
+
+class TestUnbalancedItalic:
+    def test_unclosed_underscore(self):
+        result = sanitize_markdown("Đây là _quan trọng cho việc tiết kiệm.")
+        assert result == "Đây là \\_quan trọng cho việc tiết kiệm."
+
+    def test_underscore_in_ticker_balanced(self):
+        # BTC_USD ... ETH_USD — the two underscores pair up. Renders as
+        # italic content between them, but parses without error.
+        text = "BTC_USD và ETH_USD"
+        out = sanitize_markdown(text)
+        # No escapes: pairs are balanced.
+        assert "\\_" not in out
+
+
+class TestUnbalancedBacktick:
+    def test_unclosed_code_span(self):
+        result = sanitize_markdown("Chạy lệnh `npm install để cài.")
+        assert result == "Chạy lệnh \\`npm install để cài."
+
+    def test_unclosed_triple_backtick(self):
+        result = sanitize_markdown("Code:\n```\npython main.py")
+        assert result.startswith("Code:\n\\`\\`\\`")
+
+    def test_balanced_triple_backtick_unchanged(self):
+        text = "```\npython main.py\n```"
+        assert sanitize_markdown(text) == text
+
+    def test_asterisk_inside_code_span_preserved(self):
+        # Code spans should preserve content verbatim — the ``*`` inside
+        # should NOT be touched.
+        text = "Use `*` for bold."
+        assert sanitize_markdown(text) == text
+
+
+class TestBrokenLinks:
+    def test_unclosed_bracket(self):
+        result = sanitize_markdown("Xem [thêm tại đây")
+        assert result == "Xem \\[thêm tại đây"
+
+    def test_bracket_without_paren(self):
+        # [text] without (url) — Telegram needs the full shape.
+        result = sanitize_markdown("Xem [thêm] về vấn đề này.")
+        assert result == "Xem \\[thêm] về vấn đề này."
+
+    def test_unclosed_url_paren(self):
+        result = sanitize_markdown("Xem [thêm](https://example.com chi tiết.")
+        assert result == "Xem \\[thêm](https://example.com chi tiết."
+
+
+class TestListBullets:
+    def test_asterisk_bullet_at_line_start_escaped(self):
+        # The killer LLM output mode: standard-Markdown bullet list.
+        text = "Gợi ý cho bạn:\n* Mục 1\n* Mục 2\n* Mục 3"
+        result = sanitize_markdown(text)
+        assert "\\* Mục 1" in result
+        assert "\\* Mục 2" in result
+        assert "\\* Mục 3" in result
+
+    def test_indented_bullet_escaped(self):
+        text = "List:\n  * Sub-item"
+        result = sanitize_markdown(text)
+        assert "  \\* Sub-item" in result
+
+    def test_bullet_does_not_affect_inline_bold(self):
+        text = "Note: *quan trọng* lắm.\n* Mục 1"
+        result = sanitize_markdown(text)
+        # Inline bold preserved, bullet escaped.
+        assert "*quan trọng*" in result
+        assert "\\* Mục 1" in result
+
+    def test_dash_bullets_unchanged(self):
+        # ``-`` is not a Markdown opener for Telegram, leave alone.
+        text = "List:\n- Item 1\n- Item 2"
+        assert sanitize_markdown(text) == text
+
+
+class TestRealWorldAdvisoryOutput:
+    """Cases drawn from real LLM advisory failures we've seen in logs."""
+
+    def test_truncated_advisory(self):
+        # The original failure from #230 logs: response cut off at
+        # ~1200 chars mid-bold.
+        text = (
+            "Mình thấy bạn đang quan tâm đến BĐS. Một vài hướng:\n\n"
+            "*Option 1*: Mua chung cư cho thuê. Lợi nhuận ổn định 5-7%/năm.\n"
+            "*Option 2*: Mua đất nền vùng ven. Tăng giá nhanh hơn nhưng *rủi ro"
+        )
+        out = sanitize_markdown(text)
+        # The unclosed `*rủi ro` opener at end gets escaped.
+        assert out.endswith("\\*rủi ro")
+        # The complete pairs are still intact.
+        assert "*Option 1*" in out
+        assert "*Option 2*" in out
+
+    def test_mixed_problems(self):
+        text = (
+            "Tóm lại:\n"
+            "* Tiết kiệm trước, đầu tư sau\n"
+            "* Mua [VN30](https://etf.vn nếu thận trọng\n"
+            "* _Đa dạng hoá quan trọng"
+        )
+        out = sanitize_markdown(text)
+        # All three bullet markers escaped.
+        assert out.count("\\*") >= 3
+        # Broken link bracket escaped.
+        assert "\\[VN30]" in out
+        # Unclosed italic escaped.
+        assert "\\_Đa dạng hoá" in out
+
+    def test_does_not_disturb_clean_advisory(self):
+        # When the LLM produces clean Markdown, we don't mangle it.
+        text = (
+            "Gợi ý của mình:\n\n"
+            "Bạn có thể thử *Option A*: gửi tiết kiệm 12 tháng "
+            "(_ổn định, lãi ~5%_).\n\n"
+            "Hoặc xem thêm [bài viết này](https://example.com).\n\n"
+            "_Đây là gợi ý cá nhân, không phải lời khuyên đầu tư._"
+        )
+        # Greedy matching pairs every entity correctly here.
+        assert sanitize_markdown(text) == text

--- a/backend/tests/test_telegram_service.py
+++ b/backend/tests/test_telegram_service.py
@@ -66,8 +66,15 @@ class TestSendTelegram:
     async def test_retries_without_parse_mode_on_parse_entities_error(
         self, mock_settings, mock_httpx
     ):
-        """When Telegram rejects bad markdown, retry as plain text so the
-        user still sees the message instead of a silent "no response"."""
+        """Last-resort retry: even if the sanitizer (#231) misses a case
+        and Telegram still rejects, we drop ``parse_mode`` so the user
+        sees raw text instead of nothing.
+
+        Uses input the sanitizer leaves alone (already-balanced) so the
+        body Telegram rejects is identical to the body we sent. This
+        keeps the test focused on the retry behaviour, not the sanitizer
+        (which has its own dedicated tests).
+        """
         from unittest.mock import MagicMock
 
         bad_response = MagicMock()
@@ -85,7 +92,11 @@ class TestSendTelegram:
 
         result = await send_telegram(
             "sendMessage",
-            {"chat_id": 123, "text": "hi *unbalanced", "parse_mode": "Markdown"},
+            {
+                "chat_id": 123,
+                "text": "hi *balanced* text",
+                "parse_mode": "Markdown",
+            },
         )
 
         assert result == {"ok": True, "result": {"message_id": 1}}
@@ -93,7 +104,7 @@ class TestSendTelegram:
         # Retry payload must NOT carry parse_mode anymore.
         retry_payload = mock_httpx.post.call_args_list[1][1]["json"]
         assert "parse_mode" not in retry_payload
-        assert retry_payload["text"] == "hi *unbalanced"
+        assert retry_payload["text"] == "hi *balanced* text"
         assert retry_payload["chat_id"] == 123
 
     @pytest.mark.asyncio
@@ -128,6 +139,114 @@ class TestSendMessage:
         assert payload["chat_id"] == 123
         assert payload["text"] == "hello"
         assert payload["parse_mode"] == "Markdown"
+
+
+class TestPreSendSanitization:
+    """The sanitizer must run BEFORE the HTTP call so unbalanced markdown
+    never reaches Telegram in the first place. The plain-text retry
+    (#230) stays as a fallback, but should rarely fire after this.
+    """
+
+    @pytest.mark.asyncio
+    async def test_unbalanced_bold_is_escaped_before_send(
+        self, mock_settings, mock_httpx
+    ):
+        await send_telegram(
+            "sendMessage",
+            {
+                "chat_id": 123,
+                "text": "Mua *VinHomes",  # truncated mid-bold
+                "parse_mode": "Markdown",
+            },
+        )
+        sent_payload = mock_httpx.post.call_args[1]["json"]
+        # Sanitizer escaped the stray ``*`` so Telegram parses cleanly.
+        assert sent_payload["text"] == "Mua \\*VinHomes"
+        # Single API call — no retry needed because the body is now valid.
+        assert mock_httpx.post.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_list_bullets_are_escaped_before_send(
+        self, mock_settings, mock_httpx
+    ):
+        await send_telegram(
+            "sendMessage",
+            {
+                "chat_id": 123,
+                "text": "Gợi ý:\n* Mục 1\n* Mục 2",
+                "parse_mode": "Markdown",
+            },
+        )
+        sent_payload = mock_httpx.post.call_args[1]["json"]
+        assert "\\* Mục 1" in sent_payload["text"]
+        assert "\\* Mục 2" in sent_payload["text"]
+
+    @pytest.mark.asyncio
+    async def test_balanced_markdown_passes_through_unchanged(
+        self, mock_settings, mock_httpx
+    ):
+        original = "Hôm nay *quan trọng* và _gợi ý_ cho bạn."
+        await send_telegram(
+            "sendMessage",
+            {"chat_id": 123, "text": original, "parse_mode": "Markdown"},
+        )
+        sent_payload = mock_httpx.post.call_args[1]["json"]
+        assert sent_payload["text"] == original
+
+    @pytest.mark.asyncio
+    async def test_html_mode_is_not_touched_by_sanitizer(
+        self, mock_settings, mock_httpx
+    ):
+        # The sanitizer only knows Markdown; HTML has its own escaping.
+        original = "<b>Hello *world*</b>"
+        await send_telegram(
+            "sendMessage",
+            {"chat_id": 123, "text": original, "parse_mode": "HTML"},
+        )
+        sent_payload = mock_httpx.post.call_args[1]["json"]
+        assert sent_payload["text"] == original
+
+    @pytest.mark.asyncio
+    async def test_no_parse_mode_skips_sanitizer(
+        self, mock_settings, mock_httpx
+    ):
+        # Plain text doesn't need sanitization.
+        original = "Mua *VinHomes (raw text, no parser)"
+        await send_telegram(
+            "sendMessage", {"chat_id": 123, "text": original}
+        )
+        sent_payload = mock_httpx.post.call_args[1]["json"]
+        assert sent_payload["text"] == original
+
+    @pytest.mark.asyncio
+    async def test_edit_message_text_also_sanitized(
+        self, mock_settings, mock_httpx
+    ):
+        await send_telegram(
+            "editMessageText",
+            {
+                "chat_id": 123,
+                "message_id": 456,
+                "text": "Cập nhật *truncated",
+                "parse_mode": "Markdown",
+            },
+        )
+        sent_payload = mock_httpx.post.call_args[1]["json"]
+        assert sent_payload["text"] == "Cập nhật \\*truncated"
+
+    @pytest.mark.asyncio
+    async def test_non_text_method_payload_untouched(
+        self, mock_settings, mock_httpx
+    ):
+        # answerCallbackQuery has no body; sanitizer must be a no-op.
+        await send_telegram(
+            "answerCallbackQuery",
+            {"callback_query_id": "cb-1", "text": "Stray *marker"},
+        )
+        sent_payload = mock_httpx.post.call_args[1]["json"]
+        # No parse_mode means the sanitizer's gate skips this anyway,
+        # and we don't have answerCallbackQuery in the field map.
+        assert sent_payload["text"] == "Stray *marker"
 
 
 class TestAnswerCallback:

--- a/backend/utils/markdown_sanitizer.py
+++ b/backend/utils/markdown_sanitizer.py
@@ -1,0 +1,189 @@
+"""Sanitize LLM-generated text for Telegram's legacy Markdown parser.
+
+Telegram's Bot API rejects messages whose markdown entities aren't
+balanced and returns ``Bad Request: can't parse entities`` — fatal,
+the message is silently dropped. The advisory handler hit this in
+prod (#231): an LLM response with an odd number of ``*`` made the
+whole reply disappear, the user saw the spinner clear with no answer.
+
+The previous fix (#230) was a transport-layer band-aid: on parse
+failure, retry without ``parse_mode``. That ships, but it's
+plain-text — bullets, bolds, links all become noise. Worse, it
+hides the real problem: the LLM output should be valid in the first
+place, or, failing that, *fixed* before send rather than stripped of
+all formatting.
+
+This module is the root-cause fix. It pre-processes Markdown bodies
+so unbalanced entities get escaped (``\\*``) and render as literal
+characters instead of breaking parsing. The plain-text retry stays
+as a last-resort safety net for cases the sanitizer doesn't catch
+(deeply nested cross-emphasis, novel LLM failure modes), but should
+be exercised <1% of the time once this lands.
+
+Failure modes this catches
+--------------------------
+- Truncated mid-emphasis: ``Mua *VinHomes`` (LLM hit token cap).
+- Standard-vs-Telegram syntax mix: ``**bold**`` (renders fine, was
+  parsing OK already, no change here — included for coverage).
+- Stray opener: ``Đây là _quan trọng cho việc tiết kiệm.``
+- Broken link: ``[xem thêm](https://example.com`` (no closing ``)``).
+- Bullet lists: ``* Mục 1\\n* Mục 2`` — Telegram parses the leading
+  ``*`` as a bold opener, eating the next line. We escape line-leading
+  ``*`` followed by a space so bullets stay literal.
+- Stray code-span backtick: ``` Lệnh `git st `` ``` (no close).
+
+Limitations
+-----------
+- We don't recurse into balanced spans to repair nested unbalance
+  (e.g. ``*foo _bar*`` leaves the inner ``_`` alone — Telegram errors
+  on this and the plain-text retry will catch it).
+- We don't rewrite ``**foo**`` into ``*foo*``. Telegram parses the
+  former as two empty bolds + literal ``foo``, which is ugly but
+  doesn't error.
+- MarkdownV2 (different escape set) is not handled — the codebase
+  uses legacy ``Markdown``.
+
+Idempotence: passing already-balanced markdown through the sanitizer
+returns the input unchanged. Tests assert this.
+"""
+from __future__ import annotations
+
+__all__ = ["sanitize_markdown"]
+
+
+def sanitize_markdown(text: str) -> str:
+    """Escape unbalanced legacy-Markdown entities for Telegram.
+
+    Walks ``text`` once. For each entity opener (``*``, ``_``, `````,
+    ``[``, ```` ``` ````), tries to find a matching closer. Matched pairs
+    pass through verbatim. Unmatched openers get backslash-escaped so
+    Telegram renders them literally instead of erroring on parse.
+
+    Line-leading ``* `` is treated as a literal list bullet (escaped),
+    not a bold opener — this is the single most common LLM failure
+    mode for Vietnamese advisory output.
+    """
+    if not text:
+        return text
+
+    # Pre-pass: line-leading "* " (with a space after) is a Markdown
+    # list bullet in standard Markdown but a bold opener in Telegram's
+    # legacy parser. LLMs default to standard-Markdown habits, so this
+    # pattern is everywhere in advisory output. Escape it before the
+    # main pass so the bullet stays literal.
+    text = _escape_list_bullets(text)
+
+    out: list[str] = []
+    i = 0
+    n = len(text)
+
+    while i < n:
+        ch = text[i]
+
+        # Already-escaped char (from the list-bullet pre-pass or from
+        # the LLM itself emitting ``\*``). Pass the backslash + next
+        # char through verbatim so we don't try to match the entity.
+        if ch == "\\" and i + 1 < n and text[i + 1] in "*_`[]()\\":
+            out.append(text[i : i + 2])
+            i += 2
+            continue
+
+        # Triple-backtick code block — must be matched before single
+        # backticks. Content inside is verbatim per Telegram spec.
+        if text.startswith("```", i):
+            close = text.find("```", i + 3)
+            if close == -1:
+                # No closer — escape the whole opener so the literal
+                # backticks render and parse stays balanced.
+                out.append("\\`\\`\\`")
+                i += 3
+            else:
+                out.append(text[i : close + 3])
+                i = close + 3
+            continue
+
+        # Single-backtick code span.
+        if ch == "`":
+            close = _find_unescaped(text, "`", i + 1)
+            if close == -1:
+                out.append("\\`")
+                i += 1
+            else:
+                out.append(text[i : close + 1])
+                i = close + 1
+            continue
+
+        # Link: requires the full ``[text](url)`` shape. Anything less
+        # than complete gets the bracket escaped.
+        if ch == "[":
+            close_bracket = _find_unescaped(text, "]", i + 1)
+            if (
+                close_bracket != -1
+                and close_bracket + 1 < n
+                and text[close_bracket + 1] == "("
+            ):
+                close_paren = _find_unescaped(text, ")", close_bracket + 2)
+                if close_paren != -1:
+                    out.append(text[i : close_paren + 1])
+                    i = close_paren + 1
+                    continue
+            out.append("\\[")
+            i += 1
+            continue
+
+        # Bold (``*``) and italic (``_``) — single-char paired entities.
+        if ch in ("*", "_"):
+            close = _find_unescaped(text, ch, i + 1)
+            if close == -1:
+                out.append("\\" + ch)
+                i += 1
+            else:
+                out.append(text[i : close + 1])
+                i = close + 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
+def _find_unescaped(text: str, target: str, start: int) -> int:
+    """Find the next occurrence of ``target`` in ``text`` from ``start``,
+    skipping any preceded by a backslash.
+
+    Needed because the list-bullet pre-pass inserts ``\\*`` markers and
+    LLMs occasionally emit ``\\*`` themselves; the main pass must not
+    treat those as real entity delimiters.
+    """
+    i = start
+    n = len(text)
+    while i < n:
+        idx = text.find(target, i)
+        if idx == -1:
+            return -1
+        if idx > 0 and text[idx - 1] == "\\":
+            i = idx + 1
+            continue
+        return idx
+    return -1
+
+
+def _escape_list_bullets(text: str) -> str:
+    """Escape ``*`` at line-start followed by a space.
+
+    Standard Markdown writes lists as ``* item`` / ``- item``. The
+    ``-`` form passes through Telegram untouched. The ``*`` form is
+    parsed as a bold opener and eats the following text up to the
+    next ``*``, which is exactly the failure we keep seeing in
+    advisory output. Escape only this very specific shape so we
+    don't disturb inline ``*emphasis*``.
+    """
+    lines = text.split("\n")
+    for idx, line in enumerate(lines):
+        stripped = line.lstrip(" \t")
+        if stripped.startswith("* "):
+            # Replace exactly the first non-whitespace ``*``.
+            leading_ws_len = len(line) - len(stripped)
+            lines[idx] = line[:leading_ws_len] + "\\*" + stripped[1:]
+    return "\n".join(lines)


### PR DESCRIPTION
## Summary

Root-cause fix for the parse-entities failure that #230 patched at the transport layer. PR #230 retried with ``parse_mode`` stripped when Telegram rejected the body — that ships, but it's plain text. The user sees literal ``*foo*`` and ``[link](url)`` characters instead of formatted output. The real problem is that LLM bodies arrive at Telegram already malformed.

This PR adds a pre-send markdown sanitizer that fixes the body BEFORE the wire call, so the message renders correctly the first time. The plain-text retry from #230 stays as a last-resort safety net for cases the sanitizer doesn't catch.

## Why a sanitizer instead of better LLM prompting

Three reasons:
1. **Defence in depth** — even a perfectly-prompted LLM can truncate mid-emphasis when the response hits the token budget
2. **Independent of model** — DeepSeek today, Claude / Gemini tomorrow; the failure modes vary by model
3. **Single point of enforcement** — wired in ``send_telegram()`` so EVERY caller (advisory, briefing, handlers, future LLM features) gets it for free with no per-callsite changes

## What the sanitizer handles

| Failure mode | Example LLM output | After sanitize |
|---|---|---|
| Truncated mid-bold | ``Mua *VinHomes`` | ``Mua \*VinHomes`` |
| Stray italic opener | ``Đây là _quan trọng cho`` | ``Đây là \_quan trọng cho`` |
| Broken link | ``[xem thêm](https://x.com`` (no paren) | ``\[xem thêm](https://x.com`` |
| Bullet list ``* item`` | ``* Mục 1\n* Mục 2`` | ``\* Mục 1\n\* Mục 2`` |
| Unclosed code span | `` `git st `` | ``\`git st`` |
| Unclosed code block | ` ``` python main.py` | escaped triple-backtick |

Balanced markdown passes through verbatim — the sanitizer is idempotent on valid input.

## Where it runs

- ``send_telegram(method, payload)`` — applies whenever ``payload["parse_mode"] == "Markdown"`` and the method is one that carries body text (``sendMessage``, ``editMessageText``, ``sendPhoto`` caption, ``editMessageCaption``)
- ``send_photo()`` — multipart path bypasses ``send_telegram``, so it has its own inline sanitize call for the caption
- HTML mode and plain-text payloads pass through untouched (HTML escaping is the formatter's responsibility; plain text needs no parsing)

## Test coverage

- ``backend/tests/test_markdown_sanitizer.py`` — 26 unit tests covering balanced/unbalanced/idempotent/code-span/list-bullet/real-world advisory cases
- ``backend/tests/test_telegram_service.py::TestPreSendSanitization`` — 7 integration tests that run through ``send_telegram`` and assert the payload hitting the HTTP mock has been sanitized

The existing #230 retry test was updated to use already-balanced input (so the sanitizer leaves it alone) and assert the retry path still works as a fallback.

## Limitations (documented in the module)

- Doesn't recurse into balanced spans to repair nested unbalance (e.g. ``*foo _bar*`` leaves the inner ``_`` alone — the plain-text retry catches these)
- Doesn't rewrite ``**foo**`` into ``*foo*``. Telegram parses ``**foo**`` as two empty bolds + literal ``foo``, which is ugly but doesn't error
- MarkdownV2 not handled — the codebase uses legacy ``Markdown``

## Test plan

- [x] All 26 sanitizer unit tests pass
- [x] All 7 telegram_service integration tests pass
- [x] Existing #230 retry test still passes (updated for new behaviour)
- [x] Full backend test suite: 1286 passed (one pre-existing flaky intent test unrelated to this change)
- [ ] Smoke test in prod: trigger an advisory query with /menu → Tài sản → Tư vấn tối ưu and verify the response arrives formatted (not as plain text fallback)

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)