### PR TITLE
Harden profile menu fallback handling

### DIFF
--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -295,6 +295,7 @@ async def _navigate(
     sub-menu category (already validated by caller).
     """
     level = user.wealth_level
+    user_id = user.id
     if target == "main":
         text, keyboard = format_main_menu(user, level=level)
     elif target == "profile":
@@ -303,7 +304,7 @@ async def _navigate(
         await handle_profile_view(db, chat_id, user, message_id=message_id)
         analytics.track(
             "profile_viewed",
-            user_id=user.id,
+            user_id=user_id,
             properties={"source": "menu"},
         )
         return

--- a/backend/profile/handlers/profile_menu.py
+++ b/backend/profile/handlers/profile_menu.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import re
+from dataclasses import dataclass
 from datetime import time
 from decimal import Decimal
 from typing import Any
@@ -35,6 +36,26 @@ PROFILE_DEGRADED_NOTICE = (
     "_Mình đang hiển thị Profile ở chế độ an toàn; vài số liệu/cài đặt "
     "có thể tạm thời chưa cập nhật._"
 )
+PROFILE_SCHEMA_NOTICE = (
+    "_Profile chưa sẵn sàng vì DB thiếu bảng profile; "
+    "admin chạy `alembic upgrade head` nhé._"
+)
+
+
+@dataclass(frozen=True)
+class ProfileUserSnapshot:
+    """Stable user fields needed to render Profile after DB rollback.
+
+    ``AsyncSession.rollback()`` expires ORM instances. The Profile fallback path
+    must therefore snapshot user fields before any query that can fail; otherwise
+    rendering the degraded profile can trigger another async lazy-load error.
+    """
+
+    id: Any
+    display_name: str | None = None
+    telegram_handle: str | None = None
+    briefing_enabled: bool = True
+    briefing_time: time | None = None
 
 
 def profile_keyboard(
@@ -132,8 +153,8 @@ def time_keyboard(kind: str) -> dict[str, list[list[dict[str, str]]]]:
 
 
 async def get_profile_or_default(
-    db: AsyncSession, user: User
-) -> tuple[UserProfile, bool]:
+    db: AsyncSession, user: User | ProfileUserSnapshot
+) -> tuple[UserProfile, bool, str | None]:
     """Return the saved profile when available, otherwise safe defaults.
 
     The Profile screen is a read path. It should not fail the whole menu just
@@ -145,14 +166,22 @@ async def get_profile_or_default(
         profile = (
             await db.execute(select(UserProfile).where(UserProfile.user_id == user.id))
         ).scalar_one_or_none()
-    except SQLAlchemyError:
-        logger.exception("profile lookup failed; rendering degraded profile")
+    except SQLAlchemyError as exc:
+        notice = (
+            PROFILE_SCHEMA_NOTICE
+            if _looks_like_missing_profile_table(exc)
+            else PROFILE_DEGRADED_NOTICE
+        )
+        logger.exception(
+            "profile lookup failed; rendering degraded profile; schema_hint=%s",
+            notice == PROFILE_SCHEMA_NOTICE,
+        )
         await db.rollback()
-        return _default_profile(user), False
+        return _default_profile(user), False, notice
 
     if profile is not None:
-        return profile, True
-    return _default_profile(user), True
+        return profile, True, None
+    return _default_profile(user), True, None
 
 
 async def get_or_create_profile(db: AsyncSession, user_id) -> UserProfile:
@@ -174,11 +203,11 @@ async def handle_profile_view(
     *,
     message_id: int | None = None,
 ) -> None:
-    profile, profile_editable = await get_profile_or_default(db, user)
-    notice = None
+    user_snapshot = _snapshot_user(user)
+    profile, profile_editable, notice = await get_profile_or_default(db, user_snapshot)
     if profile_editable:
         try:
-            stats = await ProfileStatsAggregator().aggregate(db, user.id)
+            stats = await ProfileStatsAggregator().aggregate(db, user_snapshot.id)
         except SQLAlchemyError:
             logger.exception("profile stats aggregation failed; rendering fallback stats")
             await db.rollback()
@@ -190,8 +219,8 @@ async def handle_profile_view(
             notice = PROFILE_DEGRADED_NOTICE
     else:
         stats = _fallback_stats()
-        notice = PROFILE_DEGRADED_NOTICE
-    text = render_profile(profile, user, stats, notice=notice)
+        notice = notice or PROFILE_DEGRADED_NOTICE
+    text = render_profile(profile, user_snapshot, stats, notice=notice)
     if message_id is None:
         await send_message(
             chat_id=chat_id,
@@ -509,7 +538,27 @@ async def _set_notification_time(
     await db.flush()
 
 
-def _default_profile(user: User) -> UserProfile:
+def _looks_like_missing_profile_table(exc: SQLAlchemyError) -> bool:
+    text = str(exc).lower()
+    return "user_profiles" in text and (
+        "does not exist" in text
+        or "undefinedtable" in text
+        or "missing" in text
+        or "no such table" in text
+    )
+
+
+def _snapshot_user(user: User) -> ProfileUserSnapshot:
+    return ProfileUserSnapshot(
+        id=user.id,
+        display_name=user.display_name,
+        telegram_handle=getattr(user, "telegram_handle", None),
+        briefing_enabled=bool(getattr(user, "briefing_enabled", True)),
+        briefing_time=getattr(user, "briefing_time", None),
+    )
+
+
+def _default_profile(user: User | ProfileUserSnapshot) -> UserProfile:
     profile = UserProfile(user_id=user.id)
     profile.display_name = getattr(user, "display_name", None)
     profile.age_range = None
@@ -539,7 +588,7 @@ def _fallback_stats() -> dict[str, Any]:
     }
 
 
-def _display_name(profile: UserProfile, user: User) -> str:
+def _display_name(profile: UserProfile, user: User | ProfileUserSnapshot) -> str:
     for value in (
         profile.display_name,
         user.display_name,
@@ -582,6 +631,9 @@ def _time_menu_text(kind: str) -> str:
 __all__ = [
     "FLOW_PROFILE",
     "STEP_DISPLAY_NAME",
+    "PROFILE_DEGRADED_NOTICE",
+    "PROFILE_SCHEMA_NOTICE",
+    "ProfileUserSnapshot",
     "STEP_NOTIFICATION_TIME",
     "age_keyboard",
     "get_or_create_profile",

--- a/backend/profile/handlers/profile_menu.py
+++ b/backend/profile/handlers/profile_menu.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import logging
 import re
 from datetime import time
 from decimal import Decimal
 from typing import Any
 
 from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.bot.formatters.money import format_money_short
@@ -13,6 +15,7 @@ from backend.bot.formatters.progress_bar import make_progress_bar
 from backend.models.user import User
 from backend.profile.models.user_profile import AGE_RANGES, UserProfile
 from backend.profile.services.stats_aggregator import ProfileStatsAggregator
+from backend.profile.services.wealth_level_mapper import WealthLevelMapper
 from backend.services import wizard_service
 from backend.services.telegram_service import (
     answer_callback,
@@ -26,19 +29,30 @@ STEP_NOTIFICATION_TIME = "awaiting_notification_time"
 TIME_PRESETS = (time(6, 0), time(7, 0), time(8, 0), time(9, 0))
 _TIME_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
 _CONTROL_CHARS_RE = re.compile(r"[\x00-\x1f\x7f]")
+logger = logging.getLogger(__name__)
+
+PROFILE_DEGRADED_NOTICE = (
+    "_Mình đang hiển thị Profile ở chế độ an toàn; vài số liệu/cài đặt "
+    "có thể tạm thời chưa cập nhật._"
+)
 
 
-def profile_keyboard() -> dict[str, list[list[dict[str, str]]]]:
-    return {
-        "inline_keyboard": [
+def profile_keyboard(
+    *, editable: bool = True
+) -> dict[str, list[list[dict[str, str]]]]:
+    rows = []
+    if editable:
+        rows.extend(
             [
-                {"text": "📝 Đổi tên hiển thị", "callback_data": "profile:edit_name"},
-                {"text": "🎂 Đổi nhóm tuổi", "callback_data": "profile:edit_age"},
-            ],
-            [{"text": "🔔 Cài thông báo", "callback_data": "profile:notifications"}],
-            [{"text": "◀️ Quay lại", "callback_data": "menu:main"}],
-        ]
-    }
+                [
+                    {"text": "📝 Đổi tên hiển thị", "callback_data": "profile:edit_name"},
+                    {"text": "🎂 Đổi nhóm tuổi", "callback_data": "profile:edit_age"},
+                ],
+                [{"text": "🔔 Cài thông báo", "callback_data": "profile:notifications"}],
+            ]
+        )
+    rows.append([{"text": "◀️ Quay lại", "callback_data": "menu:main"}])
+    return {"inline_keyboard": rows}
 
 
 def age_keyboard() -> dict[str, list[list[dict[str, str]]]]:
@@ -117,6 +131,30 @@ def time_keyboard(kind: str) -> dict[str, list[list[dict[str, str]]]]:
     }
 
 
+async def get_profile_or_default(
+    db: AsyncSession, user: User
+) -> tuple[UserProfile, bool]:
+    """Return the saved profile when available, otherwise safe defaults.
+
+    The Profile screen is a read path. It should not fail the whole menu just
+    because the optional profile overlay cannot be read (for example while a
+    migration is being rolled out). Editable actions still use
+    ``get_or_create_profile`` below.
+    """
+    try:
+        profile = (
+            await db.execute(select(UserProfile).where(UserProfile.user_id == user.id))
+        ).scalar_one_or_none()
+    except SQLAlchemyError:
+        logger.exception("profile lookup failed; rendering degraded profile")
+        await db.rollback()
+        return _default_profile(user), False
+
+    if profile is not None:
+        return profile, True
+    return _default_profile(user), True
+
+
 async def get_or_create_profile(db: AsyncSession, user_id) -> UserProfile:
     profile = (
         await db.execute(select(UserProfile).where(UserProfile.user_id == user_id))
@@ -136,15 +174,30 @@ async def handle_profile_view(
     *,
     message_id: int | None = None,
 ) -> None:
-    profile = await get_or_create_profile(db, user.id)
-    stats = await ProfileStatsAggregator().aggregate(db, user.id)
-    text = render_profile(profile, user, stats)
+    profile, profile_editable = await get_profile_or_default(db, user)
+    notice = None
+    if profile_editable:
+        try:
+            stats = await ProfileStatsAggregator().aggregate(db, user.id)
+        except SQLAlchemyError:
+            logger.exception("profile stats aggregation failed; rendering fallback stats")
+            await db.rollback()
+            stats = _fallback_stats()
+            notice = PROFILE_DEGRADED_NOTICE
+        except Exception:
+            logger.exception("profile stats aggregation failed; rendering fallback stats")
+            stats = _fallback_stats()
+            notice = PROFILE_DEGRADED_NOTICE
+    else:
+        stats = _fallback_stats()
+        notice = PROFILE_DEGRADED_NOTICE
+    text = render_profile(profile, user, stats, notice=notice)
     if message_id is None:
         await send_message(
             chat_id=chat_id,
             text=text,
             parse_mode="Markdown",
-            reply_markup=profile_keyboard(),
+            reply_markup=profile_keyboard(editable=profile_editable),
         )
         return
     await edit_message_text(
@@ -152,7 +205,7 @@ async def handle_profile_view(
         message_id=message_id,
         text=text,
         parse_mode="Markdown",
-        reply_markup=profile_keyboard(),
+        reply_markup=profile_keyboard(editable=profile_editable),
     )
 
 
@@ -324,7 +377,13 @@ async def handle_profile_text_input(
     return False
 
 
-def render_profile(profile: UserProfile, user: User, stats: dict[str, Any]) -> str:
+def render_profile(
+    profile: UserProfile,
+    user: User,
+    stats: dict[str, Any],
+    *,
+    notice: str | None = None,
+) -> str:
     level = stats["wealth_level"]
     progress = stats["wealth_progress"]
     name = _display_name(profile, user)
@@ -350,6 +409,9 @@ def render_profile(profile: UserProfile, user: User, stats: dict[str, Any]) -> s
     if change is not None:
         sign = "+" if change >= 0 else ""
         lines.append(f"• Thay đổi tài sản: *{sign}{change:.1f}%*")
+
+    if notice:
+        lines.extend(["", notice])
 
     lines.extend([
         "",
@@ -447,6 +509,36 @@ async def _set_notification_time(
     await db.flush()
 
 
+def _default_profile(user: User) -> UserProfile:
+    profile = UserProfile(user_id=user.id)
+    profile.display_name = getattr(user, "display_name", None)
+    profile.age_range = None
+    profile.briefing_enabled = bool(getattr(user, "briefing_enabled", True))
+    profile.briefing_time = getattr(user, "briefing_time", None) or time(7, 0)
+    profile.reminder_enabled = True
+    profile.reminder_time = time(9, 0)
+    return profile
+
+
+def _fallback_stats() -> dict[str, Any]:
+    mapper = WealthLevelMapper()
+    net_worth = Decimal("0")
+    return {
+        "account_age_days": 0,
+        "net_worth": net_worth,
+        "wealth_level": mapper.get_level(net_worth),
+        "wealth_progress": mapper.get_progress_to_next(net_worth),
+        "asset_types_count": 0,
+        "transaction_count_total": 0,
+        "transaction_count_this_month": 0,
+        "goals_active": 0,
+        "goals_completed": 0,
+        "briefing_read_count": 0,
+        "current_streak": 1,
+        "net_worth_change_pct": None,
+    }
+
+
 def _display_name(profile: UserProfile, user: User) -> str:
     for value in (
         profile.display_name,
@@ -493,6 +585,7 @@ __all__ = [
     "STEP_NOTIFICATION_TIME",
     "age_keyboard",
     "get_or_create_profile",
+    "get_profile_or_default",
     "handle_profile_callback",
     "handle_profile_text_input",
     "handle_profile_view",

--- a/backend/tests/test_menu_v2.py
+++ b/backend/tests/test_menu_v2.py
@@ -289,6 +289,57 @@ class TestHandleMenuCallback:
             is False
         )
 
+    @pytest.mark.asyncio
+    async def test_profile_navigation_tracks_with_snapshotted_user_id(self, monkeypatch):
+        """Profile fallback can rollback the session, which expires ORM users.
+
+        The menu handler must snapshot ``user.id`` before rendering Profile so
+        analytics does not touch an expired ORM object after the rollback.
+        """
+        from backend.bot.handlers import menu_handler
+        from backend.profile.handlers import profile_menu
+
+        expired = False
+
+        class RollbackExpiringUser:
+            wealth_level = "starter"
+
+            @property
+            def id(self):
+                if expired:
+                    raise AssertionError("user.id accessed after profile rollback")
+                return "user-1"
+
+        async def fake_profile_view(*args, **kwargs):
+            nonlocal expired
+            expired = True
+
+        tracked: dict = {}
+
+        def fake_track(event_type, user_id=None, properties=None):
+            tracked.update({
+                "event_type": event_type,
+                "user_id": user_id,
+                "properties": properties,
+            })
+
+        monkeypatch.setattr(profile_menu, "handle_profile_view", fake_profile_view)
+        monkeypatch.setattr(menu_handler.analytics, "track", fake_track)
+
+        await menu_handler._navigate(
+            db=None,
+            user=RollbackExpiringUser(),
+            chat_id=42,
+            message_id=7,
+            target="profile",
+        )
+
+        assert tracked == {
+            "event_type": "profile_viewed",
+            "user_id": "user-1",
+            "properties": {"source": "menu"},
+        }
+
 
 # ============================================================
 # Wealth-level adaptive intros — Story S7 (Epic 2)

--- a/backend/tests/test_phase_3_8_5_profile.py
+++ b/backend/tests/test_phase_3_8_5_profile.py
@@ -7,10 +7,12 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from sqlalchemy.exc import SQLAlchemyError
 
 from backend.jobs.reminder_scheduler_job import _should_send_reminders_now
 from backend.models.user import User
 from backend.profile.handlers.profile_menu import (
+    handle_profile_view,
     notification_keyboard,
     parse_hhmm,
     render_profile,
@@ -119,6 +121,69 @@ def test_render_profile_includes_vn_level_and_stats():
     assert "Tinh Hoa" in text
     assert "8" in text
 
+
+@pytest.mark.asyncio
+async def test_handle_profile_view_degrades_when_profile_storage_fails(monkeypatch):
+    user = User()
+    user.id = uuid.uuid4()
+    user.display_name = "Bé Tiền Test"
+    user.briefing_enabled = True
+    user.briefing_time = time(7, 0)
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=SQLAlchemyError("missing user_profiles"))
+    db.rollback = AsyncMock()
+    sent: dict = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(
+        "backend.profile.handlers.profile_menu.send_message",
+        fake_send_message,
+    )
+
+    await handle_profile_view(db, chat_id=42, user=user)
+
+    assert sent["chat_id"] == 42
+    assert "Profile của Bé Tiền Test" in sent["text"]
+    assert "chế độ an toàn" in sent["text"]
+    assert sent["reply_markup"]["inline_keyboard"] == [
+        [{"text": "◀️ Quay lại", "callback_data": "menu:main"}]
+    ]
+    db.rollback.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_handle_profile_view_degrades_when_stats_fail(monkeypatch):
+    user = User()
+    user.id = uuid.uuid4()
+    user.display_name = "Bé Tiền Test"
+
+    db = MagicMock()
+    db.execute = AsyncMock(return_value=_scalar(None))
+    sent: dict = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    async def fake_aggregate(self, db, user_id):
+        raise RuntimeError("stats backend down")
+
+    monkeypatch.setattr(
+        "backend.profile.handlers.profile_menu.send_message",
+        fake_send_message,
+    )
+    monkeypatch.setattr(
+        "backend.profile.handlers.profile_menu.ProfileStatsAggregator.aggregate",
+        fake_aggregate,
+    )
+
+    await handle_profile_view(db, chat_id=42, user=user)
+
+    assert "Profile của Bé Tiền Test" in sent["text"]
+    assert "chế độ an toàn" in sent["text"]
+    assert len(sent["reply_markup"]["inline_keyboard"]) == 3
 
 
 def test_sanitize_display_name_validates_and_strips_at():

--- a/backend/tests/test_phase_3_8_5_profile.py
+++ b/backend/tests/test_phase_3_8_5_profile.py
@@ -124,15 +124,28 @@ def test_render_profile_includes_vn_level_and_stats():
 
 @pytest.mark.asyncio
 async def test_handle_profile_view_degrades_when_profile_storage_fails(monkeypatch):
-    user = User()
-    user.id = uuid.uuid4()
-    user.display_name = "Bé Tiền Test"
-    user.briefing_enabled = True
-    user.briefing_time = time(7, 0)
+    expired = False
+
+    class RollbackExpiringUser:
+        id = uuid.uuid4()
+        briefing_enabled = True
+        briefing_time = time(7, 0)
+
+        @property
+        def display_name(self):
+            if expired:
+                raise AssertionError("user ORM object was accessed after rollback")
+            return "Bé Tiền Test"
+
+    user = RollbackExpiringUser()
+
+    async def expire_on_rollback():
+        nonlocal expired
+        expired = True
 
     db = MagicMock()
     db.execute = AsyncMock(side_effect=SQLAlchemyError("missing user_profiles"))
-    db.rollback = AsyncMock()
+    db.rollback = AsyncMock(side_effect=expire_on_rollback)
     sent: dict = {}
 
     async def fake_send_message(**kwargs):
@@ -147,7 +160,7 @@ async def test_handle_profile_view_degrades_when_profile_storage_fails(monkeypat
 
     assert sent["chat_id"] == 42
     assert "Profile của Bé Tiền Test" in sent["text"]
-    assert "chế độ an toàn" in sent["text"]
+    assert "alembic upgrade head" in sent["text"]
     assert sent["reply_markup"]["inline_keyboard"] == [
         [{"text": "◀️ Quay lại", "callback_data": "menu:main"}]
     ]


### PR DESCRIPTION
### Motivation
- Clicking Profile could crash the menu when the profile row or stats aggregation failed, showing a generic error instead of the profile; the UI must degrade gracefully so users can still see something and navigate.

### Description
- Add `get_profile_or_default` to safely return a saved `UserProfile` or a `_default_profile` and a boolean `editable` flag, catching `SQLAlchemyError` on lookup.
- Wrap `ProfileStatsAggregator.aggregate` in `handle_profile_view` with error handling to fall back to `_fallback_stats()` and set a `PROFILE_DEGRADED_NOTICE` shown to users.
- Make `profile_keyboard` accept `editable: bool` and render only a back button when not editable to avoid exposing actions that rely on unavailable data.
- Add `_default_profile`, `_fallback_stats`, and surface an optional `notice` in `render_profile` to explain degraded mode.
- Add regression tests `test_handle_profile_view_degrades_when_profile_storage_fails` and `test_handle_profile_view_degrades_when_stats_fail` in `backend/tests/test_phase_3_8_5_profile.py`.

### Testing
- Ran `pytest -q backend/tests/test_phase_3_8_5_profile.py backend/tests/test_menu_v2.py` and the targeted tests passed (`62 passed`).
- Compiled changed modules with `python -m py_compile backend/profile/handlers/profile_menu.py backend/tests/test_phase_3_8_5_profile.py` which succeeded.
- Ran the full test suite (`pytest -q`) which shows unrelated failures in `test_sync_phase_status` and telegram webhook/router tests; those failures pre-existed and are outside the scope of this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc823cf388832fb1873856bedeb9d7)