### PR TITLE
Phase 3.9 — Market data foundation (Epic 1)

### DIFF
--- a/backend/market_data/__init__.py
+++ b/backend/market_data/__init__.py
@@ -1,0 +1,11 @@
+"""Market data foundation for Phase 3.9.
+
+This package contains provider abstractions, normalized quote models,
+Redis-backed caching, and dispatcher utilities used by concrete market data
+integrations.
+"""
+
+from backend.market_data.base import BaseProvider
+from backend.market_data.normalizer import PriceQuote
+
+__all__ = ["BaseProvider", "PriceQuote"]

--- a/backend/market_data/analytics/__init__.py
+++ b/backend/market_data/analytics/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3.9 market data subpackage."""

--- a/backend/market_data/base.py
+++ b/backend/market_data/base.py
@@ -1,0 +1,23 @@
+"""Base provider contract for market data integrations."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+
+from backend.market_data.normalizer import PriceQuote
+
+
+class BaseProvider(ABC):
+    """Common async interface implemented by every market data provider."""
+
+    @abstractmethod
+    async def fetch_quote(self, symbol: str) -> PriceQuote:
+        """Fetch one normalized quote for ``symbol``."""
+
+    @abstractmethod
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+        """Fetch normalized quotes for many symbols."""
+
+    @property
+    @abstractmethod
+    def asset_type(self) -> str:
+        """Asset type produced by this provider (stock, crypto, gold, ...)."""

--- a/backend/market_data/cache/__init__.py
+++ b/backend/market_data/cache/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3.9 market data subpackage."""

--- a/backend/market_data/cache/cache_keys.py
+++ b/backend/market_data/cache/cache_keys.py
@@ -1,0 +1,24 @@
+"""Redis key helpers for market data."""
+from __future__ import annotations
+
+PREFIX = "market_data"
+
+
+def quote_key(asset_type: str, symbol: str) -> str:
+    return f"{PREFIX}:{asset_type.lower()}:{symbol.upper()}"
+
+
+def last_known_key(asset_type: str, symbol: str) -> str:
+    return f"{quote_key(asset_type, symbol)}:last_known"
+
+
+def asset_pattern(asset_type: str) -> str:
+    return f"{PREFIX}:{asset_type.lower()}:*"
+
+
+def health_failures_key(provider_name: str) -> str:
+    return f"{PREFIX}:health:{provider_name}:failures"
+
+
+def health_open_until_key(provider_name: str) -> str:
+    return f"{PREFIX}:health:{provider_name}:open_until"

--- a/backend/market_data/cache/price_cache.py
+++ b/backend/market_data/cache/price_cache.py
@@ -1,0 +1,84 @@
+"""Redis-backed price cache with per-asset TTLs and last-known fallback."""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any, Protocol
+
+from backend.market_data.cache.cache_keys import asset_pattern, last_known_key, quote_key
+from backend.market_data.normalizer import PriceQuote
+
+
+class RedisLike(Protocol):
+    """Subset of redis.asyncio.Redis used by PriceCache."""
+
+    async def get(self, key: str) -> str | bytes | None: ...
+    async def set(self, key: str, value: str) -> Any: ...
+    async def setex(self, key: str, time: int, value: str) -> Any: ...
+    async def delete(self, *keys: str) -> int: ...
+    def scan_iter(self, match: str) -> Any: ...
+
+TTL_SECONDS: dict[str, int] = {
+    "stock": 300,
+    "crypto": 120,
+    "gold": 3600,
+    "bank_rate": 604800,
+    "news": 1800,
+}
+
+
+class PriceCache:
+    """Small async wrapper around ``redis.asyncio.Redis`` for PriceQuote data."""
+
+    def __init__(self, redis_client: RedisLike):
+        self.redis = redis_client
+
+    @staticmethod
+    def key_for(asset_type: str, symbol: str) -> str:
+        return quote_key(asset_type, symbol)
+
+    @staticmethod
+    def last_known_key_for(asset_type: str, symbol: str) -> str:
+        return last_known_key(asset_type, symbol)
+
+    async def get(self, key: str) -> PriceQuote | None:
+        """Return a cached quote by exact key, or ``None`` on miss/expiry."""
+        raw = await self.redis.get(key)
+        if raw is None:
+            return None
+        return PriceQuote.from_json(raw)
+
+    async def set(self, quote: PriceQuote) -> None:
+        """Store quote under the standard key using the asset-type TTL."""
+        ttl = TTL_SECONDS[quote.asset_type]
+        await self.redis.setex(quote_key(quote.asset_type, quote.symbol), ttl, quote.to_json())
+
+    async def set_last_known(self, quote: PriceQuote) -> None:
+        """Store last-known quote without TTL; later writes win."""
+        await self.redis.set(last_known_key(quote.asset_type, quote.symbol), quote.to_json())
+
+    async def get_last_known(
+        self,
+        symbol: str,
+        asset_type: str | None = None,
+    ) -> PriceQuote | None:
+        """Return last-known quote, optionally scoped to an asset type."""
+        asset_types = [asset_type.lower()] if asset_type else list(TTL_SECONDS)
+        for candidate_type in asset_types:
+            raw = await self.redis.get(last_known_key(candidate_type, symbol))
+            if raw is not None:
+                return PriceQuote.from_json(raw).mark_stale()
+        return None
+
+    async def flush_asset_type(self, asset_type: str) -> int:
+        """Delete all market-data keys for one asset type and return count."""
+        keys: list[str] = []
+        scanner = self.redis.scan_iter(match=asset_pattern(asset_type))
+        if isinstance(scanner, AsyncIterator):
+            async for key in scanner:
+                keys.append(key.decode("utf-8") if isinstance(key, bytes) else key)
+        else:
+            for key in scanner:
+                keys.append(key.decode("utf-8") if isinstance(key, bytes) else key)
+        if not keys:
+            return 0
+        return int(await self.redis.delete(*keys))

--- a/backend/market_data/exceptions.py
+++ b/backend/market_data/exceptions.py
@@ -1,0 +1,26 @@
+"""Exception hierarchy for market data providers and cache consumers."""
+from __future__ import annotations
+
+
+class MarketDataError(Exception):
+    """Base class for all market data errors."""
+
+
+class ProviderUnavailable(MarketDataError):
+    """Provider is temporarily unavailable or returned a server error."""
+
+
+class RateLimitError(MarketDataError):
+    """Provider rate limit was reached."""
+
+
+class ParserError(MarketDataError):
+    """Provider response could not be parsed into the normalized schema."""
+
+
+class SymbolNotFound(MarketDataError):
+    """Provider does not know the requested symbol."""
+
+
+class StaleDataWarning(Warning):
+    """Warning emitted when callers receive last-known stale market data."""

--- a/backend/market_data/jobs/__init__.py
+++ b/backend/market_data/jobs/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3.9 market data subpackage."""

--- a/backend/market_data/normalizer.py
+++ b/backend/market_data/normalizer.py
@@ -1,0 +1,80 @@
+"""Normalized quote model used across providers, cache, and consumers."""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Self
+
+
+@dataclass(slots=True)
+class PriceQuote:
+    """Unified representation for a market price.
+
+    ``price`` is intentionally a ``Decimal`` to avoid float rounding in money
+    calculations. ``is_stale`` supports the Phase 3.9 stale-while-revalidate
+    fallback while keeping the core schema additive.
+    """
+
+    symbol: str
+    price: Decimal
+    currency: str
+    asset_type: str
+    fetched_at: datetime
+    source: str
+    metadata: dict[str, Any] = field(default_factory=dict)
+    is_stale: bool = False
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.price, Decimal):
+            self.price = Decimal(str(self.price))
+        self.symbol = self.symbol.upper()
+        self.currency = self.currency.upper()
+        self.asset_type = self.asset_type.lower()
+        if self.fetched_at.tzinfo is None:
+            self.fetched_at = self.fetched_at.replace(tzinfo=timezone.utc)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dictionary representation."""
+        return {
+            "symbol": self.symbol,
+            "price": str(self.price),
+            "currency": self.currency,
+            "asset_type": self.asset_type,
+            "fetched_at": self.fetched_at.isoformat(),
+            "source": self.source,
+            "metadata": self.metadata,
+            "is_stale": self.is_stale,
+        }
+
+    def to_json(self) -> str:
+        """Serialize quote to a Redis-friendly JSON string."""
+        return json.dumps(self.to_dict(), ensure_ascii=False, sort_keys=True)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        """Build a quote from a dictionary produced by ``to_dict``."""
+        return cls(
+            symbol=str(data["symbol"]),
+            price=Decimal(str(data["price"])),
+            currency=str(data["currency"]),
+            asset_type=str(data["asset_type"]),
+            fetched_at=datetime.fromisoformat(str(data["fetched_at"])),
+            source=str(data["source"]),
+            metadata=dict(data.get("metadata") or {}),
+            is_stale=bool(data.get("is_stale", False)),
+        )
+
+    @classmethod
+    def from_json(cls, value: str | bytes) -> Self:
+        """Deserialize a quote from a Redis string/bytes payload."""
+        if isinstance(value, bytes):
+            value = value.decode("utf-8")
+        return cls.from_dict(json.loads(value))
+
+    def mark_stale(self) -> Self:
+        """Return a copy marked as stale for fallback responses."""
+        data = self.to_dict()
+        data["is_stale"] = True
+        return self.from_dict(data)

--- a/backend/market_data/providers/__init__.py
+++ b/backend/market_data/providers/__init__.py
@@ -1,0 +1,1 @@
+"""Phase 3.9 market data subpackage."""

--- a/backend/market_data/providers/base_dispatcher.py
+++ b/backend/market_data/providers/base_dispatcher.py
@@ -1,0 +1,122 @@
+"""Provider dispatcher with primary/secondary fallback and Redis circuit breaker."""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Protocol
+
+from backend.market_data.base import BaseProvider
+from backend.market_data.cache.cache_keys import health_failures_key, health_open_until_key
+from backend.market_data.exceptions import ProviderUnavailable, RateLimitError
+from backend.market_data.normalizer import PriceQuote
+
+
+class RedisLike(Protocol):
+    """Subset of redis.asyncio.Redis used by Dispatcher."""
+
+    async def get(self, key: str) -> str | bytes | None: ...
+    async def setex(self, key: str, time: int, value: str) -> Any: ...
+    async def incr(self, key: str) -> int: ...
+    async def expire(self, key: str, time: int) -> Any: ...
+    async def delete(self, *keys: str) -> int: ...
+
+logger = logging.getLogger(__name__)
+
+_FAILURE_THRESHOLD = 5
+_FAILURE_WINDOW_SECONDS = 60
+_OPEN_SECONDS = 300
+
+_RETRYABLE_ERRORS = (asyncio.TimeoutError, TimeoutError, ProviderUnavailable, RateLimitError)
+
+
+class Dispatcher:
+    """Fetch through primary provider first, falling back to secondary provider."""
+
+    def __init__(
+        self,
+        primary: BaseProvider,
+        secondary: BaseProvider,
+        redis_client: RedisLike,
+        timeout: float = 3.0,
+    ) -> None:
+        self.primary = primary
+        self.secondary = secondary
+        self.redis = redis_client
+        self.timeout = timeout
+
+    @property
+    def asset_type(self) -> str:
+        return self.primary.asset_type
+
+    async def fetch_quote(self, symbol: str) -> PriceQuote:
+        """Fetch one quote, using circuit state to decide provider order."""
+        if not await self._is_circuit_open(self.primary):
+            try:
+                return await self._call_provider(self.primary, symbol)
+            except _RETRYABLE_ERRORS as exc:
+                await self._record_failure(self.primary)
+                logger.warning(
+                    "Primary provider failed for %s, falling back to secondary: %s",
+                    symbol,
+                    exc,
+                )
+        else:
+            logger.info(
+                "Circuit OPEN for %s; skipping primary for %s",
+                self._provider_name(self.primary),
+                symbol,
+            )
+
+        return await self._call_secondary(symbol)
+
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+        """Fetch many symbols sequentially through dispatcher fallback logic."""
+        return [await self.fetch_quote(symbol) for symbol in symbols]
+
+    async def _call_secondary(self, symbol: str) -> PriceQuote:
+        try:
+            return await self._call_provider(self.secondary, symbol)
+        except _RETRYABLE_ERRORS:
+            await self._record_failure(self.secondary)
+            raise
+
+    async def _call_provider(self, provider: BaseProvider, symbol: str) -> PriceQuote:
+        quote = await asyncio.wait_for(provider.fetch_quote(symbol), timeout=self.timeout)
+        await self._record_success(provider)
+        return quote
+
+    async def _is_circuit_open(self, provider: BaseProvider) -> bool:
+        name = self._provider_name(provider)
+        raw = await self.redis.get(health_open_until_key(name))
+        if raw is None:
+            return False
+        open_until = float(raw.decode("utf-8") if isinstance(raw, bytes) else raw)
+        if open_until > time.time():
+            return True
+        logger.info("Circuit HALF-OPEN for %s, testing", name)
+        return False
+
+    async def _record_failure(self, provider: BaseProvider) -> None:
+        name = self._provider_name(provider)
+        failures_key = health_failures_key(name)
+        failures = int(await self.redis.incr(failures_key))
+        if failures == 1:
+            await self.redis.expire(failures_key, _FAILURE_WINDOW_SECONDS)
+        if failures >= _FAILURE_THRESHOLD:
+            await self._open_circuit(name)
+
+    async def _record_success(self, provider: BaseProvider) -> None:
+        name = self._provider_name(provider)
+        deleted = await self.redis.delete(health_failures_key(name), health_open_until_key(name))
+        if deleted:
+            logger.info("Circuit CLOSED for %s", name)
+
+    async def _open_circuit(self, provider_name: str) -> None:
+        open_until = time.time() + _OPEN_SECONDS
+        await self.redis.setex(health_open_until_key(provider_name), _OPEN_SECONDS, str(open_until))
+        logger.warning("Circuit OPEN for %s", provider_name)
+
+    @staticmethod
+    def _provider_name(provider: BaseProvider) -> str:
+        return str(getattr(provider, "name", provider.__class__.__name__)).lower()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -24,6 +24,8 @@ google-api-python-client>=2.120.0
 notion-client>=2.2.0
 
 # Market data
+redis>=5.0.0
+fakeredis>=2.23.0
 vnstock>=0.2.9
 requests>=2.31.0
 beautifulsoup4>=4.12.0

--- a/backend/tests/test_market_data/fakes.py
+++ b/backend/tests/test_market_data/fakes.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import fnmatch
+import time
+from collections.abc import AsyncIterator
+
+
+class FakeAsyncRedis:
+    def __init__(self) -> None:
+        self.store: dict[str, str] = {}
+        self.expires: dict[str, float] = {}
+
+    def _expired(self, key: str) -> bool:
+        expires_at = self.expires.get(key)
+        if expires_at is None or expires_at > time.time():
+            return False
+        self.store.pop(key, None)
+        self.expires.pop(key, None)
+        return True
+
+    async def get(self, key: str):
+        if self._expired(key):
+            return None
+        return self.store.get(key)
+
+    async def set(self, key: str, value: str):
+        self.store[key] = value
+        self.expires.pop(key, None)
+        return True
+
+    async def setex(self, key: str, ttl: int, value: str):
+        self.store[key] = value
+        self.expires[key] = time.time() + ttl
+        return True
+
+    async def incr(self, key: str):
+        current = await self.get(key)
+        value = int(current or 0) + 1
+        self.store[key] = str(value)
+        return value
+
+    async def expire(self, key: str, ttl: int):
+        if key not in self.store:
+            return False
+        self.expires[key] = time.time() + ttl
+        return True
+
+    async def delete(self, *keys: str):
+        deleted = 0
+        for key in keys:
+            if key in self.store:
+                deleted += 1
+            self.store.pop(key, None)
+            self.expires.pop(key, None)
+        return deleted
+
+    async def scan_iter(self, match: str) -> AsyncIterator[str]:
+        for key in list(self.store):
+            if not self._expired(key) and fnmatch.fnmatch(key, match):
+                yield key

--- a/backend/tests/test_market_data/test_dispatcher.py
+++ b/backend/tests/test_market_data/test_dispatcher.py
@@ -1,0 +1,121 @@
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from backend.market_data.base import BaseProvider
+from backend.market_data.cache.cache_keys import health_failures_key, health_open_until_key
+from backend.market_data.exceptions import ProviderUnavailable
+from backend.market_data.normalizer import PriceQuote
+from backend.market_data.providers.base_dispatcher import Dispatcher
+from backend.tests.test_market_data.fakes import FakeAsyncRedis
+
+
+class ProviderStub(BaseProvider):
+    def __init__(self, name: str, *, fail_times: int = 0) -> None:
+        self.name = name
+        self.fail_times = fail_times
+        self.calls = 0
+
+    @property
+    def asset_type(self) -> str:
+        return "stock"
+
+    async def fetch_quote(self, symbol: str) -> PriceQuote:
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            raise ProviderUnavailable(self.name)
+        return PriceQuote(
+            symbol=symbol,
+            price=Decimal("100"),
+            currency="VND",
+            asset_type="stock",
+            fetched_at=datetime(2026, 5, 8, tzinfo=timezone.utc),
+            source=self.name,
+        )
+
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+        return [await self.fetch_quote(symbol) for symbol in symbols]
+
+
+@pytest.mark.asyncio
+async def test_closed_circuit_uses_primary_provider():
+    redis = FakeAsyncRedis()
+    primary = ProviderStub("ssi")
+    secondary = ProviderStub("vndirect")
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    quote = await dispatcher.fetch_quote("VNM")
+
+    assert quote.source == "ssi"
+    assert primary.calls == 1
+    assert secondary.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_primary_failure_falls_back_and_opens_after_five_failures():
+    redis = FakeAsyncRedis()
+    primary = ProviderStub("ssi", fail_times=5)
+    secondary = ProviderStub("vndirect")
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    for _ in range(5):
+        quote = await dispatcher.fetch_quote("VNM")
+        assert quote.source == "vndirect"
+
+    assert await redis.get(health_failures_key("ssi")) == "5"
+    assert await redis.get(health_open_until_key("ssi")) is not None
+
+
+@pytest.mark.asyncio
+async def test_open_circuit_skips_primary_and_uses_secondary():
+    redis = FakeAsyncRedis()
+    primary = ProviderStub("ssi")
+    secondary = ProviderStub("vndirect")
+    await redis.setex(health_open_until_key("ssi"), 300, str(time.time() + 300))
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    quote = await dispatcher.fetch_quote("VNM")
+
+    assert quote.source == "vndirect"
+    assert primary.calls == 0
+    assert secondary.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_half_open_success_closes_circuit():
+    redis = FakeAsyncRedis()
+    primary = ProviderStub("ssi")
+    secondary = ProviderStub("vndirect")
+    await redis.set(health_failures_key("ssi"), "5")
+    await redis.setex(health_open_until_key("ssi"), 300, str(time.time() - 1))
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    quote = await dispatcher.fetch_quote("VNM")
+
+    assert quote.source == "ssi"
+    assert await redis.get(health_failures_key("ssi")) is None
+    assert await redis.get(health_open_until_key("ssi")) is None
+
+
+@pytest.mark.asyncio
+async def test_timeout_is_retryable_and_falls_back():
+    class SlowProvider(ProviderStub):
+        async def fetch_quote(self, symbol: str) -> PriceQuote:
+            self.calls += 1
+            await asyncio.sleep(0.05)
+            return await super().fetch_quote(symbol)
+
+    redis = FakeAsyncRedis()
+    primary = SlowProvider("ssi")
+    secondary = ProviderStub("vndirect")
+    dispatcher = Dispatcher(primary, secondary, redis, timeout=0.001)
+
+    quote = await dispatcher.fetch_quote("VNM")
+
+    assert quote.source == "vndirect"
+    assert await redis.get(health_failures_key("ssi")) == "1"

--- a/backend/tests/test_market_data/test_normalizer.py
+++ b/backend/tests/test_market_data/test_normalizer.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+from backend.market_data.normalizer import PriceQuote
+
+
+def test_price_quote_json_round_trip_preserves_decimal_and_metadata():
+    quote = PriceQuote(
+        symbol="vnm",
+        price=Decimal("86400.50"),
+        currency="vnd",
+        asset_type="stock",
+        fetched_at=datetime(2026, 5, 8, 9, 30, tzinfo=timezone.utc),
+        source="ssi",
+        metadata={"volume": 12345, "change_pct": "1.25"},
+    )
+
+    restored = PriceQuote.from_json(quote.to_json())
+
+    assert restored == quote
+    assert isinstance(restored.price, Decimal)
+    assert restored.symbol == "VNM"
+    assert restored.currency == "VND"
+
+
+def test_price_quote_marks_naive_datetime_as_utc_and_can_mark_stale():
+    quote = PriceQuote(
+        symbol="btc",
+        price=Decimal("2500000000"),
+        currency="vnd",
+        asset_type="crypto",
+        fetched_at=datetime(2026, 5, 8, 9, 30),
+        source="coingecko",
+    )
+
+    stale = quote.mark_stale()
+
+    assert quote.fetched_at.tzinfo is timezone.utc
+    assert stale.is_stale is True
+    assert quote.is_stale is False

--- a/backend/tests/test_market_data/test_price_cache.py
+++ b/backend/tests/test_market_data/test_price_cache.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+
+import pytest
+
+from backend.market_data.cache.cache_keys import last_known_key, quote_key
+from backend.market_data.cache.price_cache import PriceCache
+from backend.market_data.normalizer import PriceQuote
+from backend.tests.test_market_data.fakes import FakeAsyncRedis
+
+
+def _quote(symbol: str = "VNM", asset_type: str = "stock") -> PriceQuote:
+    return PriceQuote(
+        symbol=symbol,
+        price=Decimal("86400"),
+        currency="VND",
+        asset_type=asset_type,
+        fetched_at=datetime(2026, 5, 8, 9, 30, tzinfo=timezone.utc),
+        source="ssi",
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_and_get_use_standard_key_and_ttl():
+    redis = FakeAsyncRedis()
+    cache = PriceCache(redis)
+    quote = _quote()
+
+    await cache.set(quote)
+    restored = await cache.get(quote_key("stock", "VNM"))
+
+    assert restored == quote
+    assert quote_key("stock", "VNM") in redis.expires
+
+
+@pytest.mark.asyncio
+async def test_get_returns_none_after_expiry():
+    redis = FakeAsyncRedis()
+    cache = PriceCache(redis)
+    key = quote_key("stock", "VNM")
+    await redis.setex(key, -1, _quote().to_json())
+
+    assert await cache.get(key) is None
+
+
+@pytest.mark.asyncio
+async def test_last_known_has_no_ttl_and_is_marked_stale_on_read():
+    redis = FakeAsyncRedis()
+    cache = PriceCache(redis)
+    quote = _quote()
+
+    await cache.set_last_known(quote)
+    restored = await cache.get_last_known("VNM", "stock")
+
+    assert restored is not None
+    assert restored.symbol == "VNM"
+    assert restored.is_stale is True
+    assert last_known_key("stock", "VNM") not in redis.expires
+
+
+@pytest.mark.asyncio
+async def test_flush_asset_type_deletes_matching_keys_only():
+    redis = FakeAsyncRedis()
+    cache = PriceCache(redis)
+    await cache.set(_quote("VNM", "stock"))
+    await cache.set_last_known(_quote("VNM", "stock"))
+    await cache.set(_quote("BTC", "crypto"))
+
+    deleted = await cache.flush_asset_type("stock")
+
+    assert deleted == 2
+    assert await redis.get(quote_key("stock", "VNM")) is None
+    assert await redis.get(quote_key("crypto", "BTC")) is not None


### PR DESCRIPTION
### Motivation
- Thiết lập nền tảng cho Phase 3.9 để thay thế stub bằng provider thực, chuẩn hoá interface và cache cho mọi nguồn dữ liệu thị trường.
- Cần một layer tách biệt (providers, cache, jobs, analytics) để dễ mock, test và mở rộng (SSI/VNDIRECT/CoinGecko/...).
- Giải quyết yêu cầu S1-S3 của Epic 1: base contract, PriceQuote model, Redis cache và dispatcher với circuit breaker.

### Description
- Thêm package `backend.market_data` với subpackages `providers`, `cache`, `jobs`, `analytics` và export `BaseProvider` + `PriceQuote`.
- Implement `BaseProvider` contract, `PriceQuote` dataclass với `Decimal`-based serialization (`to_json`/`from_json`), và exception hierarchy (`MarketDataError`, `ProviderUnavailable`, `RateLimitError`, `ParserError`, `SymbolNotFound`, `StaleDataWarning`).
- Thêm Redis key helpers và `PriceCache` hỗ trợ TTL per-asset, `set_last_known` (no TTL), `get_last_known` (mark stale) và `flush_asset_type`.
- Implement generic `Dispatcher` (primary → secondary) với timeout handling và Redis-backed circuit breaker (closed / open / half-open) logic.
- Thêm unit tests for normalizer, cache, dispatcher and small `FakeAsyncRedis` for test isolation, và bổ sung dev dependencies `redis` + `fakeredis` in `backend/requirements.txt`.

### Testing
- Compiled new modules with `python -m compileall -q backend/market_data backend/tests/test_market_data` and compilation succeeded.
- Ran unit tests with `python -m pytest backend/tests/test_market_data -q` and all tests passed (`11 passed`).
- Static type check with `python -m mypy backend/market_data` completed with no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6c8adbc4832f968156b51dd373b0)