### PR TITLE
Phase 3.9 Epic 4 — Enriched morning briefing, portfolio analytics & price alerts

### DIFF
--- a/alembic/versions/q6k7l8m9n0p1_phase39_epic4_analytics_alerts.py
+++ b/alembic/versions/q6k7l8m9n0p1_phase39_epic4_analytics_alerts.py
@@ -1,0 +1,59 @@
+"""phase39 epic4 analytics and alerts
+
+Revision ID: q6k7l8m9n0p1
+Revises: p5j6k7l8m9n0
+Create Date: 2026-05-08 00:00:00.000000
+"""
+from __future__ import annotations
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+revision = "q6k7l8m9n0p1"
+down_revision = "p5j6k7l8m9n0"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "stock_historical_prices",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("price_date", sa.Date(), nullable=False),
+        sa.Column("close_price", sa.Numeric(20, 4), nullable=False),
+        sa.Column("source", sa.String(length=50), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+        sa.UniqueConstraint("symbol", "price_date", name="uq_stock_historical_symbol_date"),
+    )
+    op.create_index("idx_stock_historical_lookup", "stock_historical_prices", ["symbol", "price_date"])
+
+    op.create_table(
+        "notification_settings",
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), primary_key=True),
+        sa.Column("price_alerts_enabled", sa.Boolean(), server_default=sa.text("true"), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+    )
+    op.create_table(
+        "price_alerts_log",
+        sa.Column("id", postgresql.UUID(as_uuid=True), server_default=sa.text("gen_random_uuid()"), primary_key=True),
+        sa.Column("user_id", postgresql.UUID(as_uuid=True), sa.ForeignKey("users.id"), nullable=False),
+        sa.Column("symbol", sa.String(length=20), nullable=False),
+        sa.Column("change_pct", sa.Numeric(8, 3), nullable=False),
+        sa.Column("severity", sa.String(length=20), nullable=False),
+        sa.Column("message", sa.Text(), nullable=False),
+        sa.Column("sent_at", sa.DateTime(timezone=True), server_default=sa.text("NOW()"), nullable=False),
+    )
+    op.create_index("idx_price_alerts_user_day", "price_alerts_log", ["user_id", "sent_at"])
+    op.create_index("idx_price_alerts_symbol_cooldown", "price_alerts_log", ["user_id", "symbol", "sent_at"])
+
+
+def downgrade() -> None:
+    op.drop_index("idx_price_alerts_symbol_cooldown", table_name="price_alerts_log")
+    op.drop_index("idx_price_alerts_user_day", table_name="price_alerts_log")
+    op.drop_table("price_alerts_log")
+    op.drop_table("notification_settings")
+    op.drop_index("idx_stock_historical_lookup", table_name="stock_historical_prices")
+    op.drop_table("stock_historical_prices")

--- a/backend/agent/tools/get_market_data.py
+++ b/backend/agent/tools/get_market_data.py
@@ -1,10 +1,4 @@
-"""``get_market_data`` tool — current price + change% for a ticker.
-
-Wraps ``backend.services.market_service`` snapshots and overlays the
-user's holding context (quantity, total value) when they own the
-ticker. Phase 3B will deepen this with live polling; for Epic 1 we
-read from the existing ``market_snapshots`` table only.
-"""
+"""``get_market_data`` tool — cache-first real Phase 3.9 market data."""
 from __future__ import annotations
 
 import uuid
@@ -16,7 +10,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.agent.tools.base import Tool
 from backend.agent.tools.schemas import GetMarketDataInput, MarketDataPoint
+from backend.market_data.client import get_crypto_quote, get_gold_quote, get_stock_quote
+from backend.models.bank_rate import BankRateSnapshot
 from backend.models.market_snapshot import MarketSnapshot
+from backend.models.news_article import NewsArticle
 from backend.models.user import User
 from backend.wealth.models.asset import Asset
 
@@ -24,11 +21,13 @@ _PERIOD_TO_FIELD = {
     "1d": "change_1d_pct",
     "7d": "change_1w_pct",
     "30d": "change_1m_pct",
-    # 90d / 365d not tracked in the snapshot row — return None and a
-    # ``note`` telling the user this resolution isn't available yet.
     "90d": None,
     "365d": None,
 }
+
+_GOLD_ALIASES = {"GOLD", "SJC", "SJC_GOLD", "VANG", "VÀNG"}
+_CRYPTO_ALIASES = {"BTC", "ETH", "SOL", "BNB", "XRP", "ADA", "DOGE"}
+_BANK_ALIASES = {"VCB": "Vietcombank", "VIETCOMBANK": "Vietcombank"}
 
 
 class GetMarketDataTool(Tool):
@@ -39,14 +38,15 @@ class GetMarketDataTool(Tool):
     @property
     def description(self) -> str:
         return (
-            "Get latest market price + change% for a ticker (Vietnamese "
-            "stock, fund, index, or crypto). When the user owns this "
-            "ticker, return their quantity and holding value too.\n"
-            "\n"
+            "Get latest real market data for Vietnamese stocks/indexes, "
+            "crypto, SJC gold, bank savings rates, and related news. "
+            "Returns personal holding context when the user owns the ticker.\n"
             "Examples:\n"
             "- 'VNM giá bao nhiêu?' → ticker='VNM'\n"
-            "- 'VNINDEX hôm nay' → ticker='VNINDEX', period='1d'\n"
-            "- 'BTC tuần qua' → ticker='BTC', period='7d'"
+            "- 'VN-Index hôm nay' → ticker='VNINDEX'\n"
+            "- 'BTC giá bao nhiêu?' → ticker='BTC'\n"
+            "- 'vàng SJC?' → ticker='SJC_GOLD'\n"
+            "- 'lãi suất Vietcombank?' → ticker='VCB'"
         )
 
     @property
@@ -63,20 +63,140 @@ class GetMarketDataTool(Tool):
         user: User,
         db: AsyncSession,
     ) -> MarketDataPoint:
-        ticker = input_data.ticker.strip().upper()
+        ticker = input_data.ticker.strip().upper().replace("-", "")
         period = input_data.period or "1d"
-
-        snapshot = await self._latest_snapshot(db, ticker)
         owns, qty, holding = await self._user_holding(db, user.id, ticker)
 
-        if snapshot is None:
-            # No data is a real outcome — return a row the formatter
-            # can show as "chưa có dữ liệu" rather than raising.
+        if ticker in _GOLD_ALIASES:
+            return await self._gold_point(period, owns, qty, holding)
+
+        if ticker in _CRYPTO_ALIASES:
+            crypto_point = await self._crypto_point(ticker, period, owns, qty, holding)
+            if crypto_point is not None:
+                return crypto_point
+
+        if ticker in _BANK_ALIASES:
+            bank_point = await self._bank_point(db, ticker, period)
+            if bank_point is not None:
+                return bank_point
+
+        snapshot = await self._latest_snapshot(db, ticker)
+        if snapshot is not None:
+            return await self._snapshot_point(db, snapshot, ticker, period, owns, qty, holding)
+
+        return await self._stock_point(ticker, period, owns, qty, holding)
+
+    async def _gold_point(
+        self,
+        period: str,
+        owns: bool,
+        qty: float | None,
+        holding: Decimal | None,
+    ) -> MarketDataPoint:
+        try:
+            quote = await get_gold_quote("SJC_GOLD")
+            return MarketDataPoint(
+                ticker="SJC_GOLD",
+                asset_name="Vàng SJC",
+                current_price=quote.price,
+                period=period,
+                user_owns=owns,
+                user_quantity=qty,
+                user_holding_value=holding,
+                note="Dữ liệu provider vàng." if not quote.is_stale else "Dữ liệu gần nhất (stale).",
+            )
+        except Exception as exc:
+            return MarketDataPoint(
+                ticker="SJC_GOLD",
+                current_price=Decimal(0),
+                period=period,
+                note=f"Chưa lấy được giá vàng SJC: {exc}",
+            )
+
+    async def _crypto_point(
+        self,
+        ticker: str,
+        period: str,
+        owns: bool,
+        qty: float | None,
+        holding: Decimal | None,
+    ) -> MarketDataPoint | None:
+        try:
+            quote = await get_crypto_quote(ticker)
+        except Exception:
+            return None
+        return MarketDataPoint(
+            ticker=ticker,
+            asset_name=ticker,
+            current_price=quote.price,
+            period=period,
+            user_owns=owns,
+            user_quantity=qty,
+            user_holding_value=holding,
+            note="Dữ liệu crypto realtime." if not quote.is_stale else "Dữ liệu gần nhất (stale).",
+        )
+
+    async def _bank_point(
+        self, db: AsyncSession, ticker: str, period: str
+    ) -> MarketDataPoint | None:
+        rate = await self._latest_bank_rate(db, "VCB")
+        if rate is None:
+            return None
+        return MarketDataPoint(
+            ticker="VCB",
+            asset_name=_BANK_ALIASES[ticker],
+            current_price=Decimal(rate.rate_pct),
+            period=period,
+            note=f"Lãi suất tiết kiệm kỳ hạn {rate.tenor_months} tháng (%/năm).",
+        )
+
+    async def _snapshot_point(
+        self,
+        db: AsyncSession,
+        snapshot: MarketSnapshot,
+        ticker: str,
+        period: str,
+        owns: bool,
+        qty: float | None,
+        holding: Decimal | None,
+    ) -> MarketDataPoint:
+        return MarketDataPoint(
+            ticker=ticker,
+            asset_name=snapshot.asset_name,
+            current_price=Decimal(snapshot.price or 0),
+            change_pct=self._change_pct(snapshot, period),
+            period=period,
+            user_owns=owns,
+            user_quantity=qty,
+            user_holding_value=holding,
+            note=await self._news_note(db, ticker),
+        )
+
+    async def _stock_point(
+        self,
+        ticker: str,
+        period: str,
+        owns: bool,
+        qty: float | None,
+        holding: Decimal | None,
+    ) -> MarketDataPoint:
+        try:
+            quote = await get_stock_quote(ticker)
+            note = "Dữ liệu cổ phiếu realtime." if not quote.is_stale else "Dữ liệu gần nhất (stale)."
             return MarketDataPoint(
                 ticker=ticker,
-                asset_name=None,
+                asset_name=ticker,
+                current_price=quote.price,
+                period=period,
+                user_owns=owns,
+                user_quantity=qty,
+                user_holding_value=holding,
+                note=note,
+            )
+        except Exception:
+            return MarketDataPoint(
+                ticker=ticker,
                 current_price=Decimal(0),
-                change_pct=None,
                 period=period,
                 user_owns=owns,
                 user_quantity=qty,
@@ -84,34 +204,16 @@ class GetMarketDataTool(Tool):
                 note="Chưa có dữ liệu thị trường cho mã này.",
             )
 
-        change_field = _PERIOD_TO_FIELD.get(period)
-        change_pct: float | None
-        note: str | None = None
-        if change_field is None:
-            change_pct = None
-            note = f"Chưa lưu {period} change cho mã này — Phase 3B."
-        else:
-            raw = getattr(snapshot, change_field, None)
-            change_pct = float(raw) if raw is not None else None
-
-        return MarketDataPoint(
-            ticker=ticker,
-            asset_name=snapshot.asset_name,
-            current_price=Decimal(snapshot.price or 0),
-            change_pct=change_pct,
-            period=period,
-            user_owns=owns,
-            user_quantity=qty,
-            user_holding_value=holding,
-            note=note,
-        )
-
-    # ------------------------------------------------------------------
+    @staticmethod
+    def _change_pct(snapshot: MarketSnapshot, period: str) -> float | None:
+        field = _PERIOD_TO_FIELD.get(period)
+        if field is None:
+            return None
+        raw = getattr(snapshot, field, None)
+        return float(raw) if raw is not None else None
 
     @staticmethod
-    async def _latest_snapshot(
-        db: AsyncSession, ticker: str
-    ) -> MarketSnapshot | None:
+    async def _latest_snapshot(db: AsyncSession, ticker: str) -> MarketSnapshot | None:
         stmt = (
             select(MarketSnapshot)
             .where(MarketSnapshot.asset_code == ticker)
@@ -121,12 +223,30 @@ class GetMarketDataTool(Tool):
         return (await db.execute(stmt)).scalar_one_or_none()
 
     @staticmethod
+    async def _latest_bank_rate(db: AsyncSession, bank_code: str) -> BankRateSnapshot | None:
+        stmt = (
+            select(BankRateSnapshot)
+            .where(BankRateSnapshot.bank_code == bank_code)
+            .order_by(desc(BankRateSnapshot.snapshot_date))
+            .limit(1)
+        )
+        return (await db.execute(stmt)).scalar_one_or_none()
+
+    @staticmethod
+    async def _news_note(db: AsyncSession, ticker: str) -> str | None:
+        stmt = (
+            select(NewsArticle.title)
+            .where(NewsArticle.related_symbols.any(ticker))
+            .order_by(desc(NewsArticle.published_at))
+            .limit(1)
+        )
+        title = (await db.execute(stmt)).scalar_one_or_none()
+        return f"Tin mới liên quan: {title}" if title else None
+
+    @staticmethod
     async def _user_holding(
         db: AsyncSession, user_id: uuid.UUID, ticker: str
     ) -> tuple[bool, float | None, Decimal | None]:
-        """Look up whether the user owns ``ticker`` (any asset where
-        ``extra.ticker`` or ``extra.symbol`` matches, case-insensitive).
-        Aggregates quantity + value across multiple lots."""
         stmt = select(Asset).where(
             Asset.user_id == user_id,
             Asset.is_active.is_(True),
@@ -136,17 +256,20 @@ class GetMarketDataTool(Tool):
         total_qty = 0.0
         total_value = Decimal(0)
         owns = False
-        for r in rows:
-            extra = r.extra or {}
-            sym = (extra.get("ticker") or extra.get("symbol") or "").upper()
-            if sym == ticker:
+        aliases = {ticker, "SJC_GOLD" if ticker in _GOLD_ALIASES else ticker}
+        for row in rows:
+            extra = row.extra or {}
+            sym = str(
+                extra.get("ticker") or extra.get("symbol") or extra.get("type") or ""
+            ).upper()
+            if sym in aliases:
                 owns = True
-                q = extra.get("quantity")
+                q = extra.get("quantity") or extra.get("tael")
                 try:
                     total_qty += float(q) if q is not None else 0.0
                 except (TypeError, ValueError):
                     pass
-                total_value += Decimal(r.current_value or 0)
+                total_value += Decimal(row.current_value or 0)
         if not owns:
             return False, None, None
         return True, total_qty if total_qty > 0 else None, total_value

--- a/backend/briefing/morning_briefing.py
+++ b/backend/briefing/morning_briefing.py
@@ -1,0 +1,206 @@
+"""Phase 3.9 enriched morning briefing with real market data."""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from sqlalchemy import desc, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.bot.formatters.money import format_money_short
+from backend.market_data.analytics.news_relevance import get_relevant_news
+from backend.market_data.analytics.portfolio_metrics import (
+    compute_diversification_score,
+    get_best_worst_from_assets,
+)
+from backend.market_data.client import get_crypto_quote, get_gold_quote
+from backend.models.bank_rate import BankRateSnapshot
+from backend.models.market_snapshot import MarketSnapshot
+from backend.models.user import User
+from backend.wealth.models.asset import Asset
+from backend.wealth.services import net_worth_calculator
+
+_TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "content" / "briefing.yaml"
+
+
+@dataclass(frozen=True)
+class EnrichedBriefingResult:
+    text: str
+    is_stale: bool = False
+    render_ms: int = 0
+    sections: dict[str, Any] = field(default_factory=dict)
+
+
+@lru_cache(maxsize=1)
+def _load_template() -> dict[str, Any]:
+    with open(_TEMPLATE_PATH, encoding="utf-8") as f:
+        return yaml.safe_load(f)
+
+
+def _fmt_decimal(value: Decimal | int | float | None, suffix: str = "") -> str:
+    if value is None:
+        return "chưa có"
+    dec = Decimal(str(value))
+    if dec == dec.to_integral():
+        return f"{dec:,.0f}{suffix}"
+    return f"{dec:,.2f}{suffix}"
+
+
+def _signed_pct(value: float | Decimal | None) -> str:
+    if value is None:
+        return "0.0"
+    return f"{float(value):+.1f}"
+
+
+def _quote_line(price: Decimal | None, change_pct: Any = None, currency: str = "") -> str:
+    if price is None:
+        return "chưa có dữ liệu"
+    suffix = f" {currency}" if currency else ""
+    change = "" if change_pct is None else f" ({_signed_pct(change_pct)}%)"
+    return f"{_fmt_decimal(price, suffix)}{change}"
+
+
+async def _latest_market_snapshot(db: AsyncSession, code: str) -> MarketSnapshot | None:
+    result = await db.execute(
+        select(MarketSnapshot)
+        .where(MarketSnapshot.asset_code == code)
+        .order_by(desc(MarketSnapshot.snapshot_date))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _latest_vcb_rate(db: AsyncSession) -> Decimal | None:
+    result = await db.execute(
+        select(BankRateSnapshot.rate_pct)
+        .where(BankRateSnapshot.bank_code == "VCB")
+        .order_by(desc(BankRateSnapshot.snapshot_date))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _portfolio_assets(db: AsyncSession, user_id) -> list[Asset]:
+    result = await db.execute(select(Asset).where(Asset.user_id == user_id, Asset.is_active.is_(True)))
+    return list(result.scalars().all())
+
+
+def _allocation_lines(breakdown: net_worth_calculator.NetWorthBreakdown) -> str:
+    if breakdown.total <= 0:
+        return "• Chưa có tài sản"
+    lines: list[str] = []
+    for asset_type, value in sorted(breakdown.by_type.items(), key=lambda item: item[1], reverse=True):
+        pct = value / breakdown.total * Decimal(100)
+        lines.append(f"• {asset_type}: {format_money_short(value)} ({pct:.0f}%)")
+    return "\n".join(lines)
+
+
+def _news_lines(news: list[Any]) -> str:
+    if not news:
+        return "• Chưa có tin nổi bật cho danh mục của bạn."
+    return "\n".join(f"• {item.title}" for item in news[:3])
+
+
+def _insights(assets: list[Asset], vcb_rate: Decimal | None) -> list[str]:
+    insights: list[str] = []
+    for asset in assets:
+        if asset.asset_type != "stock":
+            continue
+        extra = asset.extra or {}
+        avg = extra.get("avg_price") or extra.get("user_input_price")
+        current = extra.get("current_price")
+        if avg and current:
+            change = (Decimal(str(current)) - Decimal(str(avg))) / Decimal(str(avg)) * Decimal(100)
+            if change > 5:
+                symbol = extra.get("ticker") or extra.get("symbol") or asset.name
+                insights.append(f"{symbol} đang tăng hơn 5% — có thể chốt lời 1 phần?")
+                break
+    if vcb_rate is not None:
+        for asset in assets:
+            if asset.asset_type != "cash":
+                continue
+            extra = asset.extra or {}
+            rate = extra.get("rate_pct")
+            bank = extra.get("bank_code") or extra.get("bank")
+            if rate is not None and Decimal(str(rate)) + Decimal("0.5") < vcb_rate:
+                insights.append(f"Lãi suất {bank or 'ngân hàng hiện tại'} thấp hơn VCB >0.5% — cân nhắc chuyển ngân hàng.")
+                break
+    return insights[:2] or ["Danh mục ổn, hôm nay mình chỉ cần theo dõi nhẹ thôi."]
+
+
+async def render_enriched_morning_briefing(db: AsyncSession, user: User) -> EnrichedBriefingResult:
+    """Render five real-data sections; independent data fetches run concurrently."""
+    import time
+
+    started = time.perf_counter()
+    template = _load_template()
+
+    async def crypto_quote(symbol: str):
+        try:
+            return await get_crypto_quote(symbol)
+        except Exception:
+            return None
+
+    async def gold_quote():
+        try:
+            return await get_gold_quote("SJC_GOLD")
+        except Exception:
+            return None
+
+    # Keep AsyncSession reads sequential (SQLAlchemy sessions are not safe for
+    # concurrent DB use), while external provider/RSS calls run in parallel.
+    breakdown = await net_worth_calculator.calculate(db, user.id)
+    change = await net_worth_calculator.calculate_change(db, user.id, net_worth_calculator.PERIOD_DAY)
+    vnindex = await _latest_market_snapshot(db, "VNINDEX")
+    assets = await _portfolio_assets(db, user.id)
+    vcb_rate = await _latest_vcb_rate(db)
+    btc, gold, news = await asyncio.gather(
+        crypto_quote("BTC"),
+        gold_quote(),
+        get_relevant_news(user.id, limit=3),
+    )
+    performers = await get_best_worst_from_assets(assets)
+    diversification = compute_diversification_score([{"asset_type": asset.asset_type, "value": Decimal(asset.current_value or 0)} for asset in assets])
+
+    is_stale = bool((btc and btc.is_stale) or (gold and gold.is_stale))
+    insight_lines = _insights(assets, vcb_rate)
+    top, bottom = performers
+    if top is not None:
+        insight_lines.append(f"Tốt nhất: {top['symbol']} {_signed_pct(top['return_pct'])}%; yếu nhất: {bottom['symbol']} {_signed_pct(bottom['return_pct'])}%.")
+    insight_lines.append(f"Đa dạng hóa: {diversification['score']}/100 ({diversification['label']}).")
+
+    sections = {
+        "net_worth": template["sections"]["net_worth"].format(
+            net_worth=format_money_short(breakdown.total),
+            change_label="So với hôm qua",
+            change_abs=format_money_short(change.change_absolute),
+            change_pct=_signed_pct(change.change_percentage),
+        ),
+        "market": template["sections"]["market"].format(
+            vnindex=_quote_line(Decimal(str(vnindex.price)) if vnindex and vnindex.price is not None else None, vnindex.change_1d_pct if vnindex else None),
+            gold=_quote_line(gold.price if gold else None, None, "VND/lượng"),
+            btc=_quote_line(btc.price if btc else None, None, btc.currency if btc else ""),
+        ),
+        "portfolio": template["sections"]["portfolio"].format(
+            allocation_lines=_allocation_lines(breakdown),
+            today_change=f"{format_money_short(change.change_absolute)} ({_signed_pct(change.change_percentage)}%)",
+        ),
+        "news": template["sections"]["news"].format(news_lines=_news_lines(news)),
+        "insights": template["sections"]["insights"].format(insight_lines="\n".join(f"• {line}" for line in insight_lines[:4])),
+    }
+    text = "\n\n".join(sections.values())
+    if is_stale:
+        text = f"{text}\n\n{template['footer']['stale']}"
+    return EnrichedBriefingResult(
+        text=text,
+        is_stale=is_stale,
+        render_ms=int((time.perf_counter() - started) * 1000),
+        sections=sections,
+    )
+

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -62,6 +62,7 @@ class Settings(BaseSettings):
     # Market data
     redis_url: str = "redis://localhost:6379/0"
     market_data_timeout_seconds: float = 3.0
+    market_data_alerts_enabled: bool = False
 
     # OpenClaw Skills
     finance_api_url: str = "http://localhost:8001/api/v1"

--- a/backend/market_data/analytics/alerts.py
+++ b/backend/market_data/analytics/alerts.py
@@ -1,0 +1,125 @@
+"""Price movement alerts for held stocks."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from typing import Iterable
+
+from sqlalchemy import func, select
+from sqlalchemy.dialects.postgresql import insert
+
+from backend.config import get_settings
+from backend.database import get_session_factory
+from backend.market_data.cache.price_cache import PriceCache
+from backend.market_data.client import get_price_cache
+from backend.market_data.normalizer import PriceQuote
+from backend.models.price_alert import NotificationSettings, PriceAlertLog
+from backend.models.user import User
+from backend.ports.notifier import get_notifier
+from backend.wealth.models.asset import Asset
+
+
+@dataclass(frozen=True)
+class MovementAlert:
+    user_id: object
+    telegram_id: int
+    symbol: str
+    old_price: Decimal
+    new_price: Decimal
+    change_pct: Decimal
+    severity: str
+    message: str
+
+
+def alerts_enabled() -> bool:
+    return bool(getattr(get_settings(), "market_data_alerts_enabled", False))
+
+
+def severity_for_change(change_pct: Decimal) -> str:
+    magnitude = abs(change_pct)
+    if magnitude > Decimal("10"):
+        return "critical"
+    if magnitude >= Decimal("7"):
+        return "warning"
+    return "info"
+
+
+def format_alert_message(symbol: str, change_pct: Decimal, new_price: Decimal, severity: str) -> str:
+    direction = "tăng" if change_pct > 0 else "giảm"
+    icon = {"info": "🔔", "warning": "⚠️", "critical": "🚨"}[severity]
+    return (
+        f"{icon} Bé Tiền báo nhanh: {symbol} vừa {direction} {abs(change_pct):.1f}% trong 15 phút.\n"
+        f"Giá mới khoảng {new_price:,.0f}đ. Bạn kiểm tra danh mục khi tiện nhé."
+    )
+
+
+async def _last_known_15m(cache: PriceCache, quote: PriceQuote) -> PriceQuote | None:
+    # Cache layer stores one last-known quote. Jobs update it every run, so its
+    # value is the practical 15-minute comparison point for the stock cron.
+    return await cache.get_last_known(quote.symbol, quote.asset_type)
+
+
+async def _users_holding(db, symbol: str) -> list[tuple[User, bool]]:
+    result = await db.execute(
+        select(User, NotificationSettings.price_alerts_enabled, Asset.extra)
+        .join(Asset, Asset.user_id == User.id)
+        .outerjoin(NotificationSettings, NotificationSettings.user_id == User.id)
+        .where(Asset.asset_type == "stock", Asset.is_active.is_(True), Asset.extra.is_not(None))
+    )
+    rows: list[tuple[User, bool]] = []
+    for user, enabled, extra in result.all():
+        held = str((extra or {}).get("ticker") or (extra or {}).get("symbol") or "").upper().strip()
+        if held == symbol.upper():
+            rows.append((user, True if enabled is None else bool(enabled)))
+    return rows
+
+
+async def _can_send(db, user_id, symbol: str, now: datetime) -> bool:
+    start_day = now.replace(hour=0, minute=0, second=0, microsecond=0)
+    day_count = await db.scalar(
+        select(func.count()).select_from(PriceAlertLog).where(
+            PriceAlertLog.user_id == user_id,
+            PriceAlertLog.sent_at >= start_day,
+        )
+    )
+    if int(day_count or 0) >= 3:
+        return False
+    cooldown_count = await db.scalar(
+        select(func.count()).select_from(PriceAlertLog).where(
+            PriceAlertLog.user_id == user_id,
+            PriceAlertLog.symbol == symbol,
+            PriceAlertLog.sent_at >= now - timedelta(minutes=30),
+        )
+    )
+    return int(cooldown_count or 0) == 0
+
+
+async def check_movements(quotes: Iterable[PriceQuote], *, cache: PriceCache | None = None) -> list[MovementAlert]:
+    """Detect >=5% moves vs last-known and send/log Telegram alerts when enabled."""
+    if not alerts_enabled():
+        return []
+    price_cache = cache or get_price_cache()
+    now = datetime.now(timezone.utc)
+    alerts: list[MovementAlert] = []
+    async with get_session_factory()() as db:
+        for quote in quotes:
+            previous = await _last_known_15m(price_cache, quote)
+            if previous is None or previous.price == 0:
+                continue
+            change_pct = (quote.price - previous.price) / previous.price * Decimal(100)
+            if abs(change_pct) < Decimal("5.0"):
+                continue
+            severity = severity_for_change(change_pct)
+            message = format_alert_message(quote.symbol, change_pct, quote.price, severity)
+            holders = await _users_holding(db, quote.symbol)
+            for user, enabled in holders:
+                if not enabled or not await _can_send(db, user.id, quote.symbol, now):
+                    continue
+                alert = MovementAlert(user.id, user.telegram_id, quote.symbol, previous.price, quote.price, change_pct, severity, message)
+                result = await get_notifier().send_message(user.telegram_id, message)
+                if result is None or result.get("ok", True):
+                    db.add(PriceAlertLog(user_id=user.id, symbol=quote.symbol, change_pct=change_pct, severity=severity, message=message, sent_at=now))
+                    alerts.append(alert)
+        await db.commit()
+    return alerts

--- a/backend/market_data/analytics/portfolio_metrics.py
+++ b/backend/market_data/analytics/portfolio_metrics.py
@@ -1,0 +1,159 @@
+"""Portfolio analytics for Phase 3.9 briefings."""
+from __future__ import annotations
+
+from collections import defaultdict
+from dataclasses import dataclass
+from datetime import date
+from decimal import Decimal
+from typing import Any
+
+from sqlalchemy import desc, select
+
+from backend.database import get_session_factory
+from backend.models.stock_historical_price import StockHistoricalPrice
+from backend.wealth.models.asset import Asset
+from backend.wealth.valuation.crypto import value_crypto_holding
+from backend.wealth.valuation.gold import value_gold_holding
+from backend.wealth.valuation.stock import value_stock_holding
+
+
+@dataclass(frozen=True)
+class HoldingPerformance:
+    asset_id: Any
+    symbol: str
+    asset_type: str
+    current_value: Decimal
+    cost_basis_value: Decimal
+    return_pct: Decimal | None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "asset_id": self.asset_id,
+            "symbol": self.symbol,
+            "asset_type": self.asset_type,
+            "current_value": self.current_value,
+            "cost_basis_value": self.cost_basis_value,
+            "return_pct": self.return_pct,
+        }
+
+
+def _symbol(asset: Asset) -> str:
+    extra = asset.extra or {}
+    return str(extra.get("ticker") or extra.get("symbol") or asset.name or asset.id).upper()
+
+
+async def _value_asset(asset: Asset) -> tuple[Decimal, Decimal, Decimal | None]:
+    if asset.asset_type == "stock":
+        valuation = await value_stock_holding(asset)
+        return valuation.current_value, valuation.cost_basis * valuation.quantity, valuation.pnl_pct
+    if asset.asset_type == "crypto":
+        valuation = await value_crypto_holding(asset)
+        return valuation.current_value, valuation.cost_basis * valuation.quantity, valuation.pnl_pct
+    if asset.asset_type == "gold":
+        valuation = await value_gold_holding(asset)
+        return valuation.current_value, valuation.cost_basis * valuation.quantity, valuation.pnl_pct
+    current = Decimal(asset.current_value or 0)
+    cost = Decimal(asset.initial_value or 0)
+    pct = None if cost == 0 else (current - cost) / cost * Decimal(100)
+    return current, cost, pct
+
+
+async def _active_assets(db, user_id) -> list[Asset]:
+    result = await db.execute(select(Asset).where(Asset.user_id == user_id, Asset.is_active.is_(True)))
+    return list(result.scalars().all())
+
+
+async def _latest_ytd_price(db, symbol: str, year_start: date) -> Decimal | None:
+    result = await db.execute(
+        select(StockHistoricalPrice.close_price)
+        .where(StockHistoricalPrice.symbol == symbol, StockHistoricalPrice.price_date <= year_start)
+        .order_by(desc(StockHistoricalPrice.price_date))
+        .limit(1)
+    )
+    return result.scalar_one_or_none()
+
+
+async def compute_ytd_return(user_id) -> dict[str, Any]:
+    """Return YTD performance from seeded Jan-1 prices where available."""
+    year_start = date(date.today().year, 1, 1)
+    async with get_session_factory()() as db:
+        assets = await _active_assets(db, user_id)
+        rows: list[dict[str, Any]] = []
+        total_current = Decimal(0)
+        total_start = Decimal(0)
+        for asset in assets:
+            current, cost, pct = await _value_asset(asset)
+            start_value = cost
+            if asset.asset_type == "stock":
+                extra = asset.extra or {}
+                qty = Decimal(str(extra.get("quantity") or 1))
+                seeded = await _latest_ytd_price(db, _symbol(asset), year_start)
+                if seeded is not None:
+                    start_value = Decimal(seeded) * qty
+            absolute = current - start_value
+            row_pct = None if start_value == 0 else absolute / start_value * Decimal(100)
+            rows.append({
+                "asset_id": asset.id,
+                "symbol": _symbol(asset),
+                "asset_type": asset.asset_type,
+                "current_value": current,
+                "start_value": start_value,
+                "absolute": absolute,
+                "return_pct": row_pct if row_pct is not None else pct,
+            })
+            total_current += current
+            total_start += start_value
+    absolute = total_current - total_start
+    return {
+        "available": bool(rows) and total_start > 0,
+        "return_pct": None if total_start == 0 else absolute / total_start * Decimal(100),
+        "absolute": absolute,
+        "by_holding": rows,
+    }
+
+
+async def get_best_worst_from_assets(assets: list[Asset]) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    performances: list[HoldingPerformance] = []
+    for asset in assets:
+        current, cost, pct = await _value_asset(asset)
+        if pct is None:
+            continue
+        performances.append(HoldingPerformance(asset.id, _symbol(asset), asset.asset_type, current, cost, pct))
+    if not performances:
+        return None, None
+    sorted_rows = sorted(performances, key=lambda row: row.return_pct or Decimal(0), reverse=True)
+    return sorted_rows[0].to_dict(), sorted_rows[-1].to_dict()
+
+
+async def get_best_worst_performer(user_id) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    """Return top and bottom active holding by P/L percentage."""
+    async with get_session_factory()() as db:
+        assets = await _active_assets(db, user_id)
+    return await get_best_worst_from_assets(assets)
+
+
+def compute_diversification_score(portfolio: list[Any]) -> dict[str, Any]:
+    """Score 0-100 from number of asset classes and concentration risk."""
+    by_type: dict[str, Decimal] = defaultdict(Decimal)
+    for item in portfolio:
+        if isinstance(item, dict):
+            asset_type = str(item.get("asset_type") or "other")
+            value = Decimal(str(item.get("value") or item.get("current_value") or 0))
+        else:
+            asset_type = str(getattr(item, "asset_type", "other") or "other")
+            value = Decimal(getattr(item, "current_value", 0) or 0)
+        if value > 0:
+            by_type[asset_type] += value
+    total = sum(by_type.values(), Decimal(0))
+    if total <= 0:
+        return {"score": 0, "label": "Yếu", "details": {}}
+    type_score = min(len(by_type), 4) / Decimal(4) * Decimal(40)
+    max_weight = max(by_type.values()) / total
+    concentration_score = max(Decimal(0), Decimal(1) - max_weight) * Decimal(60)
+    score = int((type_score + concentration_score).quantize(Decimal("1")))
+    label = "Tốt" if score >= 70 else "Trung bình" if score >= 40 else "Yếu"
+    return {
+        "score": score,
+        "label": label,
+        "details": {asset_type: float(value / total) for asset_type, value in by_type.items()},
+    }

--- a/backend/market_data/jobs/historical_price_seeder.py
+++ b/backend/market_data/jobs/historical_price_seeder.py
@@ -1,0 +1,40 @@
+"""Seed beginning-of-year prices for YTD analytics."""
+from __future__ import annotations
+
+import logging
+from datetime import date
+from decimal import Decimal
+
+from sqlalchemy.dialects.postgresql import insert
+
+from backend.database import get_session_factory
+from backend.market_data.jobs.stock_updater import _held_stock_symbols
+from backend.market_data.client import get_stock_provider
+from backend.models.stock_historical_price import StockHistoricalPrice
+
+logger = logging.getLogger(__name__)
+
+
+async def seed_year_start_stock_prices() -> dict[str, int]:
+    """Persist Jan-1-equivalent current prices once a year as YTD baseline."""
+    price_date = date(date.today().year, 1, 1)
+    async with get_session_factory()() as db:
+        symbols = await _held_stock_symbols(db)
+    if not symbols:
+        return {"symbols_attempted": 0, "symbols_seeded": 0}
+    quotes = await get_stock_provider().fetch_batch(symbols)
+    async with get_session_factory()() as db:
+        seeded = 0
+        for quote in quotes:
+            stmt = insert(StockHistoricalPrice).values(
+                symbol=quote.symbol,
+                price_date=price_date,
+                close_price=quote.price,
+                source=quote.source,
+            ).on_conflict_do_nothing(index_elements=["symbol", "price_date"])
+            result = await db.execute(stmt)
+            seeded += int(result.rowcount or 0)
+        await db.commit()
+    metrics = {"symbols_attempted": len(symbols), "symbols_seeded": seeded}
+    logger.info("Historical price seeder complete: %s", metrics)
+    return metrics

--- a/backend/market_data/jobs/stock_updater.py
+++ b/backend/market_data/jobs/stock_updater.py
@@ -7,6 +7,7 @@ import time
 from sqlalchemy import select
 
 from backend.database import get_session_factory
+from backend.market_data.analytics.alerts import check_movements
 from backend.market_data.client import get_price_cache, get_stock_provider
 from backend.wealth.models.asset import Asset
 
@@ -36,6 +37,7 @@ async def update_all_held_stocks() -> dict[str, int]:
     provider = get_stock_provider()
     cache = get_price_cache()
     quotes = await provider.fetch_batch(symbols)
+    await check_movements(quotes, cache=cache)
     for quote in quotes:
         await cache.set(quote)
         await cache.set_last_known(quote)

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -21,6 +21,8 @@ from backend.feedback.models.feedback import Feedback, PromptSentLog
 from backend.profile.models.user_profile import UserProfile
 from backend.models.bank_rate import BankRateSnapshot
 from backend.models.news_article import NewsArticle
+from backend.models.stock_historical_price import StockHistoricalPrice
+from backend.models.price_alert import NotificationSettings, PriceAlertLog
 from backend.models.conversation_context import (
     ROLE_ASSISTANT,
     ROLE_USER,
@@ -54,4 +56,7 @@ __all__ = [
     "ConversationContext",
     "ROLE_USER",
     "ROLE_ASSISTANT",
+    "StockHistoricalPrice",
+    "NotificationSettings",
+    "PriceAlertLog",
 ]

--- a/backend/models/price_alert.py
+++ b/backend/models/price_alert.py
@@ -1,0 +1,38 @@
+"""Price movement alert log and notification settings."""
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from decimal import Decimal
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, Index, Numeric, String, Text, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class NotificationSettings(Base):
+    __tablename__ = "notification_settings"
+
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), primary_key=True)
+    price_alerts_enabled: Mapped[bool] = mapped_column(Boolean, default=True, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow, nullable=False)
+
+
+class PriceAlertLog(Base):
+    __tablename__ = "price_alerts_log"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), ForeignKey("users.id"), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    change_pct: Mapped[Decimal] = mapped_column(Numeric(8, 3), nullable=False)
+    severity: Mapped[str] = mapped_column(String(20), nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    sent_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        Index("idx_price_alerts_user_day", "user_id", "sent_at"),
+        Index("idx_price_alerts_symbol_cooldown", "user_id", "symbol", "sent_at"),
+    )

--- a/backend/models/stock_historical_price.py
+++ b/backend/models/stock_historical_price.py
@@ -1,0 +1,28 @@
+"""Historical stock close prices used for YTD analytics."""
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime
+from decimal import Decimal
+
+from sqlalchemy import Date, DateTime, Index, Numeric, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID
+from sqlalchemy.orm import Mapped, mapped_column
+
+from backend.database import Base
+
+
+class StockHistoricalPrice(Base):
+    __tablename__ = "stock_historical_prices"
+
+    id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    symbol: Mapped[str] = mapped_column(String(20), nullable=False)
+    price_date: Mapped[date] = mapped_column(Date, nullable=False)
+    close_price: Mapped[Decimal] = mapped_column(Numeric(20, 4), nullable=False)
+    source: Mapped[str] = mapped_column(String(50), nullable=False)
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow, nullable=False)
+
+    __table_args__ = (
+        UniqueConstraint("symbol", "price_date", name="uq_stock_historical_symbol_date"),
+        Index("idx_stock_historical_lookup", "symbol", "price_date"),
+    )

--- a/backend/scheduler.py
+++ b/backend/scheduler.py
@@ -28,6 +28,7 @@ from backend.jobs.weekly_goal_reminder import run_weekly_goal_reminder
 from backend.market_data.jobs.bank_rates_updater import update_bank_rates
 from backend.market_data.jobs.crypto_updater import update_all_held_crypto
 from backend.market_data.jobs.gold_updater import update_all_held_gold
+from backend.market_data.jobs.historical_price_seeder import seed_year_start_stock_prices
 from backend.market_data.jobs.news_updater import update_news_articles
 from backend.market_data.jobs.stock_updater import update_all_held_stocks
 
@@ -135,6 +136,11 @@ def register_jobs(scheduler: AsyncIOScheduler) -> None:
         update_news_articles, "cron",
         minute=0, timezone="Asia/Ho_Chi_Minh",
         id="news_updater",
+    )
+    scheduler.add_job(
+        seed_year_start_stock_prices, "cron",
+        month=1, day=1, hour=7, minute=0, timezone="Asia/Ho_Chi_Minh",
+        id="historical_price_seeder",
     )
 
 

--- a/backend/tests/test_briefing_phase39.py
+++ b/backend/tests/test_briefing_phase39.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.briefing.morning_briefing import render_enriched_morning_briefing
+from backend.market_data.normalizer import PriceQuote
+from backend.models.user import User
+from backend.wealth.services.net_worth_calculator import NetWorthBreakdown, NetWorthChange
+
+
+class _Result:
+    def __init__(self, rows=None, scalar=None):
+        self.rows = rows or []
+        self._scalar = scalar
+
+    def scalar_one_or_none(self):
+        return self._scalar
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self.rows
+
+
+class _DB:
+    async def execute(self, stmt):
+        return _Result([])
+
+
+def _quote(symbol: str, price: str, asset_type: str, *, stale=False):
+    return PriceQuote(symbol, Decimal(price), "VND", asset_type, datetime.now(timezone.utc), "test", is_stale=stale)
+
+
+@pytest.mark.asyncio
+async def test_enriched_briefing_renders_five_sections_and_stale_footer():
+    user = User()
+    user.id = uuid.uuid4()
+    user.telegram_id = 123
+    breakdown = NetWorthBreakdown(total=Decimal("100000000"), by_type={"stock": Decimal("60000000"), "cash": Decimal("40000000")}, asset_count=2)
+    change = NetWorthChange(Decimal("100000000"), Decimal("99000000"), Decimal("1000000"), 1.0, "hôm qua")
+
+    with patch("backend.briefing.morning_briefing.net_worth_calculator.calculate", AsyncMock(return_value=breakdown)), \
+         patch("backend.briefing.morning_briefing.net_worth_calculator.calculate_change", AsyncMock(return_value=change)), \
+         patch("backend.briefing.morning_briefing.get_crypto_quote", AsyncMock(return_value=_quote("BTC", "100", "crypto", stale=True))), \
+         patch("backend.briefing.morning_briefing.get_gold_quote", AsyncMock(return_value=_quote("SJC_GOLD", "90000000", "gold"))), \
+         patch("backend.briefing.morning_briefing.get_relevant_news", AsyncMock(return_value=[])), \
+         patch("backend.briefing.morning_briefing.get_best_worst_from_assets", AsyncMock(return_value=(None, None))):
+        result = await render_enriched_morning_briefing(_DB(), user)
+
+    assert "Tổng tài sản" in result.text
+    assert "Thị trường sáng nay" in result.text
+    assert "Danh mục" in result.text
+    assert "Top tin liên quan" in result.text
+    assert "Gợi ý nhanh" in result.text
+    assert "dữ liệu gần nhất" in result.text
+    assert result.is_stale is True

--- a/backend/tests/test_market_data/test_alerts.py
+++ b/backend/tests/test_market_data/test_alerts.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from backend.market_data.analytics.alerts import format_alert_message, severity_for_change
+
+
+def test_severity_for_change_thresholds():
+    assert severity_for_change(Decimal("5.0")) == "info"
+    assert severity_for_change(Decimal("7.0")) == "warning"
+    assert severity_for_change(Decimal("10.1")) == "critical"
+
+
+def test_alert_message_uses_vietnamese_persona():
+    message = format_alert_message("HPG", Decimal("6.5"), Decimal("30000"), "info")
+
+    assert "Bé Tiền" in message
+    assert "HPG" in message
+    assert "tăng" in message

--- a/backend/tests/test_market_data/test_portfolio_metrics.py
+++ b/backend/tests/test_market_data/test_portfolio_metrics.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from backend.market_data.analytics.portfolio_metrics import compute_diversification_score
+
+
+def test_diversification_score_good_for_balanced_portfolio():
+    result = compute_diversification_score([
+        {"asset_type": "stock", "value": Decimal("40")},
+        {"asset_type": "cash", "value": Decimal("30")},
+        {"asset_type": "gold", "value": Decimal("20")},
+        {"asset_type": "crypto", "value": Decimal("10")},
+    ])
+
+    assert result["score"] >= 70
+    assert result["label"] == "Tốt"
+
+
+def test_diversification_score_weak_for_single_asset():
+    result = compute_diversification_score([{"asset_type": "stock", "value": Decimal("100")}])
+
+    assert result["score"] < 40
+    assert result["label"] == "Yếu"

--- a/content/briefing.yaml
+++ b/content/briefing.yaml
@@ -1,0 +1,23 @@
+# Phase 3.9 real-data morning briefing template.
+# 5 sections, intentionally compact for Telegram.
+sections:
+  net_worth: |
+    💰 Tổng tài sản: {net_worth}
+    {change_label}: {change_abs} ({change_pct}%)
+  market: |
+    🌤️ Thị trường sáng nay:
+    • VN-Index: {vnindex}
+    • Vàng SJC: {gold}
+    • BTC: {btc}
+  portfolio: |
+    📊 Danh mục:
+    {allocation_lines}
+    Hôm nay: {today_change}
+  news: |
+    📰 Top tin liên quan:
+    {news_lines}
+  insights: |
+    💡 Gợi ý nhanh:
+    {insight_lines}
+footer:
+  stale: "⚠️ Một số giá đang dùng dữ liệu gần nhất vì nguồn realtime tạm chậm."


### PR DESCRIPTION
### Motivation
- Thay tất cả stub market-data bằng dữ liệu thật để `morning_briefing` và valuation hiển thị số chính xác, tăng niềm tin người dùng trước soft-launch.
- Bổ sung phần analytics và alerts để briefing có insights hữu dụng (YTD, best/worst, diversification) và cảnh báo biến động giá quan trọng.

### Description
- Thêm renderer briefing real-data `backend/briefing/morning_briefing.py` và template `content/briefing.yaml` để hiển thị 5 section (net worth, market, portfolio, news, insights) và footer khi dữ liệu stale.
- Bổ sung analytics `backend/market_data/analytics/portfolio_metrics.py` (YTD return, best/worst, diversification) và job `backend/market_data/jobs/historical_price_seeder.py` plus scheduler registration for annual seeding.
- Thêm alerts `backend/market_data/analytics/alerts.py` với feature flag (`market_data_alerts_enabled`), severity tiers, anti-spam (max 3 alerts/user/day) và cooldown 30 phút/symbol, và hook vào stock updater (`backend/market_data/jobs/stock_updater.py`).
- Cập nhật agent/tool `backend/agent/tools/get_market_data.py` để trả về dữ liệu realtime cho stock/crypto/gold/bank/news; thêm DB models + migration: `StockHistoricalPrice`, `NotificationSettings`, `PriceAlertLog` (`backend/models/*.py` + `alembic/versions/...`).
- Thêm unit tests tập trung cho briefing, alerts và diversification score dưới `backend/tests/...` và small wiring/compile fixes; config flag default `False`.

### Testing
- Ran focused unit/integration tests: `PYTHONPATH=. pytest backend/tests/test_market_data/test_portfolio_metrics.py backend/tests/test_market_data/test_alerts.py backend/tests/test_briefing_phase39.py backend/tests/test_market_data/test_updater_jobs.py backend/tests/test_wealth_valuation_market_data.py`, and these passed (all new/related tests green).
- Compiled modules to ensure no syntax errors: `PYTHONPATH=. python -m compileall backend alembic/versions/q6k7l8m9n0p1_phase39_epic4_analytics_alerts.py` succeeded.
- Full repo test run earlier surfaced unrelated failures in pre-existing `sync_phase_status` and Telegram webhook tests; the changes in this PR target market/briefing code and the new tests pass, while broader failures are from unrelated areas in the test tree.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fda73161c8832facc6d401b07e48e7)