### PR TITLE
Implement Phase 3.8.5 Epic 3 — Profile edit flows (display name, age range, notifications)

### DIFF
--- a/backend/jobs/morning_briefing_job.py
+++ b/backend/jobs/morning_briefing_job.py
@@ -33,7 +33,7 @@ import logging
 from datetime import datetime, time, timedelta, timezone
 from zoneinfo import ZoneInfo
 
-from sqlalchemy import distinct, select
+from sqlalchemy import and_, distinct, or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend import analytics
@@ -43,6 +43,7 @@ from backend.database import get_session_factory
 from backend.models.event import Event
 from backend.models.expense import Expense
 from backend.models.user import User
+from backend.profile.models.user_profile import UserProfile
 from backend.ports.notifier import get_notifier
 
 logger = logging.getLogger(__name__)
@@ -106,14 +107,30 @@ async def _get_briefing_candidates(db: AsyncSession) -> list[User]:
     if not user_ids:
         return []
 
-    stmt = select(User).where(
-        User.id.in_(user_ids),
-        User.is_active.is_(True),
-        User.deleted_at.is_(None),
-        User.telegram_id.isnot(None),
-        User.briefing_enabled.is_(True),
+    stmt = (
+        select(User, UserProfile)
+        .outerjoin(UserProfile, UserProfile.user_id == User.id)
+        .where(
+            User.id.in_(user_ids),
+            User.is_active.is_(True),
+            User.deleted_at.is_(None),
+            User.telegram_id.isnot(None),
+            or_(
+                and_(
+                    UserProfile.user_id.is_(None),
+                    User.briefing_enabled.is_(True),
+                ),
+                UserProfile.briefing_enabled.is_(True),
+            ),
+        )
     )
-    return list((await db.execute(stmt)).scalars())
+    candidates: list[User] = []
+    for user, profile in (await db.execute(stmt)).all():
+        user._profile_briefing_time = (  # type: ignore[attr-defined]
+            profile.briefing_time if profile is not None else user.briefing_time
+        )
+        candidates.append(user)
+    return candidates
 
 
 async def run_morning_briefing_job(
@@ -143,7 +160,11 @@ async def run_morning_briefing_job(
     )
 
     for user in candidates:
-        target = user.briefing_time or time(7, 0)
+        target = (
+            getattr(user, "_profile_briefing_time", None)
+            or user.briefing_time
+            or time(7, 0)
+        )
         if not _is_within_15_min(now.time(), target):
             skipped_window += 1
             continue

--- a/backend/jobs/reminder_scheduler_job.py
+++ b/backend/jobs/reminder_scheduler_job.py
@@ -23,8 +23,9 @@ Telegram failures roll back the per-user transaction so the
 from __future__ import annotations
 
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, time
 from decimal import Decimal
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import select
 
@@ -36,6 +37,7 @@ from backend.config.categories import get_category
 from backend.database import get_session_factory
 from backend.models.recurring_pattern import RecurringPattern
 from backend.models.user import User
+from backend.profile.models.user_profile import UserProfile
 from backend.services import recurring_service
 from backend.services.telegram_service import send_message
 
@@ -45,10 +47,13 @@ logger = logging.getLogger(__name__)
 # A user with this many distinct patterns due TODAY gets one
 # bundled message instead of three pings. 3 = the spec threshold.
 BUNDLE_THRESHOLD = 3
+REMINDER_TIMEZONE = ZoneInfo("Asia/Ho_Chi_Minh")
+WINDOW_MINUTES = 15
 
 
-async def run_reminder_scheduler() -> None:
+async def run_reminder_scheduler(*, now: datetime | None = None) -> None:
     """Entry point for the APScheduler cron registration."""
+    now = now or datetime.now(REMINDER_TIMEZONE)
     session_factory = get_session_factory()
     async with session_factory() as db:
         # Pull due patterns + group by user. One DB session for the
@@ -65,6 +70,9 @@ async def run_reminder_scheduler() -> None:
                 user = await user_db.get(User, user_id)
                 if user is None or user.deleted_at is not None:
                     continue
+                profile = await user_db.get(UserProfile, user_id)
+                if not _should_send_reminders_now(profile, now=now):
+                    continue
                 await _send_for_user(user_db, user, patterns)
                 await user_db.commit()
             except Exception:
@@ -72,6 +80,25 @@ async def run_reminder_scheduler() -> None:
                 logger.exception(
                     "reminder send failed for user %s", user_id,
                 )
+
+
+def _is_within_15_min(now: time, target: time) -> bool:
+    now_min = now.hour * 60 + now.minute
+    target_min = target.hour * 60 + target.minute
+    delta = (now_min - target_min) % (24 * 60)
+    return delta < WINDOW_MINUTES
+
+
+def _should_send_reminders_now(
+    profile: UserProfile | None,
+    *,
+    now: datetime,
+) -> bool:
+    if profile is None:
+        return _is_within_15_min(now.time(), time(9, 0))
+    if not profile.reminder_enabled:
+        return False
+    return _is_within_15_min(now.time(), profile.reminder_time or time(9, 0))
 
 
 # ---------------------------------------------------------------------

--- a/backend/profile/handlers/profile_menu.py
+++ b/backend/profile/handlers/profile_menu.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import re
+from datetime import time
 from decimal import Decimal
 from typing import Any
 
@@ -9,20 +11,108 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.bot.formatters.money import format_money_short
 from backend.bot.formatters.progress_bar import make_progress_bar
 from backend.models.user import User
-from backend.profile.models.user_profile import UserProfile
+from backend.profile.models.user_profile import AGE_RANGES, UserProfile
 from backend.profile.services.stats_aggregator import ProfileStatsAggregator
-from backend.services.telegram_service import edit_message_text, send_message
+from backend.services import wizard_service
+from backend.services.telegram_service import (
+    answer_callback,
+    edit_message_text,
+    send_message,
+)
+
+FLOW_PROFILE = "profile_edit"
+STEP_DISPLAY_NAME = "awaiting_display_name"
+STEP_NOTIFICATION_TIME = "awaiting_notification_time"
+TIME_PRESETS = (time(6, 0), time(7, 0), time(8, 0), time(9, 0))
+_TIME_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
 
 
 def profile_keyboard() -> dict[str, list[list[dict[str, str]]]]:
     return {
         "inline_keyboard": [
             [
-                {"text": "📝 Đổi tên", "callback_data": "profile:edit_name"},
-                {"text": "🎂 Đổi tuổi", "callback_data": "profile:edit_age"},
+                {"text": "📝 Đổi tên hiển thị", "callback_data": "profile:edit_name"},
+                {"text": "🎂 Đổi nhóm tuổi", "callback_data": "profile:edit_age"},
             ],
             [{"text": "🔔 Cài thông báo", "callback_data": "profile:notifications"}],
             [{"text": "◀️ Quay lại", "callback_data": "menu:main"}],
+        ]
+    }
+
+
+def age_keyboard() -> dict[str, list[list[dict[str, str]]]]:
+    return {
+        "inline_keyboard": [
+            [
+                {"text": "20-29", "callback_data": "profile:age:20-29"},
+                {"text": "30-39", "callback_data": "profile:age:30-39"},
+            ],
+            [
+                {"text": "40-49", "callback_data": "profile:age:40-49"},
+                {"text": "50+", "callback_data": "profile:age:50+"},
+            ],
+            [{"text": "🚫 Không muốn nói", "callback_data": "profile:age:none"}],
+            [{"text": "◀️ Quay lại Profile", "callback_data": "profile:view"}],
+        ]
+    }
+
+
+def notification_keyboard(
+    profile: UserProfile,
+) -> dict[str, list[list[dict[str, str]]]]:
+    briefing_status = "✅ Bật" if profile.briefing_enabled else "🔕 Tắt"
+    reminder_status = "✅ Bật" if profile.reminder_enabled else "🔕 Tắt"
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": f"🌅 Daily Briefing: {briefing_status}",
+                    "callback_data": "profile:toggle:briefing",
+                }
+            ],
+            [
+                {
+                    "text": f"🕖 Giờ briefing: {_fmt_time(profile.briefing_time)}",
+                    "callback_data": "profile:time_menu:briefing",
+                }
+            ],
+            [
+                {
+                    "text": f"⏰ Nhắc định kỳ: {reminder_status}",
+                    "callback_data": "profile:toggle:reminder",
+                }
+            ],
+            [
+                {
+                    "text": f"🕘 Giờ nhắc: {_fmt_time(profile.reminder_time)}",
+                    "callback_data": "profile:time_menu:reminder",
+                }
+            ],
+            [{"text": "◀️ Quay lại Profile", "callback_data": "profile:view"}],
+        ]
+    }
+
+
+def time_keyboard(kind: str) -> dict[str, list[list[dict[str, str]]]]:
+    return {
+        "inline_keyboard": [
+            [
+                {
+                    "text": _fmt_time(preset),
+                    "callback_data": f"profile:time:{kind}:{_fmt_time(preset)}",
+                }
+                for preset in TIME_PRESETS[:2]
+            ],
+            [
+                {
+                    "text": _fmt_time(preset),
+                    "callback_data": f"profile:time:{kind}:{_fmt_time(preset)}",
+                }
+                for preset in TIME_PRESETS[2:]
+            ],
+            [{"text": "✏️ Tự nhập", "callback_data": f"profile:custom_time:{kind}"}],
+            [{"text": "◀️ Cài thông báo", "callback_data": "profile:notifications"}],
         ]
     }
 
@@ -66,6 +156,174 @@ async def handle_profile_view(
     )
 
 
+async def handle_profile_callback(
+    db: AsyncSession,
+    callback_query: dict[str, Any],
+) -> bool:
+    data = callback_query.get("data") or ""
+    if not data.startswith("profile:"):
+        return False
+
+    callback_id = callback_query["id"]
+    message = callback_query.get("message") or {}
+    chat_id = message.get("chat", {}).get("id")
+    message_id = message.get("message_id")
+    telegram_id = (callback_query.get("from") or {}).get("id")
+    user = await _get_user_by_telegram_id(db, telegram_id)
+    if user is None:
+        await answer_callback(
+            callback_id,
+            "Gõ /start để mình nhận ra bạn nhé 🌱",
+            show_alert=True,
+        )
+        return True
+
+    profile = await get_or_create_profile(db, user.id)
+    parts = data.split(":")
+    action = parts[1] if len(parts) > 1 else ""
+    await answer_callback(callback_id)
+
+    if action == "view":
+        await wizard_service.clear(db, user.id)
+        await handle_profile_view(db, chat_id, user, message_id=message_id)
+        return True
+
+    if action == "edit_name":
+        await wizard_service.start_flow(db, user.id, FLOW_PROFILE, STEP_DISPLAY_NAME)
+        await send_message(
+            chat_id=chat_id,
+            text="📝 Tên mới của bạn?\n\nGõ /cancel nếu muốn bỏ qua.",
+        )
+        return True
+
+    if action == "edit_age":
+        await edit_message_text(
+            chat_id=chat_id,
+            message_id=message_id,
+            text="🎂 Bạn thuộc nhóm tuổi nào?",
+            reply_markup=age_keyboard(),
+        )
+        return True
+
+    if action == "age" and len(parts) >= 3:
+        value = None if parts[2] == "none" else parts[2]
+        if value is not None and value not in AGE_RANGES:
+            await answer_callback(callback_id, "Nhóm tuổi không hợp lệ.", show_alert=True)
+            return True
+        profile.age_range = value
+        await db.flush()
+        await send_message(chat_id=chat_id, text=_age_confirm_text(value))
+        await handle_profile_view(db, chat_id, user, message_id=message_id)
+        return True
+
+    if action == "notifications":
+        await _render_notifications(chat_id, message_id, profile)
+        return True
+
+    if action == "toggle" and len(parts) >= 3:
+        kind = parts[2]
+        if kind == "briefing":
+            profile.briefing_enabled = not profile.briefing_enabled
+            user.briefing_enabled = profile.briefing_enabled
+        elif kind == "reminder":
+            profile.reminder_enabled = not profile.reminder_enabled
+        else:
+            return True
+        await db.flush()
+        await _render_notifications(chat_id, message_id, profile)
+        return True
+
+    if action == "time_menu" and len(parts) >= 3:
+        kind = parts[2]
+        await edit_message_text(
+            chat_id=chat_id,
+            message_id=message_id,
+            text=_time_menu_text(kind),
+            reply_markup=time_keyboard(kind),
+        )
+        return True
+
+    if action == "time" and len(parts) >= 4:
+        kind = parts[2]
+        parsed = parse_hhmm(parts[3])
+        if parsed is None:
+            await answer_callback(callback_id, "Giờ không hợp lệ.", show_alert=True)
+            return True
+        await _set_notification_time(db, user, profile, kind, parsed)
+        await _render_notifications(chat_id, message_id, profile)
+        return True
+
+    if action == "custom_time" and len(parts) >= 3:
+        kind = parts[2]
+        await wizard_service.start_flow(
+            db,
+            user.id,
+            FLOW_PROFILE,
+            STEP_NOTIFICATION_TIME,
+            {"kind": kind, "message_id": message_id},
+        )
+        await send_message(
+            chat_id=chat_id,
+            text="✏️ Nhập giờ theo format HH:MM (00:00 - 23:59).\n\nGõ /cancel nếu muốn bỏ qua.",
+        )
+        return True
+
+    return True
+
+
+async def handle_profile_text_input(
+    db: AsyncSession,
+    message: dict[str, Any],
+) -> bool:
+    text = message.get("text", "")
+    chat_id = message["chat"]["id"]
+    telegram_id = (message.get("from") or {}).get("id")
+    user = await _get_user_by_telegram_id(db, telegram_id)
+    if user is None or (user.wizard_state or {}).get("flow") != FLOW_PROFILE:
+        return False
+
+    state = user.wizard_state or {}
+    step = state.get("step")
+    profile = await get_or_create_profile(db, user.id)
+
+    if text.strip().lower() in {"/cancel", "/huy"}:
+        await wizard_service.clear(db, user.id)
+        await send_message(chat_id=chat_id, text="Đã hủy chỉnh sửa profile nhé.")
+        await handle_profile_view(db, chat_id, user)
+        return True
+
+    if step == STEP_DISPLAY_NAME:
+        name, error = sanitize_display_name(text)
+        if error:
+            await send_message(chat_id=chat_id, text=error)
+            return True
+        profile.display_name = name
+        user.display_name = name
+        await wizard_service.clear(db, user.id)
+        await db.flush()
+        await send_message(chat_id=chat_id, text=f"✅ Đã đổi tên hiển thị thành {name}.")
+        await handle_profile_view(db, chat_id, user)
+        return True
+
+    if step == STEP_NOTIFICATION_TIME:
+        parsed = parse_hhmm(text.strip())
+        if parsed is None:
+            await send_message(
+                chat_id=chat_id,
+                text="Giờ không hợp lệ. Format: HH:MM (00:00 - 23:59)",
+            )
+            return True
+        kind = ((state.get("draft") or {}).get("kind") or "").strip()
+        await _set_notification_time(db, user, profile, kind, parsed)
+        await wizard_service.clear(db, user.id)
+        await db.flush()
+        await send_message(chat_id=chat_id, text=f"✅ Đã cập nhật giờ thành {_fmt_time(parsed)}.")
+        await handle_profile_view(db, chat_id, user)
+        return True
+
+    return False
+
+
 def render_profile(profile: UserProfile, user: User, stats: dict[str, Any]) -> str:
     level = stats["wealth_level"]
     progress = stats["wealth_progress"]
@@ -75,6 +333,12 @@ def render_profile(profile: UserProfile, user: User, stats: dict[str, Any]) -> s
     lines = [
         f"👤 *Profile của {name}* {level['icon']} *{level['name_vn']}*",
         f"_{level['description']}_",
+        "",
+        "*Thông tin cá nhân*",
+        f"• Tên hiển thị: *{name}*",
+        f"• Nhóm tuổi: *{profile.age_range or 'Chưa chia sẻ'}*",
+        f"• Briefing: *{'Bật' if profile.briefing_enabled else 'Tắt'}* lúc *{_fmt_time(profile.briefing_time)}*",
+        f"• Nhắc định kỳ: *{'Bật' if profile.reminder_enabled else 'Tắt'}* lúc *{_fmt_time(profile.reminder_time)}*",
         "",
         "*Tổng quan*",
         f"• Tuổi tài khoản: *{stats['account_age_days']} ngày*",
@@ -108,6 +372,81 @@ def render_profile(profile: UserProfile, user: User, stats: dict[str, Any]) -> s
     return "\n".join(lines)
 
 
+def sanitize_display_name(text: str) -> tuple[str | None, str | None]:
+    name = _CONTROL_CHARS_RE.sub("", text or "").strip()
+    if name.startswith("@"):
+        name = name[1:].strip()
+    if not name:
+        return None, "Tên không được trống."
+    if len(name) > 50:
+        return None, "Tên dài quá! Tối đa 50 ký tự nhé."
+    return name, None
+
+
+def parse_hhmm(value: str) -> time | None:
+    match = _TIME_RE.match((value or "").strip())
+    if not match:
+        return None
+    hour = int(match.group(1))
+    minute = int(match.group(2))
+    if hour > 23 or minute > 59:
+        return None
+    return time(hour, minute)
+
+
+async def _get_user_by_telegram_id(
+    db: AsyncSession,
+    telegram_id: int | None,
+) -> User | None:
+    if telegram_id is None:
+        return None
+    return (
+        await db.execute(select(User).where(User.telegram_id == telegram_id))
+    ).scalar_one_or_none()
+
+
+async def _render_notifications(
+    chat_id: int,
+    message_id: int | None,
+    profile: UserProfile,
+) -> None:
+    text = (
+        "🔔 *Cài thông báo*\n\n"
+        f"• Daily Briefing: *{'✅ Bật' if profile.briefing_enabled else '🔕 Tắt'}*\n"
+        f"• Giờ briefing: *{_fmt_time(profile.briefing_time)}*\n"
+        f"• Nhắc định kỳ: *{'✅ Bật' if profile.reminder_enabled else '🔕 Tắt'}*\n"
+        f"• Giờ nhắc: *{_fmt_time(profile.reminder_time)}*"
+    )
+    if message_id is None:
+        await send_message(
+            chat_id=chat_id,
+            text=text,
+            reply_markup=notification_keyboard(profile),
+        )
+        return
+    await edit_message_text(
+        chat_id=chat_id,
+        message_id=message_id,
+        text=text,
+        reply_markup=notification_keyboard(profile),
+    )
+
+
+async def _set_notification_time(
+    db: AsyncSession,
+    user: User,
+    profile: UserProfile,
+    kind: str,
+    value: time,
+) -> None:
+    if kind == "briefing":
+        profile.briefing_time = value
+        user.briefing_time = value
+    elif kind == "reminder":
+        profile.reminder_time = value
+    await db.flush()
+
+
 def _display_name(profile: UserProfile, user: User) -> str:
     for value in (
         profile.display_name,
@@ -133,9 +472,34 @@ def _format_wealth_journey(progress: dict[str, Any]) -> str:
     )
 
 
+def _fmt_time(value: time | None) -> str:
+    return (value or time(7, 0)).strftime("%H:%M")
+
+
+def _age_confirm_text(value: str | None) -> str:
+    if value is None:
+        return "✅ Đã lưu: không chia sẻ nhóm tuổi."
+    return f"✅ Đã cập nhật nhóm tuổi: {value}."
+
+
+def _time_menu_text(kind: str) -> str:
+    label = "briefing" if kind == "briefing" else "nhắc định kỳ"
+    return f"🕒 Chọn giờ {label}:"
+
+
 __all__ = [
+    "FLOW_PROFILE",
+    "STEP_DISPLAY_NAME",
+    "STEP_NOTIFICATION_TIME",
+    "age_keyboard",
     "get_or_create_profile",
+    "handle_profile_callback",
+    "handle_profile_text_input",
     "handle_profile_view",
+    "notification_keyboard",
+    "parse_hhmm",
     "profile_keyboard",
     "render_profile",
+    "sanitize_display_name",
+    "time_keyboard",
 ]

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -95,12 +95,12 @@ def register_jobs(scheduler: AsyncIOScheduler) -> None:
         hour=2, minute=0, timezone="Asia/Ho_Chi_Minh",
         id="recurring_detection",
     )
-    # Phase 3.8 Epic 3 — daily reminder scheduler. 09:00 — early
-    # enough to fit the user's morning routine, late enough that
-    # overnight bank charges have settled.
+    # Phase 3.8 Epic 3 + Phase 3.8.5 profile settings — run every
+    # 15 minutes so each user's custom reminder_time can be respected.
+    # The job itself filters by user_profiles.reminder_enabled/time.
     scheduler.add_job(
-        run_reminder_scheduler, "cron",
-        hour=9, minute=0, timezone="Asia/Ho_Chi_Minh",
+        run_reminder_scheduler, "interval",
+        minutes=15, timezone="Asia/Ho_Chi_Minh",
         id="recurring_reminders",
     )
 

--- a/backend/tests/test_phase_3_8_5_profile.py
+++ b/backend/tests/test_phase_3_8_5_profile.py
@@ -1,15 +1,21 @@
 from __future__ import annotations
 
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, time, timezone
 from decimal import Decimal
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from backend.jobs.reminder_scheduler_job import _should_send_reminders_now
 from backend.models.user import User
-from backend.profile.handlers.profile_menu import render_profile
+from backend.profile.handlers.profile_menu import (
+    notification_keyboard,
+    parse_hhmm,
+    render_profile,
+    sanitize_display_name,
+)
 from backend.profile.models.user_profile import UserProfile
 from backend.profile.services.stats_aggregator import ProfileStatsAggregator
 from backend.profile.services.wealth_level_mapper import WealthLevelMapper
@@ -64,7 +70,10 @@ async def test_aggregate_new_user_defaults_gracefully():
         _scalar(None),  # first snapshot
     ])
 
-    with patch("backend.profile.services.stats_aggregator.net_worth_calculator.calculate", AsyncMock(return_value=SimpleNamespace(total=Decimal("0")))):
+    with patch(
+        "backend.profile.services.stats_aggregator.net_worth_calculator.calculate",
+        AsyncMock(return_value=SimpleNamespace(total=Decimal("0"))),
+    ):
         stats = await ProfileStatsAggregator().aggregate(db, user.id)
 
     assert stats["account_age_days"] == 0
@@ -89,7 +98,9 @@ def test_render_profile_includes_vn_level_and_stats():
         "account_age_days": 12,
         "net_worth": Decimal("300000000"),
         "wealth_level": WealthLevelMapper().get_level(Decimal("300000000")),
-        "wealth_progress": WealthLevelMapper().get_progress_to_next(Decimal("300000000")),
+        "wealth_progress": WealthLevelMapper().get_progress_to_next(
+            Decimal("300000000")
+        ),
         "asset_types_count": 3,
         "transaction_count_total": 40,
         "transaction_count_this_month": 8,
@@ -107,3 +118,55 @@ def test_render_profile_includes_vn_level_and_stats():
     assert "Trung Lưu Vững" in text
     assert "Tinh Hoa" in text
     assert "8" in text
+
+
+
+def test_sanitize_display_name_validates_and_strips_at():
+    assert sanitize_display_name("@Phương 💚\x00") == ("Phương 💚", None)
+    assert sanitize_display_name("   ")[1] == "Tên không được trống."
+    assert sanitize_display_name("x" * 51)[1] == (
+        "Tên dài quá! Tối đa 50 ký tự nhé."
+    )
+
+
+def test_parse_hhmm_validation():
+    assert parse_hhmm("7:05") == time(7, 5)
+    assert parse_hhmm("25:99") is None
+    assert parse_hhmm("bad") is None
+
+
+def test_notification_keyboard_reflects_status_and_times():
+    profile = UserProfile(user_id=uuid.uuid4())
+    profile.briefing_enabled = False
+    profile.briefing_time = time(8, 0)
+    profile.reminder_enabled = True
+    profile.reminder_time = time(9, 30)
+
+    keyboard = notification_keyboard(profile)
+    buttons = [button[0]["text"] for button in keyboard["inline_keyboard"][:4]]
+
+    assert "🔕 Tắt" in buttons[0]
+    assert "08:00" in buttons[1]
+    assert "✅ Bật" in buttons[2]
+    assert "09:30" in buttons[3]
+
+
+def test_reminder_profile_settings_gate_delivery_time():
+    profile = UserProfile(user_id=uuid.uuid4())
+    profile.reminder_enabled = True
+    profile.reminder_time = time(8, 0)
+
+    assert _should_send_reminders_now(
+        profile,
+        now=datetime(2026, 5, 7, 8, 10, tzinfo=timezone.utc),
+    ) is True
+    assert _should_send_reminders_now(
+        profile,
+        now=datetime(2026, 5, 7, 8, 15, tzinfo=timezone.utc),
+    ) is False
+
+    profile.reminder_enabled = False
+    assert _should_send_reminders_now(
+        profile,
+        now=datetime(2026, 5, 7, 8, 5, tzinfo=timezone.utc),
+    ) is False

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -79,6 +79,7 @@ async def route_update(data: dict) -> None:
     from backend.bot.handlers import recurring_entry as recurring_entry_handlers
     from backend.bot.handlers import storytelling as storytelling_handlers
     from backend.feedback.handlers import feedback_command as feedback_handlers
+    from backend.profile.handlers import profile_menu as profile_handlers
     from backend.bot.handlers.callbacks import handle_transaction_callback
     from backend.bot.handlers.menu_handler import (
         handle_menu_callback as handle_menu_v2_callback,
@@ -108,6 +109,7 @@ async def route_update(data: dict) -> None:
                     goal_entry_handlers=goal_entry_handlers,
                     storytelling_handlers=storytelling_handlers,
                     feedback_handlers=feedback_handlers,
+                    profile_handlers=profile_handlers,
                     dashboard_service=dashboard_service,
                     handle_report_command=handle_report_command,
                     handle_text_message=handle_text_message,
@@ -128,6 +130,7 @@ async def route_update(data: dict) -> None:
                         briefing_handlers=briefing_handlers,
                         storytelling_handlers=storytelling_handlers,
                         feedback_handlers=feedback_handlers,
+                        profile_handlers=profile_handlers,
                         dashboard_service=dashboard_service,
                         handle_transaction_callback=handle_transaction_callback,
                         handle_menu_v2_callback=handle_menu_v2_callback,
@@ -160,6 +163,7 @@ async def _handle_message(
     goal_entry_handlers,
     storytelling_handlers,
     feedback_handlers,
+    profile_handlers,
     dashboard_service,
     handle_report_command,
     handle_text_message,
@@ -285,7 +289,9 @@ async def _handle_message(
     # so the user needs a non-button way to bail.
     if command in ("/huy", "/cancel"):
         if resolved_user is not None:
-            if (resolved_user.wizard_state or {}).get("flow") == feedback_handlers.FLOW_FEEDBACK:
+            if (resolved_user.wizard_state or {}).get("flow") == profile_handlers.FLOW_PROFILE:
+                await profile_handlers.handle_profile_text_input(db, message)
+            elif (resolved_user.wizard_state or {}).get("flow") == feedback_handlers.FLOW_FEEDBACK:
                 await feedback_handlers.handle_feedback_text_input(db, message)
             elif not await asset_entry_handlers.cancel_wizard(
                 db, chat_id, resolved_user
@@ -333,6 +339,18 @@ async def _handle_message(
         consumed = await onboarding_handlers.handle_name_input(
             db, chat_id, resolved_user, text
         )
+        if consumed:
+            return resolved_user.id
+
+    # Profile edit text input — must run before generic wizard/free-form parsers.
+    if (
+        text
+        and resolved_user is not None
+        and not command.startswith("/")
+        and (resolved_user.wizard_state or {}).get("flow")
+        == profile_handlers.FLOW_PROFILE
+    ):
+        consumed = await profile_handlers.handle_profile_text_input(db, message)
         if consumed:
             return resolved_user.id
 
@@ -503,6 +521,7 @@ async def _handle_callback(
     briefing_handlers,
     storytelling_handlers,
     feedback_handlers,
+    profile_handlers,
     dashboard_service,
     handle_transaction_callback,
     handle_menu_v2_callback,
@@ -535,6 +554,10 @@ async def _handle_callback(
 
     # Feedback prompt callbacks own the feedback:* namespace.
     if await feedback_handlers.handle_feedback_callback(db, callback_query):
+        return await _resolved_user_id()
+
+    # Profile edit callbacks own the profile:* namespace.
+    if await profile_handlers.handle_profile_callback(db, callback_query):
         return await _resolved_user_id()
 
     # About-page callbacks are static and do not need a user lookup.


### PR DESCRIPTION
### Motivation
- Cung cấp các flow chỉnh sửa profile tối thiểu của Phase 3.8.5 để user có thể đổi `display_name`, `age_range` và cài thông báo (briefing/reminder) trước soft-launch.
- Profile giữ chế độ view-first; chỉ cho phép 3 field chỉnh sửa và đảm bảo các job scheduler tôn trọng cài đặt user.

### Description
- Thêm/cập nhật handler profile: `backend/profile/handlers/profile_menu.py` implements profile menu, callbacks `profile:*`, text-input flows, validation/sanitization cho tên, `HH:MM` parsing, và keyboards cho age/time.
- Wire-in routing: `backend/workers/telegram_worker.py` now routes `profile:*` callbacks and routes profile text-state handling before generic parsers and `/cancel` flows.
- Scheduler integration: `backend/jobs/morning_briefing_job.py` reads `user_profiles.briefing_enabled` / `briefing_time` when present; `backend/jobs/reminder_scheduler_job.py` respects `user_profiles.reminder_enabled`/`reminder_time` and exposes `_should_send_reminders_now` helper; `backend/scheduler.py` changed reminder job to 15-minute interval so per-user times are supported.
- Tests and small test refactors: updated/added `backend/tests/test_phase_3_8_5_profile.py` to cover name sanitization, `HH:MM` parsing, notification keyboard rendering and reminder gating logic.

### Testing
- Compiled changed modules: `python -m py_compile backend/profile/handlers/profile_menu.py backend/jobs/morning_briefing_job.py backend/jobs/reminder_scheduler_job.py backend/workers/telegram_worker.py backend/scheduler.py` (succeeded).
- Ran focused unit tests: `pytest -q backend/tests/test_phase_3_8_5_profile.py backend/tests/test_morning_briefing_job.py` (all tests passed).
- Ran full backend test suite: `pytest -q backend/tests` — the suite ran largely green; a small set of webhook/router tests failed in this environment because `DATABASE_URL` is not configured (environment limitation), not because of the profile changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc3a03456c832fa178c452cc7ca5e2)