### PR TITLE
Fast menu net-worth path, separate stored/historical change calc, and analytics timing fix

### DIFF
--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -56,6 +56,7 @@ from backend.bot.formatters.menu_formatter import (
     format_submenu,
     known_categories,
 )
+from backend.bot.formatters.money import format_money_full
 from backend.bot.handlers.free_form_text import _send_outcome
 from backend.intent.dispatcher import IntentDispatcher
 from backend.intent.intents import (
@@ -346,10 +347,10 @@ async def _navigate(
 # single source of truth — the dispatcher does the rest (handler call,
 # personality wrap, follow-up keyboard).
 _INTENT_MAP: dict[tuple[str, str], tuple[IntentType, dict]] = {
-    # Tài sản — "Tổng tài sản" = short summary; "Báo cáo chi tiết" = list
-    # of every asset grouped by type. The mapping was swapped before
-    # Phase 3.6 user feedback called out the mismatch.
-    ("assets", "net_worth"): (IntentType.QUERY_NET_WORTH, {}),
+    # Tài sản — "Tổng tài sản" uses a direct fast handler because the
+    # callback is deterministic and should answer from the already-current
+    # asset values without waiting for historical snapshot comparisons.
+    # "Báo cáo chi tiết" still maps to the existing per-asset list intent.
     ("assets", "report"): (IntentType.QUERY_ASSETS, {}),
     # Chi tiêu
     ("expenses", "report"): (IntentType.QUERY_EXPENSES, {}),
@@ -401,16 +402,19 @@ async def _route_action(
       3. Synthesised advisory via ``_ADVISORY_MAP``.
       4. Coming-soon fallback (never crash, always escape route).
     """
-    analytics.track(
-        "menu_action_tapped",
-        user_id=user.id,
-        properties={"category": category, "action": action},
-    )
+    # Track after the selected action has rendered. ``analytics.track`` is
+    # fire-and-forget, but it still opens a background DB session; doing it
+    # before fast read paths can contend for the same connection pool and
+    # add visible latency before the user sees a reply.
+    track_properties = {"category": category, "action": action}
 
     # 1. Direct-handler actions.
     direct = _DIRECT_HANDLERS.get((category, action))
     if direct is not None:
         await direct(db=db, user=user, chat_id=chat_id, message_id=message_id)
+        analytics.track(
+            "menu_action_tapped", user_id=user.id, properties=track_properties
+        )
         return
 
     # 2. Synthesised read intent.
@@ -423,6 +427,9 @@ async def _route_action(
             intent_type=intent_type,
             parameters=params,
             origin=f"menu:{category}:{action}",
+        )
+        analytics.track(
+            "menu_action_tapped", user_id=user.id, properties=track_properties
         )
         return
 
@@ -438,10 +445,16 @@ async def _route_action(
             origin=f"menu:{category}:{action}",
             raw_text=prompt,
         )
+        analytics.track(
+            "menu_action_tapped", user_id=user.id, properties=track_properties
+        )
         return
 
     # 4. Genuinely unwired — friendly stub with escape route.
     await _send_coming_soon(chat_id, category, action)
+    analytics.track(
+        "menu_action_tapped", user_id=user.id, properties=track_properties
+    )
 
 
 async def _dispatch_synthesised(
@@ -490,6 +503,52 @@ async def _send_coming_soon(chat_id: int, category: str, action: str) -> None:
 # -----------------------------------------------------------------
 # Direct-handler implementations (wizards, prompt-and-wait)
 # -----------------------------------------------------------------
+
+
+async def _action_assets_net_worth(
+    *, db: AsyncSession, user: User, chat_id: int, message_id: int | None
+) -> None:
+    """Fast menu response for ``Tài sản → Tổng tài sản``.
+
+    A menu callback has an exact intent, so this path intentionally skips
+    the generic intent dispatcher, historical snapshot comparisons, and live
+    market quote refreshes. The slower free-form ``query_net_worth`` handler
+    still provides monthly/YTD change context when the user asks in natural
+    language.
+    """
+    from backend.intent.wealth_adapt import decorate, style_for_level
+    from backend.wealth.ladder import detect_level
+    from backend.wealth.services import net_worth_calculator
+
+    breakdown = await net_worth_calculator.calculate_stored_current(db, user.id)
+    name = user.display_name or "bạn"
+    if breakdown.total <= 0:
+        await send_message(
+            chat_id=chat_id,
+            text=(
+                f"💎 {name} chưa có tài sản nào trong hệ thống.\n\n"
+                "Tap /themtaisan để mình tính tổng tài sản giúp nhé 🚀"
+            ),
+            reply_markup=back_to_main_keyboard(),
+        )
+        return
+
+    level = detect_level(breakdown.total)
+    style = style_for_level(level, breakdown.total)
+    lines = [
+        f"💰 Tổng tài sản của {name}:",
+        f"*{format_money_full(breakdown.total)}*",
+    ]
+    if breakdown.asset_count and not style.is_starter:
+        lines.append("")
+        lines.append(f"_Theo dõi qua {breakdown.asset_count} tài sản_")
+
+    await send_message(
+        chat_id=chat_id,
+        text=decorate("\n".join(lines), style),
+        parse_mode="Markdown",
+        reply_markup=back_to_main_keyboard(),
+    )
 
 
 async def _action_assets_add(
@@ -626,6 +685,7 @@ async def _action_goals_update(
 
 
 _DIRECT_HANDLERS = {
+    ("assets", "net_worth"): _action_assets_net_worth,
     ("assets", "add"): _action_assets_add,
     ("assets", "edit"): _action_assets_edit,
     ("assets", "mark_rental"): _action_assets_mark_rental,

--- a/backend/intent/handlers/query_net_worth.py
+++ b/backend/intent/handlers/query_net_worth.py
@@ -29,8 +29,11 @@ class QueryNetWorthHandler(IntentHandler):
         level = detect_level(breakdown.total)
         style = style_for_level(level, breakdown.total)
 
-        change = await net_worth_calculator.calculate_change(
-            db, user.id, period=net_worth_calculator.PERIOD_MONTH
+        change = await net_worth_calculator.calculate_change_from_current(
+            db,
+            user.id,
+            breakdown.total,
+            period=net_worth_calculator.PERIOD_MONTH,
         )
 
         name = user.display_name or "bạn"
@@ -55,8 +58,11 @@ class QueryNetWorthHandler(IntentHandler):
         # year-period approximation from net_worth_calculator.
         if style.show_ytd_return:
             try:
-                yearly = await net_worth_calculator.calculate_change(
-                    db, user.id, period=net_worth_calculator.PERIOD_YEAR
+                yearly = await net_worth_calculator.calculate_change_from_current(
+                    db,
+                    user.id,
+                    breakdown.total,
+                    period=net_worth_calculator.PERIOD_YEAR,
                 )
             except ValueError:
                 yearly = None

--- a/backend/tests/test_intent/test_handlers.py
+++ b/backend/tests/test_intent/test_handlers.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import uuid
 from datetime import date
 from decimal import Decimal
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -211,12 +211,15 @@ async def test_query_net_worth_handler_includes_change_when_baseline_exists():
     change.change_percentage = 11.11
     change.period_label = "tháng trước"
 
+    calculate_mock = AsyncMock(return_value=breakdown)
+    change_mock = AsyncMock(return_value=change)
+
     with patch(
         "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate",
-        AsyncMock(return_value=breakdown),
+        calculate_mock,
     ), patch(
-        "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change",
-        AsyncMock(return_value=change),
+        "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_from_current",
+        change_mock,
     ):
         intent = IntentResult(
             intent=IntentType.QUERY_NET_WORTH,
@@ -228,6 +231,10 @@ async def test_query_net_worth_handler_includes_change_when_baseline_exists():
     assert "500,000,000" in response
     assert "tháng trước" in response
     assert "📈" in response or "📉" in response
+    calculate_mock.assert_awaited_once()
+    change_mock.assert_awaited_once_with(
+        ANY, ANY, Decimal("500000000"), period="month"
+    )
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_menu_v2.py
+++ b/backend/tests/test_menu_v2.py
@@ -8,7 +8,9 @@ Three concerns covered:
 """
 from __future__ import annotations
 
+from decimal import Decimal
 from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
 import pytest
 
@@ -602,6 +604,50 @@ class TestCmdDashboard:
         assert url == "https://example.com/miniapp/wealth?source=dashboard_command"
 
 
+class TestNetWorthFastPath:
+    @pytest.mark.asyncio
+    async def test_assets_net_worth_direct_handler_skips_historical_change(
+        self, monkeypatch
+    ):
+        from backend.bot.handlers import menu_handler
+        from backend.wealth.services import net_worth_calculator
+
+        breakdown = SimpleNamespace(
+            total=Decimal("500000000"),
+            asset_count=3,
+        )
+        sent: dict = {}
+
+        async def fake_send_message(**kwargs):
+            sent.update(kwargs)
+
+        async def fail_change(*_args, **_kwargs):
+            raise AssertionError("menu fast path must not query snapshots")
+
+        monkeypatch.setattr(
+            net_worth_calculator,
+            "calculate_stored_current",
+            AsyncMock(return_value=breakdown),
+        )
+        monkeypatch.setattr(
+            net_worth_calculator, "calculate", fail_change
+        )
+        monkeypatch.setattr(
+            net_worth_calculator, "calculate_change_from_current", fail_change
+        )
+        monkeypatch.setattr(menu_handler, "send_message", fake_send_message)
+
+        await menu_handler._action_assets_net_worth(
+            db=object(), user=_user("An"), chat_id=42, message_id=7
+        )
+
+        assert sent["chat_id"] == 42
+        assert "Tổng tài sản của An" in sent["text"]
+        assert "500,000,000" in sent["text"]
+        assert "tháng trước" not in sent["text"]
+        assert sent["reply_markup"] == back_to_main_keyboard()
+
+
 # ============================================================
 # Cross-check: every submenu action has a wired handler or fallback
 # ============================================================
@@ -642,19 +688,18 @@ class TestActionCoverage:
             f"Unwired actions (coming-soon stub will fire): {coming_soon}"
         )
 
-    def test_assets_net_worth_and_report_intents_are_not_swapped(self):
+    def test_assets_net_worth_and_report_routes_are_not_swapped(self):
         """User feedback caught these inverted: ``📊 Tổng tài sản``
-        should fire the SHORT summary (``QUERY_NET_WORTH``) and
-        ``📈 Báo cáo chi tiết`` should fire the per-asset list
-        (``QUERY_ASSETS``). This test pins the orientation so a
-        well-meaning refactor can't silently re-swap them.
+        should show the SHORT summary and ``📈 Báo cáo chi tiết`` should
+        show the per-asset list. Pin the orientation even though net worth
+        now uses a direct fast handler instead of the intent dispatcher.
         """
-        from backend.bot.handlers.menu_handler import _INTENT_MAP
+        from backend.bot.handlers.menu_handler import _DIRECT_HANDLERS, _INTENT_MAP
         from backend.intent.intents import IntentType
 
-        assert _INTENT_MAP[("assets", "net_worth")] == (
-            IntentType.QUERY_NET_WORTH, {}
-        ), "📊 Tổng tài sản must show the short net-worth summary"
+        assert ("assets", "net_worth") in _DIRECT_HANDLERS, (
+            "📊 Tổng tài sản must use the fast short net-worth summary"
+        )
         assert _INTENT_MAP[("assets", "report")] == (
             IntentType.QUERY_ASSETS, {}
         ), "📈 Báo cáo chi tiết must list every asset"

--- a/backend/tests/test_net_worth_calculator.py
+++ b/backend/tests/test_net_worth_calculator.py
@@ -61,6 +61,30 @@ class TestCalculate:
         assert b.by_type["real_estate"] == Decimal("2_000_000_000")
         assert b.largest_asset == ("Nhà Mỹ Đình", Decimal("2_000_000_000"))
 
+    async def test_stored_current_skips_live_market_valuation(self, monkeypatch):
+        async def fail_live_valuation(*_args, **_kwargs):
+            raise AssertionError("stored-current path must not call live valuation")
+
+        monkeypatch.setattr(nwc, "value_stock_holding", fail_live_valuation)
+        monkeypatch.setattr(nwc, "value_crypto_holding", fail_live_valuation)
+        monkeypatch.setattr(
+            "backend.wealth.services.asset_service.get_user_assets",
+            AsyncMock(return_value=[
+                _asset("stock", "VNM", 20_000_000),
+                _asset("crypto", "BTC", 30_000_000),
+                _asset("cash", "VCB", 50_000_000),
+            ]),
+        )
+
+        breakdown = await nwc.calculate_stored_current(MagicMock(), uuid.uuid4())
+
+        assert breakdown.total == Decimal("100_000_000")
+        assert breakdown.asset_count == 3
+        assert breakdown.by_type["stock"] == Decimal("20_000_000")
+        assert breakdown.by_type["crypto"] == Decimal("30_000_000")
+        assert breakdown.by_type["cash"] == Decimal("50_000_000")
+        assert breakdown.largest_asset == ("VCB", Decimal("50_000_000"))
+
 
 @pytest.mark.asyncio
 class TestCalculateHistorical:
@@ -121,6 +145,27 @@ class TestCalculateChange:
         assert change.change_absolute == Decimal("50_000_000")
         # No baseline — display flat 0% rather than +inf%.
         assert change.change_percentage == 0.0
+
+    async def test_change_from_current_skips_current_recalculation(self, monkeypatch):
+        async def fail_calculate(*_args, **_kwargs):
+            raise AssertionError("calculate() should not be called")
+
+        monkeypatch.setattr(nwc, "calculate", fail_calculate)
+        result = MagicMock()
+        result.scalar.return_value = Decimal("80_000_000")
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+
+        change = await nwc.calculate_change_from_current(
+            db, uuid.uuid4(), Decimal("100_000_000"), period="month"
+        )
+
+        assert change.current == Decimal("100_000_000")
+        assert change.previous == Decimal("80_000_000")
+        assert change.change_absolute == Decimal("20_000_000")
+        assert change.change_percentage == 25.0
+        assert change.period_label == "tháng trước"
+        db.execute.assert_awaited_once()
 
     async def test_unknown_period_raises(self, monkeypatch):
         monkeypatch.setattr(

--- a/backend/wealth/services/net_worth_calculator.py
+++ b/backend/wealth/services/net_worth_calculator.py
@@ -103,6 +103,41 @@ async def calculate(
     )
 
 
+async def calculate_stored_current(
+    db: AsyncSession, user_id: uuid.UUID
+) -> NetWorthBreakdown:
+    """Sum active assets from stored ``current_value`` only.
+
+    This intentionally skips live stock/crypto market valuation. Use it for
+    deterministic UI surfaces (for example Telegram menu taps) where latency
+    matters more than refreshing quotes on demand. Rich free-form queries and
+    dashboards can still call :func:`calculate` when they want live pricing.
+    """
+    assets: list[Asset] = await asset_service.get_user_assets(db, user_id)
+    if not assets:
+        return NetWorthBreakdown()
+
+    by_type: dict[str, Decimal] = {}
+    total = Decimal(0)
+    largest_name: str | None = None
+    largest_value = Decimal(0)
+
+    for a in assets:
+        value = Decimal(a.current_value or 0)
+        total += value
+        by_type[a.asset_type] = by_type.get(a.asset_type, Decimal(0)) + value
+        if value > largest_value:
+            largest_value = value
+            largest_name = a.name
+
+    return NetWorthBreakdown(
+        total=total,
+        by_type=by_type,
+        asset_count=len(assets),
+        largest_asset=(largest_name, largest_value),
+    )
+
+
 async def calculate_historical(
     db: AsyncSession, user_id: uuid.UUID, target_date: date
 ) -> Decimal:
@@ -133,10 +168,18 @@ async def calculate_historical(
     return Decimal(total)
 
 
-async def calculate_change(
-    db: AsyncSession, user_id: uuid.UUID, period: str = PERIOD_DAY
+async def calculate_change_from_current(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    current: Decimal,
+    period: str = PERIOD_DAY,
 ) -> NetWorthChange:
-    """Compare current net worth to ``period`` ago.
+    """Compare a known current net worth to ``period`` ago.
+
+    Use this when the caller already calculated the current breakdown.
+    It avoids a second live asset valuation pass in hot paths such as
+    ``query_net_worth`` while preserving the exact historical comparison
+    semantics of :func:`calculate_change`.
 
     Edge cases:
     - User has no historical snapshots → previous=0, change=current
@@ -148,9 +191,7 @@ async def calculate_change(
             f"Unknown period {period!r}; must be one of {list(_PERIOD_DAYS)}"
         )
 
-    current_breakdown = await calculate(db, user_id)
-    current = current_breakdown.total
-
+    current = Decimal(current or 0)
     past = date.today() - timedelta(days=_PERIOD_DAYS[period])
     previous = await calculate_historical(db, user_id, past)
 
@@ -167,4 +208,20 @@ async def calculate_change(
         change_absolute=change_absolute,
         change_percentage=change_pct,
         period_label=_PERIOD_LABELS[period],
+    )
+
+
+async def calculate_change(
+    db: AsyncSession, user_id: uuid.UUID, period: str = PERIOD_DAY
+) -> NetWorthChange:
+    """Compare current net worth to ``period`` ago.
+
+    This compatibility wrapper still computes the current breakdown for
+    callers that only need a one-shot change result. Callers that already
+    have a current total should use :func:`calculate_change_from_current`
+    to avoid duplicate asset queries / live valuations.
+    """
+    current_breakdown = await calculate(db, user_id)
+    return await calculate_change_from_current(
+        db, user_id, current_breakdown.total, period=period
     )


### PR DESCRIPTION
### Motivation
- Provide an instantaneous, deterministic response for the menu "Tổng tài sản" action without triggering live market valuations or historical recalculation that add latency.
- Avoid contention on DB connections caused by tracking analytics before fast read paths return visible replies.
- Reduce duplicate work in net-worth change calculations by allowing callers that already have the current total to supply it.

### Description
- Add a direct fast handler `_action_assets_net_worth` wired into `_DIRECT_HANDLERS` for the menu callback `("assets", "net_worth")` that uses stored `current_value` only and renders a short summary with `format_money_full`.
- Introduce `calculate_stored_current` in `backend.wealth.services.net_worth_calculator` to sum stored `current_value` without live stock/crypto valuation, and add `calculate_change_from_current` which computes historical change given a known `current` total; keep `calculate_change` as a compatibility wrapper that calls the new function.
- Update `QueryNetWorthHandler` to use `calculate_change_from_current` when it already has the breakdown to avoid duplicate recalculation.
- Move `analytics.track("menu_action_tapped", ...)` so it runs after the action has rendered (per-branch) to reduce contention/latency for fast read paths.
- Update imports and formatters usage (`format_money_full`) and adjust `_INTENT_MAP`/`_DIRECT_HANDLERS` so net-worth uses the fast direct handler while `report` still maps to `QUERY_ASSETS`.
- Update unit tests to exercise the new fast path and the new calculator behaviors and adjust expectation/assertions accordingly.

### Testing
- Ran unit tests touching the changes: `backend/tests/test_net_worth_calculator.py`, `backend/tests/test_menu_v2.py`, and `backend/tests/test_intent/test_handlers.py`; all updated tests passed locally.
- Added tests verifying `calculate_stored_current` skips live valuation and `calculate_change_from_current` avoids recalculating current total, and added a menu test `TestNetWorthFastPath` that asserts the direct handler returns the stored-current summary; these tests succeeded.
- Existing intent handler tests were updated to assert the new call-site behavior for change calculation and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5f3471e4832f87a256c54566cf02)