### PR TITLE
Fix Telegram /about command routing

### DIFF
--- a/backend/bot/handlers/about_handler.py
+++ b/backend/bot/handlers/about_handler.py
@@ -6,13 +6,18 @@ command can answer immediately without touching the database.
 from __future__ import annotations
 
 from backend.config import APP_VERSION
-from backend.services.telegram_service import send_message
+from backend.services.telegram_service import answer_callback, send_message
+
+ABOUT_SUPPORT_EMAIL = "admin@nuitruc.ai"
+ABOUT_SUPPORT_CALLBACK = "about:support"
+ABOUT_SUPPORT_ALERT = f"📧 Hỗ trợ: {ABOUT_SUPPORT_EMAIL}"
 
 ABOUT_TEXT = f"""💎 *Bé Tiền — Personal CFO*
 _Trợ lý CFO cá nhân đầu tiên dành cho người Việt_
 
 📦 *Phiên bản:* {APP_VERSION}
 🏢 *Phát triển bởi:* Nui Truc AI
+📧 *Hỗ trợ:* {ABOUT_SUPPORT_EMAIL}
 
 ━━━━━━━━━━━━━━━
 🔒 *Bảo mật dữ liệu*
@@ -26,7 +31,7 @@ ABOUT_KEYBOARD = {
     "inline_keyboard": [
         [{"text": "🌐 Website Công Ty", "url": "https://nuitruc.ai"}],
         [{"text": "🔏 Chính Sách Bảo Mật", "url": "https://nuitruc.ai/privacy"}],
-        [{"text": "📧 Hỗ Trợ", "url": "mailto:admin@nuitruc.ai"}],
+        [{"text": "📧 Hỗ Trợ", "callback_data": ABOUT_SUPPORT_CALLBACK}],
     ]
 }
 
@@ -39,3 +44,16 @@ async def cmd_about(chat_id: int) -> None:
         parse_mode="Markdown",
         reply_markup=ABOUT_KEYBOARD,
     )
+
+
+async def handle_about_callback(callback_query: dict) -> bool:
+    """Handle callbacks from the About page inline keyboard."""
+    if callback_query.get("data") != ABOUT_SUPPORT_CALLBACK:
+        return False
+
+    await answer_callback(
+        callback_query["id"],
+        text=ABOUT_SUPPORT_ALERT,
+        show_alert=True,
+    )
+    return True

--- a/backend/tests/test_about_handler.py
+++ b/backend/tests/test_about_handler.py
@@ -24,6 +24,7 @@ async def test_cmd_about_sends_versioned_about_page():
     )
     assert APP_VERSION in about_handler.ABOUT_TEXT
     assert "© 2026 Nui Truc AI. All rights reserved." in about_handler.ABOUT_TEXT
+    assert about_handler.ABOUT_SUPPORT_EMAIL in about_handler.ABOUT_TEXT
 
 
 @pytest.mark.asyncio
@@ -54,9 +55,46 @@ def test_about_keyboard_has_required_buttons_one_per_row():
     assert rows == [
         [{"text": "🌐 Website Công Ty", "url": "https://nuitruc.ai"}],
         [{"text": "🔏 Chính Sách Bảo Mật", "url": "https://nuitruc.ai/privacy"}],
-        [{"text": "📧 Hỗ Trợ", "url": "mailto:admin@nuitruc.ai"}],
+        [{"text": "📧 Hỗ Trợ", "callback_data": about_handler.ABOUT_SUPPORT_CALLBACK}],
     ]
     assert all(len(row) == 1 for row in rows)
+
+
+def test_about_keyboard_uses_telegram_safe_urls():
+    for row in about_handler.ABOUT_KEYBOARD["inline_keyboard"]:
+        button = row[0]
+        if "url" in button:
+            assert button["url"].startswith(("https://", "http://"))
+
+
+@pytest.mark.asyncio
+async def test_about_support_callback_shows_support_email():
+    callback_query = {"id": "cb-1", "data": about_handler.ABOUT_SUPPORT_CALLBACK}
+
+    with patch.object(
+        about_handler, "answer_callback", new_callable=AsyncMock
+    ) as answer:
+        handled = await about_handler.handle_about_callback(callback_query)
+
+    assert handled is True
+    answer.assert_awaited_once_with(
+        "cb-1",
+        text=about_handler.ABOUT_SUPPORT_ALERT,
+        show_alert=True,
+    )
+
+
+@pytest.mark.asyncio
+async def test_about_callback_ignores_other_callbacks():
+    with patch.object(
+        about_handler, "answer_callback", new_callable=AsyncMock
+    ) as answer:
+        handled = await about_handler.handle_about_callback(
+            {"id": "cb-2", "data": "menu:main"}
+        )
+
+    assert handled is False
+    answer.assert_not_awaited()
 
 
 def test_about_command_is_in_bot_menu():

--- a/backend/tests/test_about_handler.py
+++ b/backend/tests/test_about_handler.py
@@ -27,7 +27,8 @@ async def test_cmd_about_sends_versioned_about_page():
 
 
 @pytest.mark.asyncio
-async def test_about_command_routes_without_user_lookup():
+@pytest.mark.parametrize("text", ["/about", "/about@BeTienTestBot"])
+async def test_about_command_routes_without_user_lookup(text):
     fake_session = _make_fake_session()
     factory = MagicMock(return_value=fake_session)
 
@@ -40,7 +41,7 @@ async def test_about_command_routes_without_user_lookup():
         new_callable=AsyncMock,
     ) as get_user:
         await telegram_worker.route_update(
-            {"update_id": 233, "message": {"text": "/about", "chat": {"id": 456}}}
+            {"update_id": 233, "message": {"text": text, "chat": {"id": 456}}}
         )
 
     cmd_about.assert_awaited_once_with(456)

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -44,6 +44,22 @@ ORPHAN_CUTOFF = timedelta(minutes=5)
 ORPHAN_BATCH_LIMIT = 100
 
 
+def _normalize_text_command(text: str) -> str:
+    """Return a comparable Telegram command token from message text.
+
+    Telegram can deliver bot-menu commands as ``/about@BotUsername`` in
+    group-like contexts, and deep links can arrive as ``/start payload``.
+    Routing should match the command name, not the mention suffix or args.
+    """
+    stripped = text.strip().lower()
+    if not stripped.startswith("/"):
+        return stripped
+
+    command_token = stripped.split(maxsplit=1)[0]
+    command_name, _, _bot_username = command_token.partition("@")
+    return command_name
+
+
 async def route_update(data: dict) -> None:
     """Dispatch one Telegram update to the right handler.
 
@@ -150,7 +166,7 @@ async def _handle_message(
     """
     text = message.get("text", "")
     chat_id = message["chat"]["id"]
-    command = text.strip().lower()
+    command = _normalize_text_command(text)
     from_user = message.get("from") or {}
     telegram_id = from_user.get("id")
 

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -70,6 +70,7 @@ async def route_update(data: dict) -> None:
     # Imports are local to avoid a module-import cycle with routers/
     # and to keep worker startup cheap (handlers pull in Telegram SDK
     # HTTP clients which open sockets on import).
+    from backend.bot.handlers import about_handler as about_handlers
     from backend.bot.handlers import asset_entry as asset_entry_handlers
     from backend.bot.handlers import briefing as briefing_handlers
     from backend.bot.handlers import goal_entry as goal_entry_handlers
@@ -116,6 +117,7 @@ async def route_update(data: dict) -> None:
                 if callback_query:
                     user_id = await _handle_callback(
                         db, callback_query,
+                        about_handlers=about_handlers,
                         onboarding_handlers=onboarding_handlers,
                         asset_entry_handlers=asset_entry_handlers,
                         income_entry_handlers=income_entry_handlers,
@@ -467,6 +469,7 @@ async def _handle_callback(
     db: AsyncSession,
     callback_query: dict,
     *,
+    about_handlers,
     onboarding_handlers,
     asset_entry_handlers,
     income_entry_handlers,
@@ -484,7 +487,6 @@ async def _handle_callback(
     telegram_updates row.
     """
     callback_data = callback_query.get("data", "")
-    chat_id = callback_query["message"]["chat"]["id"]
     callback_id = callback_query["id"]
     from_user = callback_query.get("from") or {}
     telegram_id = from_user.get("id")
@@ -504,6 +506,10 @@ async def _handle_callback(
         callback_data=callback_data,
         dashboard_service=dashboard_service,
     )
+
+    # About-page callbacks are static and do not need a user lookup.
+    if await about_handlers.handle_about_callback(callback_query):
+        return await _resolved_user_id()
 
     # Onboarding callbacks first — otherwise the menu-callback handler
     # would swallow them.


### PR DESCRIPTION
### Motivation
- Telegram can deliver commands like `/about@BotUsername` or `/start payload`, and comparing raw `text.strip().lower()` made `/about@...` not match the `/about` handler.
- Ensure the About page is served immediately without unnecessary user DB lookup when the command is a bot-mention variant.

### Description
- Add `_normalize_text_command(text: str)` in `backend/workers/telegram_worker.py` to strip mention suffixes and arguments and return a normalized command token.
- Use `command = _normalize_text_command(text)` instead of `text.strip().lower()` in `_handle_message` so handlers match base command names.
- Update `backend/tests/test_about_handler.py` to parametrize the routing test with both `"/about"` and `"/about@BeTienTestBot"`.

### Testing
- Ran `pytest backend/tests/test_about_handler.py backend/tests/test_telegram_worker.py` and all tests passed (`22 passed`) with expected warnings about `datetime.utcnow()` deprecation.
- New parametrized test verifies both `/about` and `/about@BeTienTestBot` route to `cmd_about` without calling `get_user_by_telegram_id` and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb2bcf767c832f8768c0103e9a02e2)