### PR TITLE
Avoid duplicate net worth valuation by adding calculate_change_from_current and updating handler/tests

### DIFF
--- a/backend/intent/handlers/query_net_worth.py
+++ b/backend/intent/handlers/query_net_worth.py
@@ -29,8 +29,11 @@ class QueryNetWorthHandler(IntentHandler):
         level = detect_level(breakdown.total)
         style = style_for_level(level, breakdown.total)
 
-        change = await net_worth_calculator.calculate_change(
-            db, user.id, period=net_worth_calculator.PERIOD_MONTH
+        change = await net_worth_calculator.calculate_change_from_current(
+            db,
+            user.id,
+            breakdown.total,
+            period=net_worth_calculator.PERIOD_MONTH,
         )
 
         name = user.display_name or "bạn"
@@ -55,8 +58,11 @@ class QueryNetWorthHandler(IntentHandler):
         # year-period approximation from net_worth_calculator.
         if style.show_ytd_return:
             try:
-                yearly = await net_worth_calculator.calculate_change(
-                    db, user.id, period=net_worth_calculator.PERIOD_YEAR
+                yearly = await net_worth_calculator.calculate_change_from_current(
+                    db,
+                    user.id,
+                    breakdown.total,
+                    period=net_worth_calculator.PERIOD_YEAR,
                 )
             except ValueError:
                 yearly = None

--- a/backend/tests/test_intent/test_handlers.py
+++ b/backend/tests/test_intent/test_handlers.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import uuid
 from datetime import date
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -211,12 +211,15 @@ async def test_query_net_worth_handler_includes_change_when_baseline_exists():
     change.change_percentage = 11.11
     change.period_label = "tháng trước"
 
+    calculate_mock = AsyncMock(return_value=breakdown)
+    change_mock = AsyncMock(return_value=change)
+
     with patch(
         "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate",
-        AsyncMock(return_value=breakdown),
+        calculate_mock,
     ), patch(
-        "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change",
-        AsyncMock(return_value=change),
+        "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_from_current",
+        change_mock,
     ):
         intent = IntentResult(
             intent=IntentType.QUERY_NET_WORTH,
@@ -228,6 +231,10 @@ async def test_query_net_worth_handler_includes_change_when_baseline_exists():
     assert "500,000,000" in response
     assert "tháng trước" in response
     assert "📈" in response or "📉" in response
+    calculate_mock.assert_awaited_once()
+    change_mock.assert_awaited_once_with(
+        ANY, ANY, Decimal("500000000"), period="month"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_net_worth_calculator.py
+++ b/backend/tests/test_net_worth_calculator.py
@@ -122,6 +122,27 @@ class TestCalculateChange:
         # No baseline — display flat 0% rather than +inf%.
         assert change.change_percentage == 0.0
 
+    async def test_change_from_current_skips_current_recalculation(self, monkeypatch):
+        async def fail_calculate(*_args, **_kwargs):
+            raise AssertionError("calculate() should not be called")
+
+        monkeypatch.setattr(nwc, "calculate", fail_calculate)
+        result = MagicMock()
+        result.scalar.return_value = Decimal("80_000_000")
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+
+        change = await nwc.calculate_change_from_current(
+            db, uuid.uuid4(), Decimal("100_000_000"), period="month"
+        )
+
+        assert change.current == Decimal("100_000_000")
+        assert change.previous == Decimal("80_000_000")
+        assert change.change_absolute == Decimal("20_000_000")
+        assert change.change_percentage == 25.0
+        assert change.period_label == "tháng trước"
+        db.execute.assert_awaited_once()
+
     async def test_unknown_period_raises(self, monkeypatch):
         monkeypatch.setattr(
             "backend.wealth.services.asset_service.get_user_assets",

--- a/backend/wealth/services/net_worth_calculator.py
+++ b/backend/wealth/services/net_worth_calculator.py
@@ -133,10 +133,18 @@ async def calculate_historical(
     return Decimal(total)
 
 
-async def calculate_change(
-    db: AsyncSession, user_id: uuid.UUID, period: str = PERIOD_DAY
+async def calculate_change_from_current(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    current: Decimal,
+    period: str = PERIOD_DAY,
 ) -> NetWorthChange:
-    """Compare current net worth to ``period`` ago.
+    """Compare a known current net worth to ``period`` ago.
+
+    Use this when the caller already calculated the current breakdown.
+    It avoids a second live asset valuation pass in hot paths such as
+    ``query_net_worth`` while preserving the exact historical comparison
+    semantics of :func:`calculate_change`.
 
     Edge cases:
     - User has no historical snapshots → previous=0, change=current
@@ -148,9 +156,7 @@ async def calculate_change(
             f"Unknown period {period!r}; must be one of {list(_PERIOD_DAYS)}"
         )
 
-    current_breakdown = await calculate(db, user_id)
-    current = current_breakdown.total
-
+    current = Decimal(current or 0)
     past = date.today() - timedelta(days=_PERIOD_DAYS[period])
     previous = await calculate_historical(db, user_id, past)
 
@@ -167,4 +173,20 @@ async def calculate_change(
         change_absolute=change_absolute,
         change_percentage=change_pct,
         period_label=_PERIOD_LABELS[period],
+    )
+
+
+async def calculate_change(
+    db: AsyncSession, user_id: uuid.UUID, period: str = PERIOD_DAY
+) -> NetWorthChange:
+    """Compare current net worth to ``period`` ago.
+
+    This compatibility wrapper still computes the current breakdown for
+    callers that only need a one-shot change result. Callers that already
+    have a current total should use :func:`calculate_change_from_current`
+    to avoid duplicate asset queries / live valuations.
+    """
+    current_breakdown = await calculate(db, user_id)
+    return await calculate_change_from_current(
+        db, user_id, current_breakdown.total, period=period
     )


### PR DESCRIPTION
### Motivation
- Avoid an extra live asset valuation when the caller already has the current net worth total to improve hot-path performance.  
- Preserve existing change-calculation semantics while enabling callers to reuse a previously computed breakdown.  
- Keep backwards compatibility for callers that still expect `calculate_change` to compute the current total.

### Description
- Add `calculate_change_from_current(db, user_id, current, period)` to `backend/wealth/services/net_worth_calculator.py` which computes historical comparison using a provided `current` total.  
- Reintroduce `calculate_change` as a thin compatibility wrapper that calls `calculate_change_from_current` after computing the current breakdown.  
- Update `backend/intent/handlers/query_net_worth.py` to call `calculate_change_from_current` (for month and year periods) and pass `breakdown.total` to avoid recalculating the live valuation.  
- Update tests in `backend/tests/test_intent/test_handlers.py` and `backend/tests/test_net_worth_calculator.py` to use/verify the new API and add `test_change_from_current_skips_current_recalculation` to ensure no duplicate `calculate()` call occurs; add `ANY` import for stricter call assertions.

### Testing
- Ran the updated intent handler unit test `backend/tests/test_intent/test_handlers.py::test_query_net_worth_handler_includes_change_when_baseline_exists`, which passed.  
- Ran the new calculator unit test `backend/tests/test_net_worth_calculator.py::TestCalculateChange::test_change_from_current_skips_current_recalculation`, which passed.  
- Ran the modified test suite for net-worth-related behaviors and all updated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5f3471e4832f87a256c54566cf02)