### PR TITLE
Route transaction-summary queries to `query_expenses` and avoid report fast‑path hijack

### DIFF
--- a/backend/intent/classifier/llm_based.py
+++ b/backend/intent/classifier/llm_based.py
@@ -59,7 +59,7 @@ INTENTS:
 - query_assets: Hỏi về tài sản (BĐS, CK, crypto, vàng, tiền)
 - query_net_worth: Hỏi tổng tài sản / net worth
 - query_portfolio: Hỏi danh mục chứng khoán
-- query_expenses: Hỏi chi tiêu chung
+- query_expenses: Hỏi chi tiêu chung; tổng hợp/báo cáo giao dịch theo thời gian
 - query_expenses_by_category: Hỏi chi tiêu theo loại (ăn uống, sức khỏe...)
 - query_income: Hỏi thu nhập / lương
 - query_cashflow: Hỏi dòng tiền / dư cuối tháng

--- a/backend/services/report_service.py
+++ b/backend/services/report_service.py
@@ -8,6 +8,7 @@ from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.bot.formatters.money import format_money_full, format_money_short
+from backend.intent.extractors._normalize import strip_diacritics
 from backend.models.expense import Expense
 from backend.models.goal import Goal
 from backend.models.report import MonthlyReport
@@ -41,8 +42,19 @@ _REPORT_KEYWORDS = frozenset([
 
 
 def is_report_query(text: str) -> bool:
-    """Return True when text looks like a spending-report request, not an expense entry."""
+    """Return True for monthly report requests, not transaction listings.
+
+    Phrases like "báo cáo giao dịch hôm qua" should go through the
+    intent pipeline as ``query_expenses`` so the time range (including
+    daily ranges) is respected instead of generating the monthly CFO
+    report.
+    """
     lower = text.lower()
+    normalized = strip_diacritics(lower)
+
+    if "giao dich" in normalized:
+        return False
+
     return any(kw in lower for kw in _REPORT_KEYWORDS)
 
 

--- a/backend/tests/test_intent/fixtures/query_examples.yaml
+++ b/backend/tests/test_intent/fixtures/query_examples.yaml
@@ -94,6 +94,17 @@ canonical:
   - text: "tháng này tôi tiết kiệm được bao nhiêu?"
     expected_intent: query_cashflow
     notes: "Net cashflow / saving for the month."
+  - text: "tổng hợp giao dịch tháng trước"
+    expected_intent: query_expenses
+    expected_parameters:
+      time_range: "last_month"
+    notes: "Regression: read-only transaction summary must not fall to LLM/unclear."
+
+  - text: "báo cáo giao dịch hôm qua"
+    expected_intent: query_expenses
+    expected_parameters:
+      time_range: "yesterday"
+    notes: "Regression: report + giao dịch means transaction listing, not monthly CFO report."
 
 
 edge_cases:

--- a/backend/tests/test_report_service.py
+++ b/backend/tests/test_report_service.py
@@ -65,6 +65,13 @@ class TestIsReportQuery:
         assert is_report_query("tháng trước tôi chi tiêu bao nhiêu?") is False
         assert is_report_query("thang truoc toi chi tieu bao nhieu") is False
 
+    def test_does_not_hijack_transaction_summary_queries(self):
+        # Transaction summaries need the intent pipeline so daily/weekly
+        # ranges like "hôm qua" are respected; monthly report_service only
+        # understands month keys.
+        assert is_report_query("báo cáo giao dịch hôm qua") is False
+        assert is_report_query("bao cao giao dich thang truoc") is False
+
 
 class TestExtractMonthKey:
     def test_defaults_to_current_month(self):

--- a/content/intent_patterns.yaml
+++ b/content/intent_patterns.yaml
@@ -95,8 +95,12 @@ query_portfolio:
       confidence: 0.9
 
 query_expenses:
-  description: "User asks about expenses (general, no specific category)."
+  description: "User asks about expenses / transactions (general, no specific category)."
   patterns:
+    # "tổng hợp giao dịch tháng trước" / "báo cáo giao dịch hôm qua"
+    # are read-only transaction summaries, not quick-transaction writes.
+    - pattern: '(?:tong\s*hop|bao\s*cao|liet\s*ke|xem).*(?:giao\s*dich|chi\s*(?:tieu|phi)).*(?:thang|tuan|nam|hom)'
+      confidence: 0.92
     - pattern: 'chi\s*(?:tieu|phi).*(?:thang|tuan|nam|hom)'
       confidence: 0.9
     - pattern: '(?:toi|minh).*(?:da\s+)?(?:chi|tieu).*(?:thang|tuan)'


### PR DESCRIPTION
### Motivation
- Users asking e.g. "tổng hợp giao dịch tháng trước" were not matched by rules and either fell to the LLM/UNCLEAR or were intercepted by the legacy monthly-report fast-path, losing correct time-range handling like `hôm qua` / `tháng trước`.
- Fix routing so read-only transaction-summary phrases go to the `query_expenses` intent (rule layer) and the monthly-report fast-path does not hijack messages that mention "giao dịch".

### Description
- Added a high-confidence regex pattern to `content/intent_patterns.yaml` under `query_expenses` to match phrases like `tổng hợp/ báo cáo / liệt kê / xem ... giao dịch ... (tháng|tuần|hôm)` so they classify as `query_expenses` with an extracted `time_range`.
- Updated `backend/services/report_service.py::is_report_query` to strip diacritics and return `False` when the normalized text contains `giao dich`, so transaction-summary messages fall through to the intent pipeline instead of the monthly-report fast-path.
- Imported `strip_diacritics` in `report_service.py` to support the new check and kept month-extraction logic unchanged.
- Clarified the LLM classifier prompt in `backend/intent/classifier/llm_based.py` to note that `query_expenses` covers transaction-summary/reporting phrasing, aligning LLM fallbacks with rule semantics.
- Added regression coverage: appended two canonical fixtures to `backend/tests/test_intent/fixtures/query_examples.yaml` for `"tổng hợp giao dịch tháng trước"` and `"báo cáo giao dịch hôm qua"` and a test in `backend/tests/test_report_service.py` to assert the report fast-path no longer hijacks transaction-summary queries.

### Testing
- Ran a quick local check with `RuleBasedClassifier().classify(...)` and `is_report_query(...)` for representative phrases; rule classifications matched and `is_report_query` returned `False` for transaction-summary inputs (manual check passed).
- Ran targeted unit tests: `pytest backend/tests/test_report_service.py::TestIsReportQuery backend/tests/test_intent/test_rule_based.py -q` which passed (the rule-based and report-query tests covering the changes succeeded).
- Ran full test suite `pytest -q`; the failures are unrelated existing tests (sync-phase-status / Telegram DB wiring) caused by environment/test harness issues (missing env DB and script shape), not by intent/report changes. The intent/report tests introduced here passed in isolation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd44986f88832f9553da144d71c102)