### PR TITLE
Implement /about command

### DIFF
--- a/backend/bot/handlers/about_handler.py
+++ b/backend/bot/handlers/about_handler.py
@@ -1,0 +1,41 @@
+"""/about command handler.
+
+Keeps product trust metadata in one fast, dependency-light place so the
+command can answer immediately without touching the database.
+"""
+from __future__ import annotations
+
+from backend.config import APP_VERSION
+from backend.services.telegram_service import send_message
+
+ABOUT_TEXT = f"""💎 *Bé Tiền — Personal CFO*
+_Trợ lý CFO cá nhân đầu tiên dành cho người Việt_
+
+📦 *Phiên bản:* {APP_VERSION}
+🏢 *Phát triển bởi:* Nui Truc AI
+
+━━━━━━━━━━━━━━━
+🔒 *Bảo mật dữ liệu*
+Dữ liệu tài chính của bạn được mã hóa và lưu trữ an toàn.
+Chúng tôi không bao giờ chia sẻ thông tin cá nhân với bên thứ ba.
+━━━━━━━━━━━━━━━
+
+© 2026 Nui Truc AI. All rights reserved."""
+
+ABOUT_KEYBOARD = {
+    "inline_keyboard": [
+        [{"text": "🌐 Website Công Ty", "url": "https://nuitruc.ai"}],
+        [{"text": "🔏 Chính Sách Bảo Mật", "url": "https://nuitruc.ai/privacy"}],
+        [{"text": "📧 Hỗ Trợ", "url": "mailto:admin@nuitruc.ai"}],
+    ]
+}
+
+
+async def cmd_about(chat_id: int) -> None:
+    """Send the product About page for ``/about``."""
+    await send_message(
+        chat_id=chat_id,
+        text=ABOUT_TEXT,
+        parse_mode="Markdown",
+        reply_markup=ABOUT_KEYBOARD,
+    )

--- a/backend/bot/setup_commands.py
+++ b/backend/bot/setup_commands.py
@@ -1,4 +1,4 @@
-"""Phase 3.6 bot menu commands — the 4 entries that show up under the
+"""Phase 3.6 bot menu commands — the key entries that show up under the
 Telegram bot menu button (corner of the chat input).
 
 These are **shortcuts**, not the rich /menu inline UI:
@@ -7,6 +7,7 @@ These are **shortcuts**, not the rich /menu inline UI:
   /menu      — opens the rich 5-category inline menu (the real UX)
   /help      — short usage guide (handled via Phase 3.5 HELP intent)
   /dashboard — opens the wealth Mini App in-place
+  /about    — product version, privacy and support info
 
 The bot menu button is a Telegram-native list of slash commands — tapping
 one inserts the command into the input and sends it. So each command
@@ -18,10 +19,11 @@ Routing of these slash commands lives in ``workers/telegram_worker._handle_messa
   - ``/help`` matches the rule-based pattern in ``intent_patterns.yaml``
     and resolves through the normal text path
   - ``/dashboard`` is wired in the worker as part of Epic 2
+  - ``/about`` is wired in the worker and renders static product info
 
 Old Phase 3A commands (``/themtaisan``, ``/taisan``, ``/report``, ``/goals``,
 ``/market``) still work as text — they just no longer appear in the menu
-button list. Surfacing 4 high-leverage entry points reduces decision
+button list. Surfacing a small set of high-leverage entry points reduces decision
 friction; the rich /menu is one tap away for everything else.
 """
 from __future__ import annotations
@@ -38,6 +40,7 @@ BOT_COMMANDS: list[dict[str, str]] = [
     {"command": "menu", "description": "Menu chính"},
     {"command": "help", "description": "Hướng dẫn sử dụng"},
     {"command": "dashboard", "description": "Mở Mini App dashboard"},
+    {"command": "about", "description": "Thông tin ứng dụng"},
 ]
 
 

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -12,6 +12,9 @@ from functools import lru_cache
 from pydantic_settings import BaseSettings
 
 
+APP_VERSION = "1.3.8.01"
+
+
 class Settings(BaseSettings):
     # Backend
     environment: str = "development"
@@ -81,4 +84,4 @@ def get_settings() -> Settings:
     return Settings()
 
 
-__all__ = ["Settings", "get_settings"]
+__all__ = ["APP_VERSION", "Settings", "get_settings"]

--- a/backend/tests/test_about_handler.py
+++ b/backend/tests/test_about_handler.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.bot.handlers import about_handler
+from backend.bot.setup_commands import BOT_COMMANDS
+from backend.config import APP_VERSION
+from backend.workers import telegram_worker
+from backend.tests.test_telegram_worker import _make_fake_session
+
+
+@pytest.mark.asyncio
+async def test_cmd_about_sends_versioned_about_page():
+    with patch.object(about_handler, "send_message", new_callable=AsyncMock) as send:
+        await about_handler.cmd_about(chat_id=123)
+
+    send.assert_awaited_once_with(
+        chat_id=123,
+        text=about_handler.ABOUT_TEXT,
+        parse_mode="Markdown",
+        reply_markup=about_handler.ABOUT_KEYBOARD,
+    )
+    assert APP_VERSION in about_handler.ABOUT_TEXT
+    assert "© 2026 Nui Truc AI. All rights reserved." in about_handler.ABOUT_TEXT
+
+
+@pytest.mark.asyncio
+async def test_about_command_routes_without_user_lookup():
+    fake_session = _make_fake_session()
+    factory = MagicMock(return_value=fake_session)
+
+    with patch.object(
+        telegram_worker, "get_session_factory", return_value=factory
+    ), patch(
+        "backend.bot.handlers.about_handler.cmd_about", new_callable=AsyncMock
+    ) as cmd_about, patch(
+        "backend.services.dashboard_service.get_user_by_telegram_id",
+        new_callable=AsyncMock,
+    ) as get_user:
+        await telegram_worker.route_update(
+            {"update_id": 233, "message": {"text": "/about", "chat": {"id": 456}}}
+        )
+
+    cmd_about.assert_awaited_once_with(456)
+    get_user.assert_not_awaited()
+    fake_session.commit.assert_awaited_once()
+
+
+def test_about_keyboard_has_required_buttons_one_per_row():
+    rows = about_handler.ABOUT_KEYBOARD["inline_keyboard"]
+    assert rows == [
+        [{"text": "🌐 Website Công Ty", "url": "https://nuitruc.ai"}],
+        [{"text": "🔏 Chính Sách Bảo Mật", "url": "https://nuitruc.ai/privacy"}],
+        [{"text": "📧 Hỗ Trợ", "url": "mailto:admin@nuitruc.ai"}],
+    ]
+    assert all(len(row) == 1 for row in rows)
+
+
+def test_about_command_is_in_bot_menu():
+    assert {"command": "about", "description": "Thông tin ứng dụng"} in BOT_COMMANDS

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -181,6 +181,14 @@ async def _handle_message(
         await onboarding_handlers.resume_or_start(db, chat_id, user)
         return user.id
 
+    if command == "/about":
+        # Product metadata is static and does not require a user lookup,
+        # keeping the command fast even for first-time users.
+        from backend.bot.handlers.about_handler import cmd_about
+
+        await cmd_about(chat_id)
+        return None
+
     if command in ("/menu", "menu", "/dashboard"):
         # Phase 3.6 — both top-level commands resolve the user up front so
         # the menu adapts to ``user.wealth_level`` (Epic 2) and


### PR DESCRIPTION
### Motivation
- Cung cấp lệnh `/about` để hiện trang About (phiên bản, công ty, chính sách bảo mật, hỗ trợ) nhằm tăng độ tin cậy và chuyên nghiệp của sản phẩm.
- Trả lời nhanh mà không cần truy vấn cơ sở dữ liệu để giữ trải nghiệm snappy cho người dùng.

### Description
- Thêm handler `cmd_about` tại `backend/bot/handlers/about_handler.py` trả về nội dung About và keyboard inline 3 nút (website / privacy / mail). 
- Đưa `APP_VERSION = "1.3.8.01"` vào `backend/config/__init__.py` để source phiên bản từ cấu hình tập trung.
- Đăng ký `/about` trong `BOT_COMMANDS` tại `backend/bot/setup_commands.py` với mô tả "Thông tin ứng dụng".
- Route `/about` trực tiếp trong `backend/workers/telegram_worker.py` gọi `cmd_about(chat_id)` mà không lookup user để phản hồi nhanh.
- Close #233

### Testing
- Chạy `pytest backend/tests/test_about_handler.py backend/tests/test_telegram_worker.py -q` và tất cả tests liên quan đã pass (21 passed, 7 warnings).
- Chạy `python -m compileall backend/bot/handlers/about_handler.py backend/config/__init__.py backend/workers/telegram_worker.py backend/bot/setup_commands.py` và biên dịch thành công.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb28bde374832fb58ff34577a6e93b)