### PR TITLE
Trigger Auto Create PR workflow for Codex branches

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - "claude/**"
+      - "codex/**"
 
 permissions:
   contents: write


### PR DESCRIPTION
### Motivation
- Ensure branches created by Codex (`codex/**`) run the existing Auto Create PR workflow so PR bodies get the same automatic issue/Epic linking and closing behavior as `claude/**` branches.

### Description
- Add `codex/**` to the `push.branches` list in `.github/workflows/auto-pr.yml` so the workflow triggers on Codex-created branches.

### Testing
- Parsed the updated YAML with `python` and `yaml.safe_load()` which succeeded.
- Ran `git diff --check` to verify there are no whitespace/syntax issues and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc66ffe124832fb5933c38362b8a66)