### PR TITLE
Implement Phase 3.8.5 Epic 1 feedback system

### DIFF
--- a/alembic/versions/n3h4i5j6k7l8_phase385_feedback_system.py
+++ b/alembic/versions/n3h4i5j6k7l8_phase385_feedback_system.py
@@ -1,0 +1,99 @@
+"""phase 3.8.5 epic 1 — feedback system
+
+Revision ID: n3h4i5j6k7l8
+Revises: m2g3h4i5j6k7
+Create Date: 2026-05-07 09:00:00.000000
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+
+revision: str = "n3h4i5j6k7l8"
+down_revision: Union[str, Sequence[str], None] = "m2g3h4i5j6k7"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "feedbacks",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("content", sa.Text(), nullable=False),
+        sa.Column("category", sa.String(50), nullable=True),
+        sa.Column("sentiment", sa.String(20), nullable=True),
+        sa.Column("priority", sa.String(20), nullable=True),
+        sa.Column("classification_confidence", sa.Float(), nullable=True),
+        sa.Column("classifier_version", sa.String(50), nullable=True),
+        sa.Column("classification_attempts", sa.Integer(), nullable=False, server_default=sa.text("0")),
+        sa.Column("classification_error", sa.Text(), nullable=True),
+        sa.Column("trigger", sa.String(80), nullable=False, server_default=sa.text("'passive_command'")),
+        sa.Column("context", postgresql.JSONB(), nullable=True),
+        sa.Column("status", sa.String(20), nullable=False, server_default=sa.text("'new'")),
+        sa.Column("admin_notes", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_feedbacks_user_id", "feedbacks", ["user_id"])
+    op.create_index("ix_feedbacks_category", "feedbacks", ["category"])
+    op.create_index("ix_feedbacks_sentiment", "feedbacks", ["sentiment"])
+    op.create_index("ix_feedbacks_priority", "feedbacks", ["priority"])
+    op.create_index("ix_feedbacks_trigger", "feedbacks", ["trigger"])
+    op.create_index("ix_feedbacks_status", "feedbacks", ["status"])
+    op.create_index("ix_feedbacks_created_at", "feedbacks", ["created_at"])
+    op.create_index("idx_feedbacks_user_created_at", "feedbacks", ["user_id", "created_at"])
+    op.create_index(
+        "idx_feedbacks_unclassified",
+        "feedbacks",
+        ["created_at"],
+        postgresql_where=sa.text("category IS NULL"),
+    )
+
+    op.create_table(
+        "prompts_sent_log",
+        sa.Column("id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), nullable=False),
+        sa.Column("prompt_id", sa.String(80), nullable=False),
+        sa.Column("trigger", sa.String(80), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False, server_default=sa.text("'sent'")),
+        sa.Column("context", postgresql.JSONB(), nullable=True),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=False, server_default=sa.text("now()")),
+        sa.Column("responded_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("skipped_at", sa.DateTime(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["user_id"], ["users.id"]),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_prompts_sent_log_user_id", "prompts_sent_log", ["user_id"])
+    op.create_index("ix_prompts_sent_log_prompt_id", "prompts_sent_log", ["prompt_id"])
+    op.create_index("ix_prompts_sent_log_trigger", "prompts_sent_log", ["trigger"])
+    op.create_index("ix_prompts_sent_log_status", "prompts_sent_log", ["status"])
+    op.create_index("ix_prompts_sent_log_sent_at", "prompts_sent_log", ["sent_at"])
+    op.create_index("idx_prompts_user_prompt_sent", "prompts_sent_log", ["user_id", "prompt_id", "sent_at"])
+    op.create_index("idx_prompts_user_sent", "prompts_sent_log", ["user_id", "sent_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_prompts_user_sent", table_name="prompts_sent_log")
+    op.drop_index("idx_prompts_user_prompt_sent", table_name="prompts_sent_log")
+    op.drop_index("ix_prompts_sent_log_sent_at", table_name="prompts_sent_log")
+    op.drop_index("ix_prompts_sent_log_status", table_name="prompts_sent_log")
+    op.drop_index("ix_prompts_sent_log_trigger", table_name="prompts_sent_log")
+    op.drop_index("ix_prompts_sent_log_prompt_id", table_name="prompts_sent_log")
+    op.drop_index("ix_prompts_sent_log_user_id", table_name="prompts_sent_log")
+    op.drop_table("prompts_sent_log")
+
+    op.drop_index("idx_feedbacks_unclassified", table_name="feedbacks")
+    op.drop_index("idx_feedbacks_user_created_at", table_name="feedbacks")
+    op.drop_index("ix_feedbacks_created_at", table_name="feedbacks")
+    op.drop_index("ix_feedbacks_status", table_name="feedbacks")
+    op.drop_index("ix_feedbacks_trigger", table_name="feedbacks")
+    op.drop_index("ix_feedbacks_priority", table_name="feedbacks")
+    op.drop_index("ix_feedbacks_sentiment", table_name="feedbacks")
+    op.drop_index("ix_feedbacks_category", table_name="feedbacks")
+    op.drop_index("ix_feedbacks_user_id", table_name="feedbacks")
+    op.drop_table("feedbacks")

--- a/backend/bot/handlers/briefing.py
+++ b/backend/bot/handlers/briefing.py
@@ -158,6 +158,11 @@ async def handle_briefing_callback(
 
     await answer_callback(callback_id)
     await _record_open_if_first(db, user.id)
+    from backend.feedback.services.prompt_scheduler import check_briefing_read_prompt
+    try:
+        await check_briefing_read_prompt(db, user.id)
+    except Exception:
+        logger.exception("briefing feedback prompt hook failed")
 
     event_type = _ACTION_TO_EVENT.get(action)
     if event_type:

--- a/backend/bot/setup_commands.py
+++ b/backend/bot/setup_commands.py
@@ -40,6 +40,7 @@ BOT_COMMANDS: list[dict[str, str]] = [
     {"command": "menu", "description": "Menu chính"},
     {"command": "help", "description": "Hướng dẫn sử dụng"},
     {"command": "dashboard", "description": "Mở Mini App dashboard"},
+    {"command": "feedback", "description": "Gửi góp ý nhanh"},
     {"command": "about", "description": "Thông tin ứng dụng"},
 ]
 

--- a/backend/feedback/__init__.py
+++ b/backend/feedback/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3.8.5 feedback system package."""

--- a/backend/feedback/handlers/feedback_command.py
+++ b/backend/feedback/handlers/feedback_command.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.feedback.models.feedback import PROMPT_STATUS_RESPONDED
+from backend.feedback.services import feedback_service
+from backend.feedback.services.prompt_scheduler import PromptScheduler
+from backend.models.user import User
+from backend.services import wizard_service
+from backend.services.telegram_service import answer_callback, send_message
+
+FLOW_FEEDBACK = "feedback"
+STEP_AWAITING_TEXT = "awaiting_feedback_text"
+
+START_MESSAGE = (
+    "Bé Tiền luôn muốn lắng nghe bạn 💚\n\n"
+    "Bạn cứ nhắn tự nhiên: lỗi gặp phải, điều thích/chưa thích, hoặc tính năng mong muốn."
+)
+CONFIRMATION_MESSAGE = (
+    "✅ Đã ghi nhận! Cảm ơn bạn rất nhiều 💚\n"
+    "Team Bé Tiền sẽ review trong vòng 7 ngày."
+)
+CANCEL_MESSAGE = "Đã huỷ gửi feedback rồi nè. Khi nào muốn góp ý, bạn gõ /feedback nhé 💚"
+
+
+async def start_feedback(db: AsyncSession, chat_id: int, user: User, *, trigger: str = "passive_command") -> None:
+    await wizard_service.start(
+        db,
+        user.id,
+        flow=FLOW_FEEDBACK,
+        step=STEP_AWAITING_TEXT,
+        draft={"trigger": trigger},
+    )
+    await send_message(chat_id, START_MESSAGE, parse_mode="Markdown")
+
+
+async def handle_feedback_text_input(db: AsyncSession, message: dict) -> bool:
+    text = message.get("text") or ""
+    chat_id = message["chat"]["id"]
+    telegram_id = (message.get("from") or {}).get("id")
+    if telegram_id is None:
+        return False
+
+    from backend.services.dashboard_service import get_user_by_telegram_id
+
+    user = await get_user_by_telegram_id(db, telegram_id)
+    if user is None or (user.wizard_state or {}).get("flow") != FLOW_FEEDBACK:
+        return False
+
+    if text.strip().lower() in {"/cancel", "/huy"}:
+        await wizard_service.clear(db, user.id)
+        await send_message(chat_id, CANCEL_MESSAGE, parse_mode="Markdown")
+        return True
+
+    trigger = (user.wizard_state or {}).get("draft", {}).get("trigger") or "passive_command"
+    try:
+        await feedback_service.create_feedback(db, user, text, trigger=trigger)
+    except feedback_service.FeedbackValidationError as exc:
+        await send_message(chat_id, str(exc), parse_mode="Markdown")
+        return True
+
+    if trigger != "passive_command":
+        log = await PromptScheduler()._latest_prompt_log(db, user.id, trigger)
+        if log:
+            log.status = PROMPT_STATUS_RESPONDED
+            log.responded_at = datetime.now(timezone.utc)
+
+    await wizard_service.clear(db, user.id)
+    await send_message(chat_id, CONFIRMATION_MESSAGE, parse_mode="Markdown")
+    return True
+
+
+async def handle_feedback_callback(db: AsyncSession, callback_query: dict) -> bool:
+    data = callback_query.get("data") or ""
+    if not data.startswith("feedback:"):
+        return False
+    callback_id = callback_query["id"]
+    parts = data.split(":", 2)
+    if len(parts) != 3:
+        await answer_callback(callback_id)
+        return True
+    action, prompt_id = parts[1], parts[2]
+    from_user = callback_query.get("from") or {}
+    telegram_id = from_user.get("id")
+
+    from backend.services.dashboard_service import get_user_by_telegram_id
+
+    user = await get_user_by_telegram_id(db, telegram_id) if telegram_id is not None else None
+    if user is None:
+        await answer_callback(callback_id, "Không tìm thấy hồ sơ người dùng.")
+        return True
+
+    if action == "skip":
+        await PromptScheduler().log_skip(db, user.id, prompt_id)
+        await answer_callback(callback_id, "Đã ghi nhận, để sau nhé 💚")
+        return True
+    if action == "cta":
+        await wizard_service.start(
+            db,
+            user.id,
+            flow=FLOW_FEEDBACK,
+            step=STEP_AWAITING_TEXT,
+            draft={"trigger": prompt_id},
+        )
+        chat_id = callback_query.get("message", {}).get("chat", {}).get("id") or user.telegram_id
+        await answer_callback(callback_id)
+        await send_message(chat_id, "Bạn nhắn cảm nhận của mình ở đây nhé 💚", parse_mode="Markdown")
+        return True
+
+    await answer_callback(callback_id)
+    return True

--- a/backend/feedback/models/__init__.py
+++ b/backend/feedback/models/__init__.py
@@ -1,0 +1,3 @@
+from backend.feedback.models.feedback import Feedback, PromptSentLog
+
+__all__ = ["Feedback", "PromptSentLog"]

--- a/backend/feedback/models/feedback.py
+++ b/backend/feedback/models/feedback.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+
+from sqlalchemy import DateTime, Float, ForeignKey, Index, Integer, String, Text, text
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+FEEDBACK_STATUS_NEW = "new"
+FEEDBACK_STATUS_REVIEWING = "reviewing"
+FEEDBACK_STATUS_ACTIONED = "actioned"
+FEEDBACK_STATUS_DISMISSED = "dismissed"
+
+PROMPT_STATUS_SENT = "sent"
+PROMPT_STATUS_SKIPPED = "skipped"
+PROMPT_STATUS_RESPONDED = "responded"
+
+
+class Feedback(Base):
+    """Free-form user feedback with deferred backend classification."""
+
+    __tablename__ = "feedbacks"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+
+    category: Mapped[str | None] = mapped_column(String(50), index=True)
+    sentiment: Mapped[str | None] = mapped_column(String(20), index=True)
+    priority: Mapped[str | None] = mapped_column(String(20), index=True)
+    classification_confidence: Mapped[float | None] = mapped_column(Float)
+    classifier_version: Mapped[str | None] = mapped_column(String(50))
+    classification_attempts: Mapped[int] = mapped_column(Integer, default=0, nullable=False)
+    classification_error: Mapped[str | None] = mapped_column(Text)
+
+    trigger: Mapped[str] = mapped_column(String(80), default="passive_command", nullable=False, index=True)
+    context: Mapped[dict | None] = mapped_column(JSONB)
+
+    status: Mapped[str] = mapped_column(String(20), default=FEEDBACK_STATUS_NEW, nullable=False, index=True)
+    admin_notes: Mapped[str | None] = mapped_column(Text)
+
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False, index=True)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("idx_feedbacks_user_created_at", "user_id", "created_at"),
+        Index(
+            "idx_feedbacks_unclassified",
+            "created_at",
+            postgresql_where=text("category IS NULL"),
+        ),
+    )
+
+
+class PromptSentLog(Base):
+    """Audit table for active feedback prompts and user responses."""
+
+    __tablename__ = "prompts_sent_log"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), primary_key=True, default=uuid.uuid4
+    )
+    user_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True), ForeignKey("users.id"), nullable=False, index=True
+    )
+    prompt_id: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    trigger: Mapped[str] = mapped_column(String(80), nullable=False, index=True)
+    status: Mapped[str] = mapped_column(String(20), default=PROMPT_STATUS_SENT, nullable=False, index=True)
+    context: Mapped[dict | None] = mapped_column(JSONB)
+    sent_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False, index=True)
+    responded_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+    skipped_at: Mapped[datetime | None] = mapped_column(DateTime(timezone=True))
+
+    __table_args__ = (
+        Index("idx_prompts_user_prompt_sent", "user_id", "prompt_id", "sent_at"),
+        Index("idx_prompts_user_sent", "user_id", "sent_at"),
+    )

--- a/backend/feedback/services/__init__.py
+++ b/backend/feedback/services/__init__.py
@@ -1,0 +1,1 @@
+"""Feedback services."""

--- a/backend/feedback/services/classifier.py
+++ b/backend/feedback/services/classifier.py
@@ -1,0 +1,137 @@
+from __future__ import annotations
+
+import json
+import logging
+import re
+from typing import Any
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.feedback.models.feedback import Feedback
+from backend.feedback.services.feedback_service import list_unclassified_feedbacks
+from backend.services.llm_service import LLMError, call_llm
+
+logger = logging.getLogger(__name__)
+
+CLASSIFIER_VERSION = "feedback-v1-deepseek-2026-05"
+VALID_CATEGORIES = {"bug", "suggestion", "praise", "question", "complaint", "other"}
+VALID_SENTIMENTS = {"positive", "neutral", "negative"}
+VALID_PRIORITIES = {"high", "medium", "low"}
+
+PROMPT_TEMPLATE = """Bạn là hệ thống phân loại feedback cho app tài chính cá nhân Bé Tiền.
+
+Nhiệm vụ: đọc feedback tiếng Việt/Anh bên dưới và trả về JSON hợp lệ, không markdown, không giải thích.
+
+Schema bắt buộc:
+{{
+  "category": "bug|suggestion|praise|question|complaint|other",
+  "sentiment": "positive|neutral|negative",
+  "priority": "high|medium|low",
+  "confidence": 0.0
+}}
+
+Luật nhanh:
+- bug: lỗi kỹ thuật, bot không chạy, sai số liệu, crash, command không phản hồi.
+- suggestion: đề xuất tính năng/cải tiến.
+- praise: khen, hài lòng.
+- question: hỏi cách dùng/chính sách.
+- complaint: bực bội, chê trải nghiệm, mất niềm tin.
+- other: không rõ.
+- priority high nếu có mất dữ liệu/không dùng được/sai tiền nghiêm trọng; medium nếu ảnh hưởng UX; low nếu nice-to-have/khen.
+
+Feedback: {content}
+"""
+
+
+def _fallback() -> dict[str, Any]:
+    return {
+        "category": "other",
+        "sentiment": "neutral",
+        "priority": "low",
+        "confidence": 0.0,
+        "classifier_version": CLASSIFIER_VERSION,
+    }
+
+
+def _extract_json(raw: str) -> dict[str, Any]:
+    text = (raw or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?", "", text, flags=re.IGNORECASE).strip()
+        text = re.sub(r"```$", "", text).strip()
+    start = text.find("{")
+    end = text.rfind("}")
+    if start >= 0 and end > start:
+        text = text[start : end + 1]
+    return json.loads(text)
+
+
+class FeedbackClassifier:
+    """DeepSeek-backed classifier with deterministic safe fallback."""
+
+    def __init__(self, *, version: str = CLASSIFIER_VERSION) -> None:
+        self.version = version
+
+    async def classify(
+        self,
+        content: str,
+        *,
+        db: AsyncSession | None = None,
+    ) -> dict[str, Any]:
+        prompt = PROMPT_TEMPLATE.format(content=(content or "").strip()[:5000])
+        try:
+            raw = await call_llm(
+                prompt,
+                task_type="feedback_classify",
+                db=db,
+                use_cache=True,
+                shared_cache=True,
+            )
+            data = _extract_json(raw)
+        except (LLMError, json.JSONDecodeError, TypeError, ValueError) as exc:
+            logger.warning("Feedback classification fallback: %s", exc)
+            return _fallback()
+
+        category = str(data.get("category", "other")).strip().lower()
+        sentiment = str(data.get("sentiment", "neutral")).strip().lower()
+        priority = str(data.get("priority", "low")).strip().lower()
+        try:
+            confidence = float(data.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+
+        return {
+            "category": category if category in VALID_CATEGORIES else "other",
+            "sentiment": sentiment if sentiment in VALID_SENTIMENTS else "neutral",
+            "priority": priority if priority in VALID_PRIORITIES else "low",
+            "confidence": max(0.0, min(1.0, confidence)),
+            "classifier_version": self.version,
+        }
+
+
+async def classify_feedback_batch(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+    max_attempts: int = 3,
+    classifier: FeedbackClassifier | None = None,
+) -> int:
+    classifier = classifier or FeedbackClassifier()
+    feedbacks = await list_unclassified_feedbacks(db, limit=limit, max_attempts=max_attempts)
+    processed = 0
+    for feedback in feedbacks:
+        try:
+            feedback.classification_attempts = (feedback.classification_attempts or 0) + 1
+            result = await classifier.classify(feedback.content, db=db)
+            feedback.category = result["category"]
+            feedback.sentiment = result["sentiment"]
+            feedback.priority = result["priority"]
+            feedback.classification_confidence = result["confidence"]
+            feedback.classifier_version = result["classifier_version"]
+            feedback.classification_error = None
+            processed += 1
+        except Exception as exc:  # noqa: BLE001 - worker must keep processing other rows.
+            feedback.classification_attempts = (feedback.classification_attempts or 0) + 1
+            feedback.classification_error = str(exc)[:2000]
+            logger.exception("Failed to classify feedback id=%s", feedback.id)
+    await db.flush()
+    return processed

--- a/backend/feedback/services/feedback_service.py
+++ b/backend/feedback/services/feedback_service.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend import analytics
+from backend.feedback.models.feedback import Feedback
+from backend.models.event import Event
+from backend.models.user import User
+
+APP_VERSION = "phase-3.8.5"
+MAX_FEEDBACK_PER_DAY = 5
+MIN_FEEDBACK_CHARS = 5
+MAX_FEEDBACK_CHARS = 5000
+
+
+class FeedbackValidationError(ValueError):
+    """Raised when feedback cannot be accepted from the user."""
+
+
+class FeedbackRateLimitError(FeedbackValidationError):
+    """Raised when user has sent too many feedbacks today."""
+
+
+async def count_feedbacks_since(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    since: datetime,
+) -> int:
+    stmt = select(func.count()).where(
+        Feedback.user_id == user_id,
+        Feedback.created_at >= since,
+    )
+    return int((await db.execute(stmt)).scalar_one() or 0)
+
+
+async def validate_feedback_text(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    content: str,
+    *,
+    now: datetime | None = None,
+) -> str:
+    normalized = (content or "").strip()
+    if len(normalized) < MIN_FEEDBACK_CHARS:
+        raise FeedbackValidationError("Feedback hơi ngắn quá nè. Bạn viết thêm vài chữ giúp Bé Tiền nhé 💚")
+    if len(normalized) > MAX_FEEDBACK_CHARS:
+        raise FeedbackValidationError("Feedback dài quá rồi nè (tối đa 5.000 ký tự). Bạn rút gọn giúp Bé Tiền nhé 💚")
+
+    current_time = now or datetime.now(timezone.utc)
+    day_start = current_time - timedelta(days=1)
+    sent_today = await count_feedbacks_since(db, user_id, day_start)
+    if sent_today >= MAX_FEEDBACK_PER_DAY:
+        raise FeedbackRateLimitError("Bạn đã gửi 5 feedback trong 24 giờ qua rồi. Mai gửi tiếp giúp Bé Tiền nhé 💚")
+    return normalized
+
+
+class ContextSnapshotService:
+    """Capture non-PII context at feedback submission time."""
+
+    async def capture(self, db: AsyncSession, user: User) -> dict[str, Any]:
+        account_age_days = None
+        if user.created_at:
+            created_at = user.created_at
+            if created_at.tzinfo is None:
+                created_at = created_at.replace(tzinfo=timezone.utc)
+            account_age_days = max(
+                0,
+                (datetime.now(timezone.utc) - created_at).days,
+            )
+
+        return {
+            "wealth_level": user.wealth_level or "unknown",
+            "account_age_days": account_age_days,
+            "recent_actions": await self._recent_actions(db, user.id),
+            "active_features": self._active_features(user),
+            "app_version": APP_VERSION,
+        }
+
+    async def _recent_actions(self, db: AsyncSession, user_id: uuid.UUID) -> list[dict[str, Any]]:
+        stmt = (
+            select(Event.event_type, Event.timestamp)
+            .where(Event.user_id == user_id)
+            .order_by(Event.timestamp.desc())
+            .limit(5)
+        )
+        rows = (await db.execute(stmt)).all()
+        return [
+            {
+                "event_type": row.event_type,
+                "timestamp": row.timestamp.isoformat() if row.timestamp else None,
+            }
+            for row in rows
+        ]
+
+    def _active_features(self, user: User) -> list[str]:
+        features = ["feedback", "menu", "dashboard"]
+        if user.briefing_enabled:
+            features.append("morning_briefing")
+        if user.wizard_state:
+            flow = user.wizard_state.get("flow")
+            if flow:
+                features.append(f"wizard:{flow}")
+        return features
+
+
+async def create_feedback(
+    db: AsyncSession,
+    user: User,
+    content: str,
+    *,
+    trigger: str = "passive_command",
+    context: dict[str, Any] | None = None,
+) -> Feedback:
+    normalized = await validate_feedback_text(db, user.id, content)
+    snapshot = context or await ContextSnapshotService().capture(db, user)
+    feedback = Feedback(
+        user_id=user.id,
+        content=normalized,
+        trigger=trigger,
+        context=snapshot,
+    )
+    db.add(feedback)
+    await db.flush()
+    analytics.track(
+        "feedback_submitted",
+        user_id=user.id,
+        properties={"trigger": trigger, "wealth_level": user.wealth_level or "unknown"},
+    )
+    return feedback
+
+
+async def list_unclassified_feedbacks(
+    db: AsyncSession,
+    *,
+    limit: int = 50,
+    max_attempts: int = 3,
+) -> list[Feedback]:
+    stmt = (
+        select(Feedback)
+        .where(
+            Feedback.category.is_(None),
+            Feedback.classification_attempts < max_attempts,
+        )
+        .order_by(Feedback.created_at.asc())
+        .limit(limit)
+    )
+    return list((await db.execute(stmt)).scalars().all())

--- a/backend/feedback/services/prompt_scheduler.py
+++ b/backend/feedback/services/prompt_scheduler.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+import yaml
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend import analytics
+from backend.feedback.models.feedback import PROMPT_STATUS_SENT, PROMPT_STATUS_SKIPPED, PromptSentLog
+from backend.feedback.services.feedback_service import APP_VERSION, ContextSnapshotService
+from backend.models.event import Event
+from backend.models.goal import Goal
+from backend.models.user import User
+from backend.services.telegram_service import send_telegram
+
+PROMPTS_PATH = Path(__file__).resolve().parents[3] / "content" / "feedback_prompts.yaml"
+MAX_ACTIVE_PROMPTS_PER_30_DAYS = 2
+
+
+@dataclass(frozen=True)
+class FeedbackPrompt:
+    id: str
+    trigger: str
+    message: str
+    cta_button: str
+    skip_button: str
+    cooldown_days: int
+
+
+def load_prompts(path: Path = PROMPTS_PATH) -> list[FeedbackPrompt]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    return [FeedbackPrompt(**item) for item in data.get("prompts", [])]
+
+
+class PromptScheduler:
+    """Strict active feedback prompt scheduler.
+
+    It checks milestone conditions, prompt-specific cooldown, then the hard
+    max-2-prompts/30-days cap before sending a Telegram message.
+    """
+
+    def __init__(self, prompts: list[FeedbackPrompt] | None = None) -> None:
+        self.prompts = prompts or load_prompts()
+
+    async def check_and_send_prompts(
+        self,
+        db: AsyncSession,
+        user_id: uuid.UUID,
+        *,
+        event: str | None = None,
+        now: datetime | None = None,
+    ) -> list[str]:
+        user = await db.get(User, user_id)
+        if user is None or not user.is_active:
+            return []
+        current_time = now or datetime.now(timezone.utc)
+        metrics = await self._metrics(db, user, now=current_time)
+        sent: list[str] = []
+        for prompt in self.prompts:
+            if event and event != "daily" and prompt.id != event and not self._event_matches_prompt(event, prompt.id):
+                continue
+            if event == "daily" and prompt.id not in {"post_onboarding_day_7", "post_3_months_active"}:
+                continue
+            if not self._condition_met(prompt, metrics):
+                continue
+            if await self._within_prompt_cooldown(db, user.id, prompt, now=current_time):
+                continue
+            if await self._hit_monthly_rate_limit(db, user.id, now=current_time):
+                break
+            await self._send_prompt(db, user, prompt, metrics)
+            sent.append(prompt.id)
+        return sent
+
+    async def send_prompt(
+        self,
+        db: AsyncSession,
+        user: User,
+        prompt_id: str,
+        *,
+        now: datetime | None = None,
+    ) -> bool:
+        prompt = next((item for item in self.prompts if item.id == prompt_id), None)
+        if prompt is None:
+            return False
+        current_time = now or datetime.now(timezone.utc)
+        if await self._within_prompt_cooldown(db, user.id, prompt, now=current_time):
+            return False
+        if await self._hit_monthly_rate_limit(db, user.id, now=current_time):
+            return False
+        metrics = await self._metrics(db, user, now=current_time)
+        await self._send_prompt(db, user, prompt, metrics)
+        return True
+
+    async def log_skip(self, db: AsyncSession, user_id: uuid.UUID, prompt_id: str) -> None:
+        log = await self._latest_prompt_log(db, user_id, prompt_id)
+        if log:
+            log.status = PROMPT_STATUS_SKIPPED
+            log.skipped_at = datetime.now(timezone.utc)
+            await db.flush()
+
+    def _event_matches_prompt(self, event: str, prompt_id: str) -> bool:
+        mapping = {
+            "briefing_read": "post_briefing_30_reads",
+            "goal_completed": "post_first_goal_completed",
+            "phase_4_first_view": "post_phase_4_launch",
+            "daily": "",
+        }
+        return mapping.get(event) == prompt_id
+
+    async def _metrics(self, db: AsyncSession, user: User, *, now: datetime) -> dict[str, Any]:
+        created_at = user.created_at
+        if created_at and created_at.tzinfo is None:
+            created_at = created_at.replace(tzinfo=timezone.utc)
+        account_age_days = (now - created_at).days if created_at else 0
+
+        briefing_count = await self._event_count(db, user.id, analytics.EventType.MORNING_BRIEFING_OPENED)
+        phase_4_count = await self._event_count(db, user.id, "phase_4_first_view")
+        goals_completed = int((await db.execute(select(func.count()).where(
+            Goal.user_id == user.id,
+            Goal.status == "completed",
+            Goal.deleted_at.is_(None),
+        ))).scalar_one() or 0)
+        return {
+            "account_age_days": account_age_days,
+            "briefing_read_count": briefing_count,
+            "goals_completed_count": goals_completed,
+            "phase_4_first_view": phase_4_count > 0,
+            "app_version": APP_VERSION,
+        }
+
+    async def _event_count(self, db: AsyncSession, user_id: uuid.UUID, event_type: str) -> int:
+        stmt = select(func.count()).where(Event.user_id == user_id, Event.event_type == event_type)
+        return int((await db.execute(stmt)).scalar_one() or 0)
+
+    def _condition_met(self, prompt: FeedbackPrompt, metrics: dict[str, Any]) -> bool:
+        return {
+            "post_onboarding_day_7": metrics["account_age_days"] == 7,
+            "post_briefing_30_reads": metrics["briefing_read_count"] == 30,
+            "post_first_goal_completed": metrics["goals_completed_count"] == 1,
+            "post_phase_4_launch": metrics["phase_4_first_view"] is True,
+            "post_3_months_active": metrics["account_age_days"] == 90,
+        }.get(prompt.id, False)
+
+    async def _within_prompt_cooldown(
+        self,
+        db: AsyncSession,
+        user_id: uuid.UUID,
+        prompt: FeedbackPrompt,
+        *,
+        now: datetime,
+    ) -> bool:
+        since = now - timedelta(days=prompt.cooldown_days)
+        stmt = select(func.count()).where(
+            PromptSentLog.user_id == user_id,
+            PromptSentLog.prompt_id == prompt.id,
+            PromptSentLog.sent_at >= since,
+        )
+        return int((await db.execute(stmt)).scalar_one() or 0) > 0
+
+    async def _hit_monthly_rate_limit(self, db: AsyncSession, user_id: uuid.UUID, *, now: datetime) -> bool:
+        since = now - timedelta(days=30)
+        stmt = select(func.count()).where(
+            PromptSentLog.user_id == user_id,
+            PromptSentLog.sent_at >= since,
+        )
+        return int((await db.execute(stmt)).scalar_one() or 0) >= MAX_ACTIVE_PROMPTS_PER_30_DAYS
+
+    async def _latest_prompt_log(self, db: AsyncSession, user_id: uuid.UUID, prompt_id: str) -> PromptSentLog | None:
+        stmt = (
+            select(PromptSentLog)
+            .where(PromptSentLog.user_id == user_id, PromptSentLog.prompt_id == prompt_id)
+            .order_by(PromptSentLog.sent_at.desc())
+            .limit(1)
+        )
+        return (await db.execute(stmt)).scalar_one_or_none()
+
+    async def _send_prompt(
+        self,
+        db: AsyncSession,
+        user: User,
+        prompt: FeedbackPrompt,
+        metrics: dict[str, Any],
+    ) -> None:
+        snapshot = await ContextSnapshotService().capture(db, user)
+        snapshot.update(metrics)
+        log = PromptSentLog(
+            user_id=user.id,
+            prompt_id=prompt.id,
+            trigger=prompt.id,
+            status=PROMPT_STATUS_SENT,
+            context=snapshot,
+        )
+        db.add(log)
+        await db.flush()
+        await send_telegram(
+            "sendMessage",
+            {
+                "chat_id": user.telegram_id,
+                "text": prompt.message,
+                "reply_markup": {
+                    "inline_keyboard": [[
+                        {"text": prompt.cta_button, "callback_data": f"feedback:cta:{prompt.id}"},
+                        {"text": prompt.skip_button, "callback_data": f"feedback:skip:{prompt.id}"},
+                    ]]
+                },
+            },
+        )
+
+
+async def check_briefing_read_prompt(db: AsyncSession, user_id: uuid.UUID) -> list[str]:
+    return await PromptScheduler().check_and_send_prompts(db, user_id, event="briefing_read")
+
+
+async def check_goal_completed_prompt(db: AsyncSession, user_id: uuid.UUID) -> list[str]:
+    return await PromptScheduler().check_and_send_prompts(db, user_id, event="goal_completed")
+
+
+async def check_daily_feedback_prompts(db: AsyncSession, user_id: uuid.UUID) -> list[str]:
+    return await PromptScheduler().check_and_send_prompts(db, user_id, event="daily")

--- a/backend/jobs/feedback_classifier_job.py
+++ b/backend/jobs/feedback_classifier_job.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import logging
+
+from backend.database import get_session_factory
+from backend.feedback.services.classifier import classify_feedback_batch
+
+logger = logging.getLogger(__name__)
+
+
+async def run_feedback_classifier_batch(limit: int = 50) -> int:
+    """Process unclassified feedback rows once.
+
+    Intended for APScheduler/cron. Retries are represented by
+    feedback.classification_attempts and capped in the service query.
+    """
+    session_factory = get_session_factory()
+    async with session_factory() as db:
+        try:
+            processed = await classify_feedback_batch(db, limit=limit)
+            await db.commit()
+            return processed
+        except Exception:
+            await db.rollback()
+            logger.exception("Feedback classifier batch failed")
+            raise

--- a/backend/jobs/feedback_prompt_job.py
+++ b/backend/jobs/feedback_prompt_job.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy import select
+
+from backend.database import get_session_factory
+from backend.feedback.services.prompt_scheduler import PromptScheduler
+from backend.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+async def run_daily_feedback_prompt_check() -> int:
+    """Daily 9 AM active-prompt scan for time-based feedback triggers."""
+    session_factory = get_session_factory()
+    sent_count = 0
+    async with session_factory() as db:
+        users = list((await db.execute(select(User).where(User.deleted_at.is_(None), User.is_active.is_(True)))).scalars().all())
+        scheduler = PromptScheduler()
+        for user in users:
+            sent_count += len(await scheduler.check_and_send_prompts(db, user.id, event="daily"))
+        await db.commit()
+    logger.info("Daily feedback prompt check sent %s prompt(s)", sent_count)
+    return sent_count

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -17,6 +17,7 @@ from backend.models.telegram_update import (
     TelegramUpdate,
 )
 from backend.models.agent_audit_log import AgentAuditLog
+from backend.feedback.models.feedback import Feedback, PromptSentLog
 from backend.models.conversation_context import (
     ROLE_ASSISTANT,
     ROLE_USER,
@@ -42,6 +43,8 @@ __all__ = [
     "STATUS_DONE",
     "STATUS_FAILED",
     "AgentAuditLog",
+    "Feedback",
+    "PromptSentLog",
     "ConversationContext",
     "ROLE_USER",
     "ROLE_ASSISTANT",

--- a/backend/services/goal_service.py
+++ b/backend/services/goal_service.py
@@ -10,6 +10,7 @@ Layer contract: service flushes only — caller commits.
 """
 from __future__ import annotations
 
+import logging
 import uuid
 from datetime import datetime
 from decimal import Decimal
@@ -24,6 +25,18 @@ from backend.schemas.goal import (
     GoalProgressUpdate,
     GoalUpdate,
 )
+
+
+logger = logging.getLogger(__name__)
+
+
+async def _try_goal_completed_feedback_prompt(db: AsyncSession, user_id: uuid.UUID) -> None:
+    from backend.feedback.services.prompt_scheduler import check_goal_completed_prompt
+
+    try:
+        await check_goal_completed_prompt(db, user_id)
+    except Exception:
+        logger.exception("goal-completed feedback prompt hook failed")
 
 
 # ---------------------------------------------------------------------
@@ -60,6 +73,8 @@ async def create_goal(
     )
     db.add(goal)
     await db.flush()
+    if initial_status == "completed":
+        await _try_goal_completed_feedback_prompt(db, user_id)
     return goal
 
 
@@ -122,6 +137,7 @@ async def update_goal(
         and goal.completed_at is None
     ):
         goal.completed_at = datetime.utcnow()
+        await _try_goal_completed_feedback_prompt(db, user_id)
     await db.flush()
     return goal
 
@@ -148,6 +164,7 @@ async def update_goal_progress(
     ):
         goal.status = "completed"
         goal.completed_at = datetime.utcnow()
+        await _try_goal_completed_feedback_prompt(db, user_id)
     goal.updated_at = datetime.utcnow()
     await db.flush()
     return goal

--- a/backend/tests/test_phase_3_8_5_feedback.py
+++ b/backend/tests/test_phase_3_8_5_feedback.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.feedback.handlers import feedback_command
+from backend.feedback.models.feedback import Feedback, PromptSentLog
+from backend.feedback.services import feedback_service
+from backend.feedback.services.classifier import FeedbackClassifier, classify_feedback_batch
+from backend.feedback.services.prompt_scheduler import FeedbackPrompt, PromptScheduler
+from backend.models.user import User
+
+
+def _user(state: dict | None = None) -> User:
+    u = User()
+    u.id = uuid.uuid4()
+    u.telegram_id = 123
+    u.display_name = "Test"
+    u.wealth_level = "starter"
+    u.wizard_state = state
+    u.created_at = datetime.now(timezone.utc) - timedelta(days=7)
+    u.is_active = True
+    u.briefing_enabled = True
+    return u
+
+
+def _scalar_result(value):
+    result = MagicMock()
+    result.scalar_one.return_value = value
+    return result
+
+
+@pytest.mark.asyncio
+async def test_feedback_creation_has_context_and_trigger():
+    user = _user()
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=[_scalar_result(0), MagicMock(all=lambda: [])])
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+
+    with patch.object(feedback_service.analytics, "track"):
+        feedback = await feedback_service.create_feedback(
+            db,
+            user,
+            "App rất tốt nhưng thiếu dark mode",
+        )
+
+    assert feedback.content == "App rất tốt nhưng thiếu dark mode"
+    assert feedback.trigger == "passive_command"
+    assert feedback.context["wealth_level"] == "starter"
+    assert feedback.context["app_version"] == "phase-3.8.5"
+    db.add.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_feedback_rate_limit_blocks_sixth_submission():
+    user = _user()
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=_scalar_result(5))
+
+    with pytest.raises(feedback_service.FeedbackRateLimitError):
+        await feedback_service.validate_feedback_text(db, user.id, "Feedback hợp lệ")
+
+
+@pytest.mark.asyncio
+async def test_feedback_handler_cancel_clears_state():
+    user = _user({"flow": feedback_command.FLOW_FEEDBACK, "step": "awaiting_feedback_text", "draft": {}})
+    db = MagicMock()
+
+    with patch("backend.services.dashboard_service.get_user_by_telegram_id", AsyncMock(return_value=user)), \
+         patch.object(feedback_command.wizard_service, "clear", AsyncMock()) as clear, \
+         patch.object(feedback_command, "send_message", AsyncMock()) as send:
+        consumed = await feedback_command.handle_feedback_text_input(
+            db,
+            {"text": "/cancel", "chat": {"id": 123}, "from": {"id": 123}},
+        )
+
+    assert consumed is True
+    clear.assert_awaited_once_with(db, user.id)
+    assert "huỷ" in send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_classifier_parses_deepseek_json():
+    with patch("backend.feedback.services.classifier.call_llm", AsyncMock(return_value='{"category":"bug","sentiment":"negative","priority":"high","confidence":0.91}')):
+        result = await FeedbackClassifier().classify("Bot không trả lời khi tôi gửi /menu")
+
+    assert result["category"] == "bug"
+    assert result["sentiment"] == "negative"
+    assert result["priority"] == "high"
+    assert result["confidence"] == 0.91
+
+
+@pytest.mark.asyncio
+async def test_classifier_fallback_on_invalid_json():
+    with patch("backend.feedback.services.classifier.call_llm", AsyncMock(return_value="not json")):
+        result = await FeedbackClassifier().classify("test")
+
+    assert result["category"] == "other"
+    assert result["confidence"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_classify_feedback_batch_updates_unclassified_rows():
+    feedback = Feedback(user_id=uuid.uuid4(), content="Tuyệt vời", trigger="passive_command")
+    db = MagicMock()
+    db.flush = AsyncMock()
+
+    with patch("backend.feedback.services.classifier.list_unclassified_feedbacks", AsyncMock(return_value=[feedback])):
+        classifier = MagicMock()
+        classifier.classify = AsyncMock(return_value={
+            "category": "praise",
+            "sentiment": "positive",
+            "priority": "low",
+            "confidence": 0.8,
+            "classifier_version": "test",
+        })
+        processed = await classify_feedback_batch(db, classifier=classifier)
+
+    assert processed == 1
+    assert feedback.category == "praise"
+    assert feedback.classification_attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_prompt_scheduler_cooldown_prevents_resend():
+    user = _user()
+    prompt = FeedbackPrompt(
+        id="post_onboarding_day_7",
+        trigger="account_age_days == 7",
+        message="Hi",
+        cta_button="CTA",
+        skip_button="Skip",
+        cooldown_days=60,
+    )
+    scheduler = PromptScheduler([prompt])
+    db = MagicMock()
+    db.get = AsyncMock(return_value=user)
+    db.execute = AsyncMock(side_effect=[_scalar_result(0), _scalar_result(0), _scalar_result(0), _scalar_result(1)])
+
+    sent = await scheduler.check_and_send_prompts(db, user.id, event="daily")
+
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_prompt_scheduler_max_two_per_month_blocks_third():
+    user = _user()
+    prompt = FeedbackPrompt(
+        id="post_onboarding_day_7",
+        trigger="account_age_days == 7",
+        message="Hi",
+        cta_button="CTA",
+        skip_button="Skip",
+        cooldown_days=60,
+    )
+    scheduler = PromptScheduler([prompt])
+    db = MagicMock()
+    db.get = AsyncMock(return_value=user)
+    db.execute = AsyncMock(side_effect=[_scalar_result(0), _scalar_result(0), _scalar_result(0), _scalar_result(0), _scalar_result(2)])
+
+    sent = await scheduler.check_and_send_prompts(db, user.id, event="daily")
+
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_prompt_callback_skip_logs_skip():
+    user = _user()
+    db = MagicMock()
+    db.flush = AsyncMock()
+    log = PromptSentLog(user_id=user.id, prompt_id="post_onboarding_day_7", trigger="post_onboarding_day_7")
+
+    with patch("backend.services.dashboard_service.get_user_by_telegram_id", AsyncMock(return_value=user)), \
+         patch.object(PromptScheduler, "_latest_prompt_log", AsyncMock(return_value=log)), \
+         patch.object(feedback_command, "answer_callback", AsyncMock()):
+        handled = await feedback_command.handle_feedback_callback(db, {
+            "id": "cb1",
+            "data": "feedback:skip:post_onboarding_day_7",
+            "from": {"id": 123},
+        })
+
+    assert handled is True
+    assert log.status == "skipped"

--- a/backend/tests/test_telegram_service.py
+++ b/backend/tests/test_telegram_service.py
@@ -265,12 +265,12 @@ class TestSetupBotCommands:
         assert "setMyCommands" in call_url
 
     @pytest.mark.asyncio
-    async def test_sends_4_phase_36_commands(self, mock_settings, mock_httpx):
+    async def test_sends_phase_385_commands(self, mock_settings, mock_httpx):
         await setup_bot_commands()
         payload = mock_httpx.post.call_args[1]["json"]
         commands = payload["commands"]
         names = [c["command"] for c in commands]
-        assert names == ["start", "menu", "help", "dashboard"]
+        assert names == ["start", "menu", "help", "dashboard", "feedback", "about"]
         # No deprecated V1 commands surfaced — Phase 3.6 cuts the list.
         for legacy in ("themtaisan", "taisan", "report", "goals", "market"):
             assert legacy not in names

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -78,6 +78,7 @@ async def route_update(data: dict) -> None:
     from backend.bot.handlers import onboarding as onboarding_handlers
     from backend.bot.handlers import recurring_entry as recurring_entry_handlers
     from backend.bot.handlers import storytelling as storytelling_handlers
+    from backend.feedback.handlers import feedback_command as feedback_handlers
     from backend.bot.handlers.callbacks import handle_transaction_callback
     from backend.bot.handlers.menu_handler import (
         handle_menu_callback as handle_menu_v2_callback,
@@ -106,6 +107,7 @@ async def route_update(data: dict) -> None:
                     recurring_entry_handlers=recurring_entry_handlers,
                     goal_entry_handlers=goal_entry_handlers,
                     storytelling_handlers=storytelling_handlers,
+                    feedback_handlers=feedback_handlers,
                     dashboard_service=dashboard_service,
                     handle_report_command=handle_report_command,
                     handle_text_message=handle_text_message,
@@ -125,6 +127,7 @@ async def route_update(data: dict) -> None:
                         goal_entry_handlers=goal_entry_handlers,
                         briefing_handlers=briefing_handlers,
                         storytelling_handlers=storytelling_handlers,
+                        feedback_handlers=feedback_handlers,
                         dashboard_service=dashboard_service,
                         handle_transaction_callback=handle_transaction_callback,
                         handle_menu_v2_callback=handle_menu_v2_callback,
@@ -156,6 +159,7 @@ async def _handle_message(
     recurring_entry_handlers,
     goal_entry_handlers,
     storytelling_handlers,
+    feedback_handlers,
     dashboard_service,
     handle_report_command,
     handle_text_message,
@@ -259,6 +263,13 @@ async def _handle_message(
             return resolved_user.id
         return None
 
+    # /feedback — zero-friction feedback capture (Phase 3.8.5 Epic 1).
+    if command == "/feedback":
+        if resolved_user is not None:
+            await feedback_handlers.start_feedback(db, chat_id, resolved_user)
+            return resolved_user.id
+        return None
+
     # /story or /kechuyen — open storytelling mode (Phase 3A Epic 3).
     if command in ("/story", "/kechuyen", "/kể_chuyện"):
         if resolved_user is not None:
@@ -274,7 +285,9 @@ async def _handle_message(
     # so the user needs a non-button way to bail.
     if command in ("/huy", "/cancel"):
         if resolved_user is not None:
-            if not await asset_entry_handlers.cancel_wizard(
+            if (resolved_user.wizard_state or {}).get("flow") == feedback_handlers.FLOW_FEEDBACK:
+                await feedback_handlers.handle_feedback_text_input(db, message)
+            elif not await asset_entry_handlers.cancel_wizard(
                 db, chat_id, resolved_user
             ):
                 await storytelling_handlers.cancel_storytelling(
@@ -320,6 +333,18 @@ async def _handle_message(
         consumed = await onboarding_handlers.handle_name_input(
             db, chat_id, resolved_user, text
         )
+        if consumed:
+            return resolved_user.id
+
+    # Feedback text input — must run before other wizard/free-form parsers.
+    if (
+        text
+        and resolved_user is not None
+        and not command.startswith("/")
+        and (resolved_user.wizard_state or {}).get("flow")
+        == feedback_handlers.FLOW_FEEDBACK
+    ):
+        consumed = await feedback_handlers.handle_feedback_text_input(db, message)
         if consumed:
             return resolved_user.id
 
@@ -477,6 +502,7 @@ async def _handle_callback(
     goal_entry_handlers,
     briefing_handlers,
     storytelling_handlers,
+    feedback_handlers,
     dashboard_service,
     handle_transaction_callback,
     handle_menu_v2_callback,
@@ -506,6 +532,10 @@ async def _handle_callback(
         callback_data=callback_data,
         dashboard_service=dashboard_service,
     )
+
+    # Feedback prompt callbacks own the feedback:* namespace.
+    if await feedback_handlers.handle_feedback_callback(db, callback_query):
+        return await _resolved_user_id()
 
     # About-page callbacks are static and do not need a user lookup.
     if await about_handlers.handle_about_callback(callback_query):

--- a/content/feedback_prompts.yaml
+++ b/content/feedback_prompts.yaml
@@ -1,0 +1,31 @@
+prompts:
+  - id: post_onboarding_day_7
+    trigger: account_age_days == 7
+    message: "Bé Tiền đồng hành với bạn được 7 ngày rồi 💚 Trải nghiệm ban đầu ổn không?"
+    cta_button: "Chia sẻ cảm nhận"
+    skip_button: "Để sau"
+    cooldown_days: 60
+  - id: post_briefing_30_reads
+    trigger: briefing_read_count == 30
+    message: "Bạn đã đọc 30 bản tin sáng rồi 🎉 Có điểm nào Bé Tiền nên cải thiện không?"
+    cta_button: "Góp ý briefing"
+    skip_button: "Để sau"
+    cooldown_days: 90
+  - id: post_first_goal_completed
+    trigger: goals_completed_count == 1
+    message: "Chúc mừng bạn hoàn thành mục tiêu đầu tiên! Bé Tiền hỗ trợ hành trình này tốt chưa?"
+    cta_button: "Chia sẻ cảm nhận"
+    skip_button: "Để sau"
+    cooldown_days: 180
+  - id: post_phase_4_launch
+    trigger: phase_4_first_view == true
+    message: "Bạn vừa thử tính năng mới. Cảm nhận nhanh của bạn sẽ giúp Bé Tiền chỉnh tốt hơn 💚"
+    cta_button: "Góp ý tính năng"
+    skip_button: "Để sau"
+    cooldown_days: 30
+  - id: post_3_months_active
+    trigger: account_age_days == 90
+    message: "3 tháng dùng Bé Tiền rồi đó! Điều gì hữu ích nhất, điều gì còn vướng?"
+    cta_button: "Chia sẻ ngay"
+    skip_button: "Để sau"
+    cooldown_days: 180


### PR DESCRIPTION
### Motivation
- Tạo feedback loop "zero friction" cho soft-launch: user chỉ cần gõ `/feedback` rồi gửi, backend tự phân loại và log ngữ cảnh để team phân tích.
- Thu thập feedback có ngữ cảnh (wealth level, account age, recent actions) để cải thiện quyết định sản phẩm trước launch.
- Kích hoạt "active prompts" tại các mốc quan trọng (onboarding day 7, briefing milestone, goal completed) mà vẫn giữ cooldown/rate-limit để tránh spam.

### Description
- Thêm migration và ORM models `feedbacks` + `prompts_sent_log` cùng chỉ mục tương ứng (file `alembic/versions/n3h4i5j6k7l8_phase385_feedback_system.py` và `backend/feedback/models/feedback.py`).
- Implement flow `/feedback` với handler và wizard state (`backend/feedback/handlers/feedback_command.py`) cùng validation, rate-limit và `ContextSnapshotService` (`backend/feedback/services/feedback_service.py`).
- Thêm DeepSeek-backed classifier với fallback an toàn và batch job (`backend/feedback/services/classifier.py`, `backend/jobs/feedback_classifier_job.py`) và cập nhật hàng đợi/worker để xử lý callback và text flows (`backend/workers/telegram_worker.py`).
- Thêm active-prompt config và scheduler (`content/feedback_prompts.yaml`, `backend/feedback/services/prompt_scheduler.py`, `backend/jobs/feedback_prompt_job.py`) cùng hook vào briefing/goal events để gửi prompt khi phù hợp.

### Testing
- Đã chạy unit tests cho feedback module với `python -m pytest backend/tests/test_phase_3_8_5_feedback.py` và tất cả test trong file này đều `PASSED`.
- Đã chạy các integration tests liên quan `pytest backend/tests/test_briefing_callback.py backend/tests/test_goal_entry_handler.py backend/tests/test_telegram_service.py::TestSetupBotCommands::test_sends_phase_385_commands` và các test này `PASSED`.
- Đã byte-compile các module mới with `python -m compileall ...` để kiểm tra cú pháp, và biên dịch thành công.
- Khi chạy toàn bộ test suite `python -m pytest backend/tests -q` hầu hết test pass (≈1582 passed) nhưng một số test liên quan tới webhook/router Telegram failed trong môi trường này do `DATABASE_URL` không được cấu hình (môi trường CI dev thiếu DB), vấn đề này không phải lỗi logic của feature mới.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc1ebe7990832fa50d261c786f95f0)