### PR TITLE
Fix /feedback command wizard start

### DIFF
--- a/backend/feedback/handlers/feedback_command.py
+++ b/backend/feedback/handlers/feedback_command.py
@@ -25,8 +25,10 @@ CONFIRMATION_MESSAGE = (
 CANCEL_MESSAGE = "Đã huỷ gửi feedback rồi nè. Khi nào muốn góp ý, bạn gõ /feedback nhé 💚"
 
 
-async def start_feedback(db: AsyncSession, chat_id: int, user: User, *, trigger: str = "passive_command") -> None:
-    await wizard_service.start(
+async def start_feedback(
+    db: AsyncSession, chat_id: int, user: User, *, trigger: str = "passive_command"
+) -> None:
+    await wizard_service.start_flow(
         db,
         user.id,
         flow=FLOW_FEEDBACK,
@@ -54,7 +56,10 @@ async def handle_feedback_text_input(db: AsyncSession, message: dict) -> bool:
         await send_message(chat_id, CANCEL_MESSAGE, parse_mode="Markdown")
         return True
 
-    trigger = (user.wizard_state or {}).get("draft", {}).get("trigger") or "passive_command"
+    trigger = (
+        (user.wizard_state or {}).get("draft", {}).get("trigger")
+        or "passive_command"
+    )
     try:
         await feedback_service.create_feedback(db, user, text, trigger=trigger)
     except feedback_service.FeedbackValidationError as exc:
@@ -87,7 +92,11 @@ async def handle_feedback_callback(db: AsyncSession, callback_query: dict) -> bo
 
     from backend.services.dashboard_service import get_user_by_telegram_id
 
-    user = await get_user_by_telegram_id(db, telegram_id) if telegram_id is not None else None
+    user = (
+        await get_user_by_telegram_id(db, telegram_id)
+        if telegram_id is not None
+        else None
+    )
     if user is None:
         await answer_callback(callback_id, "Không tìm thấy hồ sơ người dùng.")
         return True
@@ -97,16 +106,21 @@ async def handle_feedback_callback(db: AsyncSession, callback_query: dict) -> bo
         await answer_callback(callback_id, "Đã ghi nhận, để sau nhé 💚")
         return True
     if action == "cta":
-        await wizard_service.start(
+        await wizard_service.start_flow(
             db,
             user.id,
             flow=FLOW_FEEDBACK,
             step=STEP_AWAITING_TEXT,
             draft={"trigger": prompt_id},
         )
-        chat_id = callback_query.get("message", {}).get("chat", {}).get("id") or user.telegram_id
+        chat_id = (
+            callback_query.get("message", {}).get("chat", {}).get("id")
+            or user.telegram_id
+        )
         await answer_callback(callback_id)
-        await send_message(chat_id, "Bạn nhắn cảm nhận của mình ở đây nhé 💚", parse_mode="Markdown")
+        await send_message(
+            chat_id, "Bạn nhắn cảm nhận của mình ở đây nhé 💚", parse_mode="Markdown"
+        )
         return True
 
     await answer_callback(callback_id)

--- a/backend/tests/test_phase_3_8_5_feedback.py
+++ b/backend/tests/test_phase_3_8_5_feedback.py
@@ -66,6 +66,64 @@ async def test_feedback_rate_limit_blocks_sixth_submission():
 
 
 @pytest.mark.asyncio
+async def test_feedback_command_starts_feedback_flow():
+    user = _user()
+    db = MagicMock()
+
+    with patch.object(
+        feedback_command.wizard_service, "start_flow", AsyncMock()
+    ) as start_flow, patch.object(
+        feedback_command, "send_message", AsyncMock()
+    ) as send:
+        await feedback_command.start_feedback(db, chat_id=123, user=user)
+
+    start_flow.assert_awaited_once_with(
+        db,
+        user.id,
+        flow=feedback_command.FLOW_FEEDBACK,
+        step=feedback_command.STEP_AWAITING_TEXT,
+        draft={"trigger": "passive_command"},
+    )
+    assert "lắng nghe" in send.await_args.args[1]
+
+
+@pytest.mark.asyncio
+async def test_feedback_cta_callback_starts_feedback_flow():
+    user = _user()
+    db = MagicMock()
+
+    with patch(
+        "backend.services.dashboard_service.get_user_by_telegram_id",
+        AsyncMock(return_value=user),
+    ), patch.object(
+        feedback_command.wizard_service, "start_flow", AsyncMock()
+    ) as start_flow, patch.object(
+        feedback_command, "send_message", AsyncMock()
+    ) as send, patch.object(
+        feedback_command, "answer_callback", AsyncMock()
+    ):
+        handled = await feedback_command.handle_feedback_callback(
+            db,
+            {
+                "id": "cb-cta",
+                "data": "feedback:cta:post_onboarding_day_7",
+                "from": {"id": 123},
+                "message": {"chat": {"id": 123}},
+            },
+        )
+
+    assert handled is True
+    start_flow.assert_awaited_once_with(
+        db,
+        user.id,
+        flow=feedback_command.FLOW_FEEDBACK,
+        step=feedback_command.STEP_AWAITING_TEXT,
+        draft={"trigger": "post_onboarding_day_7"},
+    )
+    assert "cảm nhận" in send.await_args.args[1]
+
+
+@pytest.mark.asyncio
 async def test_feedback_handler_cancel_clears_state():
     user = _user({"flow": feedback_command.FLOW_FEEDBACK, "step": "awaiting_feedback_text", "draft": {}})
     db = MagicMock()


### PR DESCRIPTION
### Motivation
- Người dùng nhấn `/feedback` nhưng bot không phản hồi vì handler gọi nhầm API `wizard_service.start` (không tồn tại), làm luồng dừng trước khi gửi message.

### Description
- Thay các gọi sai bằng API hiện có `wizard_service.start_flow` trong cả `start_feedback` và nhánh CTA của callback trong `backend/feedback/handlers/feedback_command.py`.
- Chuẩn hóa cách lấy `trigger` từ `wizard_state` và làm một vài tinh chỉnh định dạng nhỏ để dễ đọc.
- Thêm hai test để bảo vệ luồng khởi tạo feedback: `test_feedback_command_starts_feedback_flow` và `test_feedback_cta_callback_starts_feedback_flow` trong `backend/tests/test_phase_3_8_5_feedback.py`.

### Testing
- Chạy kiểm tra bộ liên quan với `pytest -q backend/tests/test_phase_3_8_5_feedback.py backend/tests/test_telegram_worker.py` và tất cả tests đã pass (`28 passed, 7 warnings`).
- Kiểm tra tìm kiếm gọi sai với `rg -n "wizard_service\.start\(" backend -g '*.py'` để đảm bảo không còn gọi tới hàm lỗi.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fc8fd7f650832f997e1f54dcad6f8d)