### PR TITLE
Phase 3.9 Epic 2 — stock & crypto market providers, cache, jobs, valuation integration

### DIFF
--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -59,6 +59,10 @@ class Settings(BaseSettings):
     telegram_webhook_secret: str = ""  # Validates webhook requests from Telegram
     owner_telegram_id: str = ""
 
+    # Market data
+    redis_url: str = "redis://localhost:6379/0"
+    market_data_timeout_seconds: float = 3.0
+
     # OpenClaw Skills
     finance_api_url: str = "http://localhost:8001/api/v1"
     finance_api_key: str = ""

--- a/backend/market_data/client.py
+++ b/backend/market_data/client.py
@@ -1,0 +1,74 @@
+"""Cache-first quote accessors used by jobs and wealth valuation."""
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+from typing import Any, Protocol
+
+from backend.config import get_settings
+from backend.market_data.cache.cache_keys import quote_key
+from backend.market_data.cache.price_cache import PriceCache
+from backend.market_data.exceptions import ProviderUnavailable
+from backend.market_data.normalizer import PriceQuote
+from backend.market_data.providers.base_dispatcher import Dispatcher
+from backend.market_data.providers.crypto_coingecko import CoinGeckoCryptoProvider
+from backend.market_data.providers.stock_dispatcher import build_stock_dispatcher
+
+logger = logging.getLogger(__name__)
+
+
+class QuoteProvider(Protocol):
+    async def fetch_quote(self, symbol: str) -> PriceQuote: ...
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]: ...
+
+
+@lru_cache
+def get_redis_client() -> Any:
+    from redis.asyncio import Redis
+
+    settings = get_settings()
+    return Redis.from_url(settings.redis_url, decode_responses=True)
+
+
+def get_price_cache() -> PriceCache:
+    return PriceCache(get_redis_client())
+
+
+def get_stock_provider() -> Dispatcher:
+    return build_stock_dispatcher(get_redis_client(), timeout=get_settings().market_data_timeout_seconds)
+
+
+def get_crypto_provider() -> CoinGeckoCryptoProvider:
+    return CoinGeckoCryptoProvider(timeout=get_settings().market_data_timeout_seconds)
+
+
+async def get_quote(asset_type: str, symbol: str, provider: QuoteProvider) -> PriceQuote:
+    """Return cached quote first; otherwise fetch, cache, and fallback to last-known."""
+    cache = get_price_cache()
+    try:
+        cached = await cache.get(quote_key(asset_type, symbol))
+        if cached is not None:
+            return cached
+        quote = await provider.fetch_quote(symbol)
+        await cache.set(quote)
+        await cache.set_last_known(quote)
+        return quote
+    except Exception as exc:
+        try:
+            last_known = await cache.get_last_known(symbol, asset_type)
+        except Exception:
+            last_known = None
+        if last_known is not None:
+            logger.warning("Using stale %s quote for %s after provider error: %s", asset_type, symbol, exc)
+            return last_known
+        if isinstance(exc, ProviderUnavailable):
+            raise
+        raise ProviderUnavailable(f"Unable to fetch {asset_type} quote for {symbol}: {exc}") from exc
+
+
+async def get_stock_quote(symbol: str) -> PriceQuote:
+    return await get_quote("stock", symbol, get_stock_provider())
+
+
+async def get_crypto_quote(symbol: str) -> PriceQuote:
+    return await get_quote("crypto", symbol, get_crypto_provider())

--- a/backend/market_data/jobs/crypto_updater.py
+++ b/backend/market_data/jobs/crypto_updater.py
@@ -1,0 +1,49 @@
+"""Scheduled crypto cache warmer for Phase 3.9."""
+from __future__ import annotations
+
+import logging
+import time
+
+from sqlalchemy import select
+
+from backend.database import get_session_factory
+from backend.market_data.client import get_crypto_provider, get_price_cache
+from backend.wealth.models.asset import Asset
+
+logger = logging.getLogger(__name__)
+
+
+async def _held_crypto_symbols(db) -> list[str]:
+    """Return distinct crypto symbols from active assets."""
+    stmt = select(Asset.extra).where(Asset.asset_type == "crypto", Asset.is_active.is_(True))
+    result = await db.execute(stmt)
+    symbols = {
+        str((extra or {}).get("symbol") or (extra or {}).get("ticker") or "").upper().strip()
+        for extra in result.scalars().all()
+    }
+    return sorted(symbol for symbol in symbols if symbol)
+
+
+async def update_all_held_crypto() -> dict[str, int]:
+    """Fetch all held crypto symbols and write regular + last-known cache entries."""
+    started = time.perf_counter()
+    async with get_session_factory()() as db:
+        symbols = await _held_crypto_symbols(db)
+    if not symbols:
+        logger.info("Crypto updater no-op: symbols_attempted=0 symbols_succeeded=0 duration_ms=0")
+        return {"symbols_attempted": 0, "symbols_succeeded": 0, "duration_ms": 0}
+
+    provider = get_crypto_provider()
+    cache = get_price_cache()
+    quotes = await provider.fetch_batch(symbols)
+    for quote in quotes:
+        await cache.set(quote)
+        await cache.set_last_known(quote)
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    metrics = {
+        "symbols_attempted": len(symbols),
+        "symbols_succeeded": len(quotes),
+        "duration_ms": duration_ms,
+    }
+    logger.info("Crypto updater complete: %s", metrics)
+    return metrics

--- a/backend/market_data/jobs/stock_updater.py
+++ b/backend/market_data/jobs/stock_updater.py
@@ -1,0 +1,49 @@
+"""Scheduled stock cache warmer for Phase 3.9."""
+from __future__ import annotations
+
+import logging
+import time
+
+from sqlalchemy import select
+
+from backend.database import get_session_factory
+from backend.market_data.client import get_price_cache, get_stock_provider
+from backend.wealth.models.asset import Asset
+
+logger = logging.getLogger(__name__)
+
+
+async def _held_stock_symbols(db) -> list[str]:
+    """Return distinct stock tickers from active assets."""
+    stmt = select(Asset.extra).where(Asset.asset_type == "stock", Asset.is_active.is_(True))
+    result = await db.execute(stmt)
+    symbols = {
+        str((extra or {}).get("ticker") or (extra or {}).get("symbol") or "").upper().strip()
+        for extra in result.scalars().all()
+    }
+    return sorted(symbol for symbol in symbols if symbol)
+
+
+async def update_all_held_stocks() -> dict[str, int]:
+    """Fetch all held stock symbols and write regular + last-known cache entries."""
+    started = time.perf_counter()
+    async with get_session_factory()() as db:
+        symbols = await _held_stock_symbols(db)
+    if not symbols:
+        logger.info("Stock updater no-op: symbols_attempted=0 symbols_succeeded=0 duration_ms=0")
+        return {"symbols_attempted": 0, "symbols_succeeded": 0, "duration_ms": 0}
+
+    provider = get_stock_provider()
+    cache = get_price_cache()
+    quotes = await provider.fetch_batch(symbols)
+    for quote in quotes:
+        await cache.set(quote)
+        await cache.set_last_known(quote)
+    duration_ms = int((time.perf_counter() - started) * 1000)
+    metrics = {
+        "symbols_attempted": len(symbols),
+        "symbols_succeeded": len(quotes),
+        "duration_ms": duration_ms,
+    }
+    logger.info("Stock updater complete: %s", metrics)
+    return metrics

--- a/backend/market_data/normalizer.py
+++ b/backend/market_data/normalizer.py
@@ -35,6 +35,19 @@ class PriceQuote:
         if self.fetched_at.tzinfo is None:
             self.fetched_at = self.fetched_at.replace(tzinfo=timezone.utc)
 
+    @staticmethod
+    def _json_safe(value: Any) -> Any:
+        """Convert nested Decimal/datetime metadata to JSON-safe values."""
+        if isinstance(value, Decimal):
+            return str(value)
+        if isinstance(value, datetime):
+            return value.isoformat()
+        if isinstance(value, dict):
+            return {key: PriceQuote._json_safe(item) for key, item in value.items()}
+        if isinstance(value, list):
+            return [PriceQuote._json_safe(item) for item in value]
+        return value
+
     def to_dict(self) -> dict[str, Any]:
         """Return a JSON-safe dictionary representation."""
         return {
@@ -44,7 +57,7 @@ class PriceQuote:
             "asset_type": self.asset_type,
             "fetched_at": self.fetched_at.isoformat(),
             "source": self.source,
-            "metadata": self.metadata,
+            "metadata": self._json_safe(self.metadata),
             "is_stale": self.is_stale,
         }
 

--- a/backend/market_data/providers/__init__.py
+++ b/backend/market_data/providers/__init__.py
@@ -1,1 +1,13 @@
-"""Phase 3.9 market data subpackage."""
+"""Concrete market data providers."""
+
+from backend.market_data.providers.crypto_coingecko import CoinGeckoCryptoProvider
+from backend.market_data.providers.stock_dispatcher import build_stock_dispatcher
+from backend.market_data.providers.stock_ssi import SSIStockProvider
+from backend.market_data.providers.stock_vndirect import VNDIRECTStockProvider
+
+__all__ = [
+    "CoinGeckoCryptoProvider",
+    "SSIStockProvider",
+    "VNDIRECTStockProvider",
+    "build_stock_dispatcher",
+]

--- a/backend/market_data/providers/coingecko_symbols.py
+++ b/backend/market_data/providers/coingecko_symbols.py
@@ -1,0 +1,30 @@
+"""Ticker to CoinGecko coin-id mapping for common crypto holdings."""
+from __future__ import annotations
+
+COINGECKO_SYMBOLS: dict[str, str] = {
+    "BTC": "bitcoin",
+    "ETH": "ethereum",
+    "USDT": "tether",
+    "BNB": "binancecoin",
+    "SOL": "solana",
+    "USDC": "usd-coin",
+    "XRP": "ripple",
+    "DOGE": "dogecoin",
+    "ADA": "cardano",
+    "TRX": "tron",
+    "AVAX": "avalanche-2",
+    "SHIB": "shiba-inu",
+    "DOT": "polkadot",
+    "LINK": "chainlink",
+    "BCH": "bitcoin-cash",
+    "NEAR": "near",
+    "MATIC": "matic-network",
+    "LTC": "litecoin",
+    "UNI": "uniswap",
+    "ATOM": "cosmos",
+    "ETC": "ethereum-classic",
+    "FIL": "filecoin",
+    "APT": "aptos",
+    "ARB": "arbitrum",
+    "OP": "optimism",
+}

--- a/backend/market_data/providers/crypto_coingecko.py
+++ b/backend/market_data/providers/crypto_coingecko.py
@@ -1,0 +1,119 @@
+"""CoinGecko free-tier crypto price provider."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Awaitable, Callable
+
+import httpx
+
+from backend.market_data.base import BaseProvider
+from backend.market_data.exceptions import ParserError, ProviderUnavailable, RateLimitError, SymbolNotFound
+from backend.market_data.normalizer import PriceQuote
+from backend.market_data.providers.coingecko_symbols import COINGECKO_SYMBOLS
+from backend.market_data.providers.http_utils import require_decimal
+
+SleepFunc = Callable[[float], Awaitable[None]]
+
+
+class CoinGeckoCryptoProvider(BaseProvider):
+    """Fetch crypto prices from CoinGecko simple price API."""
+
+    name = "coingecko"
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.coingecko.com/api/v3",
+        timeout: float = 3.0,
+        client: httpx.AsyncClient | None = None,
+        sleep: SleepFunc = asyncio.sleep,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._client = client
+        self._sleep = sleep
+
+    @property
+    def asset_type(self) -> str:
+        return "crypto"
+
+    async def fetch_quote(self, symbol: str) -> PriceQuote:
+        quotes = await self.fetch_batch([symbol])
+        if not quotes:
+            raise SymbolNotFound(symbol)
+        return quotes[0]
+
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+        clean_symbols = [symbol.upper().strip() for symbol in symbols if symbol.strip()]
+        if not clean_symbols:
+            return []
+        unknown = [symbol for symbol in clean_symbols if symbol not in COINGECKO_SYMBOLS]
+        if unknown:
+            raise SymbolNotFound(f"Unsupported crypto symbol(s): {', '.join(unknown)}")
+        ids_by_symbol = {symbol: COINGECKO_SYMBOLS[symbol] for symbol in clean_symbols}
+        payload = await self._get_json(
+            "/simple/price",
+            params={
+                "ids": ",".join(ids_by_symbol.values()),
+                "vs_currencies": "usd,vnd",
+                "include_24hr_change": "true",
+                "include_24hr_vol": "true",
+            },
+        )
+        fetched_at = datetime.now(timezone.utc)
+        quotes: list[PriceQuote] = []
+        for symbol, coin_id in ids_by_symbol.items():
+            data = payload.get(coin_id) if isinstance(payload, dict) else None
+            if not isinstance(data, dict):
+                raise SymbolNotFound(f"CoinGecko missing data for {symbol}")
+            price = require_decimal(data.get("vnd"), "vnd")
+            quotes.append(
+                PriceQuote(
+                    symbol=symbol,
+                    price=price,
+                    currency="VND",
+                    asset_type="crypto",
+                    fetched_at=fetched_at,
+                    source="coingecko",
+                    metadata={
+                        "coin_id": coin_id,
+                        "usd": require_decimal(data.get("usd"), "usd") if data.get("usd") is not None else None,
+                        "change_pct_24h": require_decimal(data.get("vnd_24h_change"), "vnd_24h_change") if data.get("vnd_24h_change") is not None else None,
+                        "volume_24h": require_decimal(data.get("vnd_24h_vol"), "vnd_24h_vol") if data.get("vnd_24h_vol") is not None else None,
+                    },
+                )
+            )
+        return quotes
+
+    async def _get_json(self, path: str, *, params: dict[str, str]) -> Any:
+        delays = (1, 2, 4)
+        last_rate_limit: RateLimitError | None = None
+        for attempt in range(len(delays) + 1):
+            response = await self._request(path, params=params)
+            if response.status_code != 429:
+                self._raise_for_status(response)
+                payload = response.json()
+                if not isinstance(payload, dict):
+                    raise ParserError("CoinGecko returned unsupported payload")
+                return payload
+            last_rate_limit = RateLimitError("CoinGecko rate limit reached")
+            if attempt < len(delays):
+                await self._sleep(delays[attempt])
+        raise last_rate_limit or RateLimitError("CoinGecko rate limit reached")
+
+    async def _request(self, path: str, *, params: dict[str, str]) -> httpx.Response:
+        if self._client is not None:
+            return await self._client.get(path, params=params)
+        async with httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout) as client:
+            return await client.get(path, params=params)
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.status_code == 404:
+            raise SymbolNotFound("CoinGecko symbol not found")
+        if 400 <= response.status_code < 500:
+            raise ProviderUnavailable(f"CoinGecko client error {response.status_code}")
+        if response.status_code >= 500:
+            raise ProviderUnavailable(f"CoinGecko server error {response.status_code}")

--- a/backend/market_data/providers/http_utils.py
+++ b/backend/market_data/providers/http_utils.py
@@ -1,0 +1,62 @@
+"""HTTP parsing helpers shared by market data providers."""
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from typing import Any
+
+from backend.market_data.exceptions import ParserError
+
+
+def decimal_or_none(value: Any) -> Decimal | None:
+    """Convert provider value to ``Decimal``; blank/non-numeric values become None."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, str):
+        value = value.replace(",", "").strip()
+    try:
+        return Decimal(str(value))
+    except (InvalidOperation, ValueError):
+        return None
+
+
+def require_decimal(value: Any, field: str) -> Decimal:
+    """Convert provider value to ``Decimal`` or raise ``ParserError``."""
+    parsed = decimal_or_none(value)
+    if parsed is None:
+        raise ParserError(f"Missing or invalid decimal field: {field}")
+    return parsed
+
+
+def first_present(data: dict[str, Any], names: tuple[str, ...]) -> Any:
+    """Return the first present/non-empty value from provider payload."""
+    for name in names:
+        value = data.get(name)
+        if value is not None and value != "":
+            return value
+    return None
+
+
+def unwrap_first_record(payload: Any) -> dict[str, Any]:
+    """Extract one quote-like record from common API response envelopes."""
+    if isinstance(payload, list):
+        if not payload:
+            raise ParserError("Provider returned an empty list")
+        record = payload[0]
+    elif isinstance(payload, dict):
+        record = payload
+        for key in ("data", "items", "result", "rows", "list"):
+            nested = payload.get(key)
+            if isinstance(nested, list):
+                if not nested:
+                    raise ParserError(f"Provider returned empty {key}")
+                record = nested[0]
+                break
+            if isinstance(nested, dict):
+                record = nested
+                break
+    else:
+        raise ParserError("Provider returned unsupported payload")
+
+    if not isinstance(record, dict):
+        raise ParserError("Provider record is not an object")
+    return record

--- a/backend/market_data/providers/stock_dispatcher.py
+++ b/backend/market_data/providers/stock_dispatcher.py
@@ -1,0 +1,16 @@
+"""Factory for stock quote dispatcher (SSI primary, VNDIRECT backup)."""
+from __future__ import annotations
+
+from backend.market_data.providers.base_dispatcher import Dispatcher, RedisLike
+from backend.market_data.providers.stock_ssi import SSIStockProvider
+from backend.market_data.providers.stock_vndirect import VNDIRECTStockProvider
+
+
+def build_stock_dispatcher(redis_client: RedisLike, *, timeout: float = 3.0) -> Dispatcher:
+    """Build the Phase 3.9 stock dispatcher with SSI primary and VNDIRECT backup."""
+    return Dispatcher(
+        SSIStockProvider(timeout=timeout),
+        VNDIRECTStockProvider(timeout=timeout),
+        redis_client,
+        timeout=timeout,
+    )

--- a/backend/market_data/providers/stock_ssi.py
+++ b/backend/market_data/providers/stock_ssi.py
@@ -1,0 +1,131 @@
+"""SSI iBoard provider for Vietnamese stock quotes."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+from backend.market_data.base import BaseProvider
+from backend.market_data.exceptions import ParserError, ProviderUnavailable, RateLimitError, SymbolNotFound
+from backend.market_data.normalizer import PriceQuote
+from backend.market_data.providers.http_utils import decimal_or_none, first_present, require_decimal, unwrap_first_record
+
+
+class SSIStockProvider(BaseProvider):
+    """Fetch and normalize SSI iBoard stock quotes."""
+
+    name = "ssi"
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://iboard.ssi.com.vn/dchart/api",
+        timeout: float = 3.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._client = client
+
+    @property
+    def asset_type(self) -> str:
+        return "stock"
+
+    async def fetch_quote(self, symbol: str) -> PriceQuote:
+        symbol = symbol.upper().strip()
+        payload = await self._get_json("/1.1/defaultAllStocks", params={"symbol": symbol})
+        record = self._find_symbol_record(payload, symbol)
+        return self._parse_record(record, symbol)
+
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+        clean_symbols = [symbol.upper().strip() for symbol in symbols if symbol.strip()]
+        if not clean_symbols:
+            return []
+        try:
+            payload = await self._get_json(
+                "/1.1/defaultAllStocks",
+                params={"symbols": ",".join(clean_symbols)},
+            )
+            records = self._unwrap_records(payload)
+            by_symbol = {
+                str(first_present(record, ("symbol", "stockSymbol", "code", "ticker")) or "").upper(): record
+                for record in records
+            }
+            if by_symbol:
+                return [self._parse_record(by_symbol[symbol], symbol) for symbol in clean_symbols if symbol in by_symbol]
+        except (ParserError, SymbolNotFound):
+            pass
+        return await asyncio.gather(*(self.fetch_quote(symbol) for symbol in clean_symbols))
+
+    async def _get_json(self, path: str, *, params: dict[str, str]) -> Any:
+        async def request(client: httpx.AsyncClient) -> httpx.Response:
+            return await client.get(path, params=params)
+
+        if self._client is not None:
+            response = await request(self._client)
+        else:
+            async with httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout) as client:
+                response = await request(client)
+        self._raise_for_status(response)
+        return response.json()
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.status_code == 429:
+            raise RateLimitError("SSI rate limit reached")
+        if response.status_code == 404:
+            raise SymbolNotFound("SSI symbol not found")
+        if 400 <= response.status_code < 500:
+            raise ProviderUnavailable(f"SSI client error {response.status_code}")
+        if response.status_code >= 500:
+            raise ProviderUnavailable(f"SSI server error {response.status_code}")
+
+    def _find_symbol_record(self, payload: Any, symbol: str) -> dict[str, Any]:
+        records = self._unwrap_records(payload)
+        for record in records:
+            record_symbol = first_present(record, ("symbol", "stockSymbol", "code", "ticker"))
+            if str(record_symbol or "").upper() == symbol:
+                return record
+        if len(records) == 1:
+            return records[0]
+        raise SymbolNotFound(f"SSI symbol not found: {symbol}")
+
+    @staticmethod
+    def _unwrap_records(payload: Any) -> list[dict[str, Any]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            for key in ("data", "items", "result", "rows", "list"):
+                nested = payload.get(key)
+                if isinstance(nested, list):
+                    return [item for item in nested if isinstance(item, dict)]
+            return [unwrap_first_record(payload)]
+        raise ParserError("SSI returned unsupported payload")
+
+    @staticmethod
+    def _parse_record(record: dict[str, Any], symbol: str) -> PriceQuote:
+        price = require_decimal(
+            first_present(record, ("matchedPrice", "lastPrice", "price", "closePrice", "last")),
+            "price",
+        )
+        if price < Decimal("1000"):
+            price *= Decimal("1000")
+        metadata = {
+            "volume": decimal_or_none(first_present(record, ("nmVolume", "volume", "matchedVolume"))),
+            "change_pct": decimal_or_none(first_present(record, ("changePercent", "change_pct", "percentPriceChange"))),
+            "high": decimal_or_none(first_present(record, ("highest", "high", "ceilingPrice"))),
+            "low": decimal_or_none(first_present(record, ("lowest", "low", "floorPrice"))),
+            "open": decimal_or_none(first_present(record, ("open", "openPrice", "refPrice"))),
+        }
+        return PriceQuote(
+            symbol=symbol,
+            price=price,
+            currency="VND",
+            asset_type="stock",
+            fetched_at=datetime.now(timezone.utc),
+            source="ssi",
+            metadata=metadata,
+        )

--- a/backend/market_data/providers/stock_vndirect.py
+++ b/backend/market_data/providers/stock_vndirect.py
@@ -1,0 +1,114 @@
+"""VNDIRECT provider used as backup for Vietnamese stock quotes."""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any
+
+import httpx
+
+from backend.market_data.base import BaseProvider
+from backend.market_data.exceptions import ParserError, ProviderUnavailable, RateLimitError, SymbolNotFound
+from backend.market_data.normalizer import PriceQuote
+from backend.market_data.providers.http_utils import decimal_or_none, first_present, require_decimal, unwrap_first_record
+
+
+class VNDIRECTStockProvider(BaseProvider):
+    """Fetch and normalize VNDIRECT stock quotes."""
+
+    name = "vndirect"
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api-finfo.vndirect.com.vn/v4",
+        timeout: float = 3.0,
+        client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self._client = client
+
+    @property
+    def asset_type(self) -> str:
+        return "stock"
+
+    async def fetch_quote(self, symbol: str) -> PriceQuote:
+        symbol = symbol.upper().strip()
+        payload = await self._get_json("/stock_prices", params={"q": f"code:{symbol}", "size": "1"})
+        record = unwrap_first_record(payload)
+        return self._parse_record(record, symbol)
+
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+        clean_symbols = [symbol.upper().strip() for symbol in symbols if symbol.strip()]
+        if not clean_symbols:
+            return []
+        q = "~".join(f"code:{symbol}" for symbol in clean_symbols)
+        try:
+            payload = await self._get_json("/stock_prices", params={"q": q, "size": str(len(clean_symbols))})
+            records = self._unwrap_records(payload)
+            by_symbol = {str(first_present(record, ("code", "symbol", "ticker")) or "").upper(): record for record in records}
+            return [self._parse_record(by_symbol[symbol], symbol) for symbol in clean_symbols if symbol in by_symbol]
+        except (ParserError, SymbolNotFound):
+            return await asyncio.gather(*(self.fetch_quote(symbol) for symbol in clean_symbols))
+
+    async def _get_json(self, path: str, *, params: dict[str, str]) -> Any:
+        async def request(client: httpx.AsyncClient) -> httpx.Response:
+            return await client.get(path, params=params)
+
+        if self._client is not None:
+            response = await request(self._client)
+        else:
+            async with httpx.AsyncClient(base_url=self.base_url, timeout=self.timeout) as client:
+                response = await request(client)
+        self._raise_for_status(response)
+        return response.json()
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        if response.status_code == 429:
+            raise RateLimitError("VNDIRECT rate limit reached")
+        if response.status_code == 404:
+            raise SymbolNotFound("VNDIRECT symbol not found")
+        if 400 <= response.status_code < 500:
+            raise ProviderUnavailable(f"VNDIRECT client error {response.status_code}")
+        if response.status_code >= 500:
+            raise ProviderUnavailable(f"VNDIRECT server error {response.status_code}")
+
+    @staticmethod
+    def _unwrap_records(payload: Any) -> list[dict[str, Any]]:
+        if isinstance(payload, list):
+            return [item for item in payload if isinstance(item, dict)]
+        if isinstance(payload, dict):
+            for key in ("data", "items", "result", "rows"):
+                nested = payload.get(key)
+                if isinstance(nested, list):
+                    return [item for item in nested if isinstance(item, dict)]
+            return [unwrap_first_record(payload)]
+        raise ParserError("VNDIRECT returned unsupported payload")
+
+    @staticmethod
+    def _parse_record(record: dict[str, Any], symbol: str) -> PriceQuote:
+        record_symbol = first_present(record, ("code", "symbol", "ticker"))
+        if record_symbol and str(record_symbol).upper() != symbol:
+            raise SymbolNotFound(f"VNDIRECT symbol mismatch: {symbol}")
+        price = require_decimal(first_present(record, ("close", "last", "price", "matchPrice")), "price")
+        if price < Decimal("1000"):
+            price *= Decimal("1000")
+        metadata = {
+            "volume": decimal_or_none(first_present(record, ("volume", "nmVolume", "accumulatedVolume"))),
+            "change_pct": decimal_or_none(first_present(record, ("pctChange", "changePercent", "change_pct"))),
+            "high": decimal_or_none(first_present(record, ("high", "highest"))),
+            "low": decimal_or_none(first_present(record, ("low", "lowest"))),
+            "open": decimal_or_none(first_present(record, ("open", "openPrice", "reference"))),
+        }
+        return PriceQuote(
+            symbol=symbol,
+            price=price,
+            currency="VND",
+            asset_type="stock",
+            fetched_at=datetime.now(timezone.utc),
+            source="vndirect",
+            metadata=metadata,
+        )

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -25,6 +25,8 @@ from backend.jobs.reminder_scheduler_job import run_reminder_scheduler
 from backend.jobs.seasonal_notifier import run_seasonal_check
 from backend.jobs.weekly_fun_facts import run_weekly_fun_facts
 from backend.jobs.weekly_goal_reminder import run_weekly_goal_reminder
+from backend.market_data.jobs.crypto_updater import update_all_held_crypto
+from backend.market_data.jobs.stock_updater import update_all_held_stocks
 
 logger = logging.getLogger(__name__)
 
@@ -102,6 +104,18 @@ def register_jobs(scheduler: AsyncIOScheduler) -> None:
         run_reminder_scheduler, "interval",
         minutes=15, timezone="Asia/Ho_Chi_Minh",
         id="recurring_reminders",
+    )
+    # Phase 3.9 Epic 2 — pre-warm real market data cache.
+    scheduler.add_job(
+        update_all_held_stocks, "cron",
+        minute="*/15", hour="9-15", day_of_week="mon-fri",
+        timezone="Asia/Ho_Chi_Minh",
+        id="stock_price_updater",
+    )
+    scheduler.add_job(
+        update_all_held_crypto, "interval",
+        minutes=5, timezone="Asia/Ho_Chi_Minh",
+        id="crypto_price_updater",
     )
 
 

--- a/backend/tests/test_market_data/test_crypto_coingecko.py
+++ b/backend/tests/test_market_data/test_crypto_coingecko.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from backend.market_data.exceptions import RateLimitError, SymbolNotFound
+from backend.market_data.providers.coingecko_symbols import COINGECKO_SYMBOLS
+from backend.market_data.providers.crypto_coingecko import CoinGeckoCryptoProvider
+
+
+@pytest.mark.asyncio
+async def test_coingecko_mapping_has_minimum_common_symbols():
+    assert len(COINGECKO_SYMBOLS) >= 20
+    assert COINGECKO_SYMBOLS["BTC"] == "bitcoin"
+
+
+@pytest.mark.asyncio
+async def test_fetch_quote_returns_vnd_price():
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(
+            200,
+            json={"bitcoin": {"vnd": 2500000000, "usd": 100000, "vnd_24h_change": 2.5}},
+            request=request,
+        )
+    )
+    async with httpx.AsyncClient(base_url="https://example.test", transport=transport) as client:
+        quote = await CoinGeckoCryptoProvider(client=client).fetch_quote("BTC")
+
+    assert quote.price == Decimal("2500000000")
+    assert quote.currency == "VND"
+    assert quote.metadata["coin_id"] == "bitcoin"
+
+
+@pytest.mark.asyncio
+async def test_fetch_batch_uses_one_comma_separated_request():
+    seen_ids = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_ids.append(request.url.params["ids"])
+        return httpx.Response(
+            200,
+            json={
+                "bitcoin": {"vnd": 1},
+                "ethereum": {"vnd": 2},
+            },
+            request=request,
+        )
+
+    async with httpx.AsyncClient(base_url="https://example.test", transport=httpx.MockTransport(handler)) as client:
+        quotes = await CoinGeckoCryptoProvider(client=client).fetch_batch(["BTC", "ETH"])
+
+    assert seen_ids == ["bitcoin,ethereum"]
+    assert [quote.symbol for quote in quotes] == ["BTC", "ETH"]
+
+
+@pytest.mark.asyncio
+async def test_unknown_symbol_raises_symbol_not_found():
+    provider = CoinGeckoCryptoProvider()
+    with pytest.raises(SymbolNotFound):
+        await provider.fetch_quote("NOPE")
+
+
+@pytest.mark.asyncio
+async def test_429_retries_with_exponential_backoff_then_raises():
+    sleeps = []
+    transport = httpx.MockTransport(lambda request: httpx.Response(429, json={}, request=request))
+
+    async def fake_sleep(delay: float) -> None:
+        sleeps.append(delay)
+
+    async with httpx.AsyncClient(base_url="https://example.test", transport=transport) as client:
+        with pytest.raises(RateLimitError):
+            await CoinGeckoCryptoProvider(client=client, sleep=fake_sleep).fetch_quote("BTC")
+
+    assert sleeps == [1, 2, 4]

--- a/backend/tests/test_market_data/test_manual_integration.py
+++ b/backend/tests/test_market_data/test_manual_integration.py
@@ -1,0 +1,20 @@
+"""Manual live-provider checks for Phase 3.9.
+
+These tests are skipped in CI/local default runs because they call public market
+APIs. Run explicitly with ``pytest ... -rs`` after removing the skip marker when
+validating provider endpoints against live data.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.market_data.providers.stock_ssi import SSIStockProvider
+
+
+@pytest.mark.asyncio
+@pytest.mark.skip(reason="Manual live SSI iBoard check; do not run in CI")
+async def test_ssi_live_vnm_quote_manual():
+    quote = await SSIStockProvider().fetch_quote("VNM")
+
+    assert quote.symbol == "VNM"
+    assert quote.price > 0

--- a/backend/tests/test_market_data/test_stock_providers.py
+++ b/backend/tests/test_market_data/test_stock_providers.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+import httpx
+import pytest
+
+from backend.market_data.exceptions import ProviderUnavailable, RateLimitError, SymbolNotFound
+from backend.market_data.providers.base_dispatcher import Dispatcher
+from backend.market_data.providers.stock_ssi import SSIStockProvider
+from backend.market_data.providers.stock_vndirect import VNDIRECTStockProvider
+from backend.tests.test_market_data.fakes import FakeAsyncRedis
+
+
+def _client(status: int, payload):
+    transport = httpx.MockTransport(
+        lambda request: httpx.Response(status, json=payload, request=request)
+    )
+    return httpx.AsyncClient(base_url="https://example.test", transport=transport)
+
+
+@pytest.mark.asyncio
+async def test_ssi_success_parses_metadata():
+    async with _client(200, {"data": [{"stockSymbol": "VNM", "matchedPrice": 86.4, "nmVolume": 1000, "changePercent": 1.2, "highest": 87, "lowest": 85, "open": 86}]}) as client:
+        quote = await SSIStockProvider(client=client).fetch_quote("VNM")
+
+    assert quote.symbol == "VNM"
+    assert quote.price == Decimal("86400.0")
+    assert quote.metadata["volume"] == Decimal("1000")
+    assert quote.metadata["change_pct"] == Decimal("1.2")
+
+
+@pytest.mark.asyncio
+async def test_ssi_404_maps_to_symbol_not_found():
+    async with _client(404, {}) as client:
+        with pytest.raises(SymbolNotFound):
+            await SSIStockProvider(client=client).fetch_quote("BAD")
+
+
+@pytest.mark.asyncio
+async def test_ssi_500_maps_to_provider_unavailable():
+    async with _client(500, {}) as client:
+        with pytest.raises(ProviderUnavailable):
+            await SSIStockProvider(client=client).fetch_quote("VNM")
+
+
+@pytest.mark.asyncio
+async def test_ssi_429_maps_to_rate_limit():
+    async with _client(429, {}) as client:
+        with pytest.raises(RateLimitError):
+            await SSIStockProvider(client=client).fetch_quote("VNM")
+
+
+@pytest.mark.asyncio
+async def test_vndirect_parser_normalizes_schema():
+    async with _client(200, {"data": [{"code": "FPT", "close": 123.5, "volume": 99, "pctChange": -0.5, "high": 124, "low": 122, "open": 123}]}) as client:
+        quote = await VNDIRECTStockProvider(client=client).fetch_quote("FPT")
+
+    assert quote.symbol == "FPT"
+    assert quote.price == Decimal("123500.0")
+    assert quote.metadata["high"] == Decimal("124")
+
+
+@pytest.mark.asyncio
+async def test_dispatcher_falls_back_to_vndirect_when_ssi_fails():
+    async with _client(500, {}) as ssi_client, _client(200, {"data": [{"code": "VNM", "close": 88}]}) as vnd_client:
+        dispatcher = Dispatcher(
+            SSIStockProvider(client=ssi_client),
+            VNDIRECTStockProvider(client=vnd_client),
+            FakeAsyncRedis(),
+        )
+        quote = await dispatcher.fetch_quote("VNM")
+
+    assert quote.source == "vndirect"
+    assert quote.price == Decimal("88000")

--- a/backend/tests/test_market_data/test_updater_jobs.py
+++ b/backend/tests/test_market_data/test_updater_jobs.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.market_data.cache.price_cache import PriceCache
+from backend.market_data.jobs import crypto_updater, stock_updater
+from backend.market_data.normalizer import PriceQuote
+from backend.tests.test_market_data.fakes import FakeAsyncRedis
+
+
+class _Result:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class _DB:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def execute(self, stmt):
+        return _Result(self.rows)
+
+
+class _SessionCtx:
+    def __init__(self, db):
+        self.db = db
+
+    async def __aenter__(self):
+        return self.db
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def _session_factory(rows):
+    return lambda: _SessionCtx(_DB(rows))
+
+
+def _quote(symbol: str, asset_type: str) -> PriceQuote:
+    return PriceQuote(symbol, Decimal("10"), "VND", asset_type, datetime.now(timezone.utc), "test")
+
+
+@pytest.mark.asyncio
+async def test_stock_updater_noops_when_no_symbols():
+    with patch.object(stock_updater, "get_session_factory", return_value=_session_factory([])):
+        metrics = await stock_updater.update_all_held_stocks()
+
+    assert metrics["symbols_attempted"] == 0
+    assert metrics["symbols_succeeded"] == 0
+
+
+@pytest.mark.asyncio
+async def test_stock_updater_fetches_distinct_symbols_and_writes_cache():
+    redis = FakeAsyncRedis()
+    provider = MagicMock()
+    provider.fetch_batch = AsyncMock(return_value=[_quote("VNM", "stock")])
+    with patch.object(stock_updater, "get_session_factory", return_value=_session_factory([{"ticker": "VNM"}, {"ticker": "vnm"}])), patch.object(stock_updater, "get_stock_provider", return_value=provider), patch.object(stock_updater, "get_price_cache", return_value=PriceCache(redis)):
+        metrics = await stock_updater.update_all_held_stocks()
+
+    provider.fetch_batch.assert_awaited_once_with(["VNM"])
+    assert metrics["symbols_attempted"] == 1
+    assert metrics["symbols_succeeded"] == 1
+    assert await redis.get("market_data:stock:VNM") is not None
+    assert await redis.get("market_data:stock:VNM:last_known") is not None
+
+
+@pytest.mark.asyncio
+async def test_crypto_updater_fetches_distinct_symbols_and_writes_cache():
+    redis = FakeAsyncRedis()
+    provider = MagicMock()
+    provider.fetch_batch = AsyncMock(return_value=[_quote("BTC", "crypto")])
+    with patch.object(crypto_updater, "get_session_factory", return_value=_session_factory([{"symbol": "BTC"}])), patch.object(crypto_updater, "get_crypto_provider", return_value=provider), patch.object(crypto_updater, "get_price_cache", return_value=PriceCache(redis)):
+        metrics = await crypto_updater.update_all_held_crypto()
+
+    provider.fetch_batch.assert_awaited_once_with(["BTC"])
+    assert metrics["symbols_attempted"] == 1
+    assert metrics["symbols_succeeded"] == 1
+    assert await redis.get("market_data:crypto:BTC") is not None

--- a/backend/tests/test_wealth_valuation_market_data.py
+++ b/backend/tests/test_wealth_valuation_market_data.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.market_data.exceptions import ProviderUnavailable
+from backend.market_data.normalizer import PriceQuote
+from backend.wealth.models.asset import Asset
+from backend.wealth.valuation.crypto import value_crypto_holding
+from backend.wealth.valuation.stock import value_stock_holding
+
+
+def _asset(asset_type: str, extra: dict, current_value=Decimal("8000000")) -> Asset:
+    a = Asset()
+    a.asset_type = asset_type
+    a.name = extra.get("ticker") or extra.get("symbol") or "asset"
+    a.extra = extra
+    a.initial_value = Decimal("7000000")
+    a.current_value = current_value
+    return a
+
+
+def _quote(symbol: str, price: str, asset_type: str, *, is_stale=False) -> PriceQuote:
+    return PriceQuote(symbol, Decimal(price), "VND", asset_type, datetime.now(timezone.utc), "test", is_stale=is_stale)
+
+
+@pytest.mark.asyncio
+async def test_stock_valuation_uses_market_price_and_pnl():
+    with patch("backend.wealth.valuation.stock.get_stock_quote", AsyncMock(return_value=_quote("VNM", "90000", "stock"))):
+        valuation = await value_stock_holding(_asset("stock", {"ticker": "VNM", "quantity": 100, "avg_price": 80000}))
+
+    assert valuation.current_price == Decimal("90000")
+    assert valuation.current_value == Decimal("9000000")
+    assert valuation.pnl_pct == Decimal("12.500")
+    assert valuation.is_stale is False
+
+
+@pytest.mark.asyncio
+async def test_stock_valuation_fallback_uses_user_input_price_and_marks_stale():
+    with patch("backend.wealth.valuation.stock.get_stock_quote", AsyncMock(side_effect=ProviderUnavailable("down"))):
+        valuation = await value_stock_holding(_asset("stock", {"ticker": "VNM", "quantity": 100, "avg_price": 80000}))
+
+    assert valuation.current_price == Decimal("80000")
+    assert valuation.current_value == Decimal("8000000")
+    assert valuation.pnl_pct == Decimal("0")
+    assert valuation.is_stale is True
+
+
+@pytest.mark.asyncio
+async def test_crypto_valuation_uses_market_price_and_pnl():
+    with patch("backend.wealth.valuation.crypto.get_crypto_quote", AsyncMock(return_value=_quote("BTC", "120", "crypto"))):
+        valuation = await value_crypto_holding(_asset("crypto", {"symbol": "BTC", "quantity": "2", "avg_price": "100"}))
+
+    assert valuation.current_price == Decimal("120")
+    assert valuation.current_value == Decimal("240")
+    assert valuation.pnl_pct == Decimal("20.0")
+
+
+@pytest.mark.asyncio
+async def test_crypto_valuation_fallback_uses_current_value_when_avg_missing():
+    with patch("backend.wealth.valuation.crypto.get_crypto_quote", AsyncMock(side_effect=ProviderUnavailable("down"))):
+        valuation = await value_crypto_holding(_asset("crypto", {"symbol": "ETH", "quantity": "2"}, current_value=Decimal("300")))
+
+    assert valuation.current_price == Decimal("150")
+    assert valuation.current_value == Decimal("300")
+    assert valuation.is_stale is True
+
+
+@pytest.mark.asyncio
+async def test_zero_cost_basis_keeps_pnl_none():
+    with patch("backend.wealth.valuation.stock.get_stock_quote", AsyncMock(return_value=_quote("ABC", "100", "stock"))):
+        valuation = await value_stock_holding(_asset("stock", {"ticker": "ABC", "quantity": 1, "avg_price": 0}, current_value=Decimal("0")))
+
+    assert valuation.pnl_pct is None

--- a/backend/wealth/services/net_worth_calculator.py
+++ b/backend/wealth/services/net_worth_calculator.py
@@ -20,6 +20,8 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.wealth.models.asset import Asset
 from backend.wealth.services import asset_service
+from backend.wealth.valuation.crypto import value_crypto_holding
+from backend.wealth.valuation.stock import value_stock_holding
 
 PERIOD_DAY = "day"
 PERIOD_WEEK = "week"
@@ -79,7 +81,14 @@ async def calculate(
     largest_value = Decimal(0)
 
     for a in assets:
-        value = Decimal(a.current_value or 0)
+        if a.asset_type == "stock":
+            valuation = await value_stock_holding(a)
+            value = valuation.current_value
+        elif a.asset_type == "crypto":
+            valuation = await value_crypto_holding(a)
+            value = valuation.current_value
+        else:
+            value = Decimal(a.current_value or 0)
         total += value
         by_type[a.asset_type] = by_type.get(a.asset_type, Decimal(0)) + value
         if value > largest_value:

--- a/backend/wealth/valuation/crypto.py
+++ b/backend/wealth/valuation/crypto.py
@@ -1,0 +1,59 @@
+"""Crypto holding valuation using real market prices with safe fallback."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from backend.market_data.client import get_crypto_quote
+from backend.wealth.models.asset import Asset
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HoldingValuation:
+    current_price: Decimal
+    quantity: Decimal
+    cost_basis: Decimal
+    current_value: Decimal
+    pnl_pct: Decimal | None
+    is_stale: bool
+
+
+def _decimal_extra(extra: dict[str, Any], key: str, default: Decimal = Decimal(0)) -> Decimal:
+    value = extra.get(key)
+    if value is None or value == "":
+        return default
+    return Decimal(str(value))
+
+
+def _fallback_price(asset: Asset) -> Decimal:
+    extra = getattr(asset, "extra", None) or {}
+    quantity = _decimal_extra(extra, "quantity", Decimal(0))
+    if extra.get("avg_price") is not None:
+        return Decimal(str(extra["avg_price"]))
+    if quantity > 0:
+        return Decimal(asset.current_value or asset.initial_value or 0) / quantity
+    return Decimal(asset.current_value or asset.initial_value or 0)
+
+
+async def value_crypto_holding(asset: Asset) -> HoldingValuation:
+    """Value one crypto asset from market data; fallback keeps old user-entered price."""
+    extra = getattr(asset, "extra", None) or {}
+    symbol = str(extra.get("symbol") or extra.get("ticker") or asset.name).upper().strip()
+    quantity = _decimal_extra(extra, "quantity", Decimal(1))
+    cost_basis = _decimal_extra(extra, "avg_price", _fallback_price(asset))
+    is_stale = False
+    try:
+        quote = await get_crypto_quote(symbol)
+        current_price = quote.price
+        is_stale = quote.is_stale
+    except Exception as exc:
+        logger.warning("Crypto market data unavailable for %s; using user input price: %s", symbol, exc)
+        current_price = _fallback_price(asset)
+        is_stale = True
+    current_value = current_price * quantity
+    pnl_pct = None if cost_basis == 0 else (current_price - cost_basis) / cost_basis * Decimal(100)
+    return HoldingValuation(current_price, quantity, cost_basis, current_value, pnl_pct, is_stale)

--- a/backend/wealth/valuation/stock.py
+++ b/backend/wealth/valuation/stock.py
@@ -1,0 +1,59 @@
+"""Stock holding valuation using real market prices with safe fallback."""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from backend.market_data.client import get_stock_quote
+from backend.wealth.models.asset import Asset
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class HoldingValuation:
+    current_price: Decimal
+    quantity: Decimal
+    cost_basis: Decimal
+    current_value: Decimal
+    pnl_pct: Decimal | None
+    is_stale: bool
+
+
+def _decimal_extra(extra: dict[str, Any], key: str, default: Decimal = Decimal(0)) -> Decimal:
+    value = extra.get(key)
+    if value is None or value == "":
+        return default
+    return Decimal(str(value))
+
+
+def _fallback_price(asset: Asset) -> Decimal:
+    extra = getattr(asset, "extra", None) or {}
+    quantity = _decimal_extra(extra, "quantity", Decimal(0))
+    if extra.get("avg_price") is not None:
+        return Decimal(str(extra["avg_price"]))
+    if quantity > 0:
+        return Decimal(asset.current_value or asset.initial_value or 0) / quantity
+    return Decimal(asset.current_value or asset.initial_value or 0)
+
+
+async def value_stock_holding(asset: Asset) -> HoldingValuation:
+    """Value one stock asset from market data; fallback keeps old user-entered price."""
+    extra = getattr(asset, "extra", None) or {}
+    symbol = str(extra.get("ticker") or extra.get("symbol") or asset.name).upper().strip()
+    quantity = _decimal_extra(extra, "quantity", Decimal(1))
+    cost_basis = _decimal_extra(extra, "avg_price", _fallback_price(asset))
+    is_stale = False
+    try:
+        quote = await get_stock_quote(symbol)
+        current_price = quote.price
+        is_stale = quote.is_stale
+    except Exception as exc:
+        logger.warning("Stock market data unavailable for %s; using user input price: %s", symbol, exc)
+        current_price = _fallback_price(asset)
+        is_stale = True
+    current_value = current_price * quantity
+    pnl_pct = None if cost_basis == 0 else (current_price - cost_basis) / cost_basis * Decimal(100)
+    return HoldingValuation(current_price, quantity, cost_basis, current_value, pnl_pct, is_stale)


### PR DESCRIPTION
### Motivation
- Replace stub market data with real providers so portfolio valuations and morning briefing show real prices and restore user trust before soft launch. 
- Provide a unified provider abstraction, cache layer and fallback/circuit logic to isolate external API complexity from business logic. 
- Pre-warm cache via scheduled jobs to reduce latency during market hours and avoid hammering providers. 

### Description
- Add provider implementations and helpers: `SSIStockProvider`, `VNDIRECTStockProvider`, `CoinGeckoCryptoProvider`, and HTTP parsing helpers under `backend/market_data/providers/` to fetch, parse and normalize external responses. 
- Add `backend/market_data/client.py` with cache-first accessors that read Redis, call providers on cache-miss, persist `regular` + `last_known` entries and return stale fallback when providers fail. 
- Add cache-aware background jobs `stock_updater` and `crypto_updater` under `backend/market_data/jobs/` and register them in `backend/scheduler.py` (stock: cron during 9:00-15:00 T2–T6 every 15min; crypto: interval every 5min). 
- Integrate market valuations into wealth logic via `backend/wealth/valuation/stock.py` and `crypto.py` and use them from `backend/wealth/services/net_worth_calculator.py`, preserving user input fallback and `is_stale` flag. 
- Add JSON-safe metadata serialization in `PriceQuote` and configuration entries (`redis_url`, `market_data_timeout_seconds`) in `backend/config`. 
- Tests: add unit tests for providers, dispatcher behaviour, updater jobs and valuation fallback/P&L; include a skipped manual SSI live check. 

### Testing
- Ran provider & job unit tests: `python -m pytest backend/tests/test_market_data backend/tests/test_wealth_valuation_market_data.py -q` — 30 passed, 1 skipped. 
- Ran broader integration subset including net worth & winners e2e: targeted pytest run of market + valuation + net-worth/winners tests — 46 passed. 
- Sanity: compiled modules with `python -m compileall` for new modules without errors. 
- Full test-suite note: the market/provider changes pass the new and related tests, but running the entire test matrix surfaced pre-existing, unrelated failures in `sync_phase_status` and some telegram/webhook tests which were not impacted by these market-data changes; those remain outside this PR scope.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fd6f588264832fafa027690637168d)