### PR TITLE
Update /about product positioning

### DIFF
--- a/backend/bot/handlers/about_handler.py
+++ b/backend/bot/handlers/about_handler.py
@@ -12,8 +12,8 @@ ABOUT_SUPPORT_EMAIL = "admin@nuitruc.ai"
 ABOUT_SUPPORT_CALLBACK = "about:support"
 ABOUT_SUPPORT_ALERT = f"📧 Hỗ trợ: {ABOUT_SUPPORT_EMAIL}"
 
-ABOUT_TEXT = f"""💎 *Bé Tiền — Personal CFO*
-_Trợ lý CFO cá nhân đầu tiên dành cho người Việt_
+ABOUT_TEXT = f"""💎 *Bé Tiền*
+_Trợ lý quản lý Tài sản cá nhân đầu tiên dành cho người Việt_
 
 📦 *Phiên bản:* {APP_VERSION}
 🏢 *Phát triển bởi:* Nui Truc AI

--- a/backend/tests/test_about_handler.py
+++ b/backend/tests/test_about_handler.py
@@ -23,6 +23,13 @@ async def test_cmd_about_sends_versioned_about_page():
         reply_markup=about_handler.ABOUT_KEYBOARD,
     )
     assert APP_VERSION in about_handler.ABOUT_TEXT
+    assert "💎 *Bé Tiền*" in about_handler.ABOUT_TEXT
+    assert "Personal CFO" not in about_handler.ABOUT_TEXT
+    assert (
+        "Trợ lý quản lý Tài sản cá nhân đầu tiên dành cho người Việt"
+        in about_handler.ABOUT_TEXT
+    )
+    assert "Trợ lý CFO cá nhân" not in about_handler.ABOUT_TEXT
     assert "© 2026 Nui Truc AI. All rights reserved." in about_handler.ABOUT_TEXT
     assert about_handler.ABOUT_SUPPORT_EMAIL in about_handler.ABOUT_TEXT
 


### PR DESCRIPTION
### Motivation
- Cập nhật copy trang `/about` để loại bỏ "Personal CFO" ở tiêu đề và thay subtitle thành "Trợ lý quản lý Tài sản cá nhân đầu tiên dành cho người Việt" nhằm khớp với định vị sản phẩm.

### Description
- Thay đổi `ABOUT_TEXT` trong `backend/bot/handlers/about_handler.py` để bỏ cụm "Personal CFO" và đổi dòng phụ đề.
- Cập nhật assertions trong `backend/tests/test_about_handler.py` để kiểm tra copy mới và đảm bảo copy cũ không còn xuất hiện.

### Testing
- Chạy `pytest backend/tests/test_about_handler.py` và tất cả test đều thành công (`8 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb7141a454832fa0f19f7449ce097f)