### PR TITLE
fix: 3 UX issues — cancel nav, rental label, dashboard label consistency

### DIFF
--- a/backend/bot/handlers/goal_entry.py
+++ b/backend/bot/handlers/goal_entry.py
@@ -196,6 +196,17 @@ async def start_goals_wizard(
     analytics.track(GoalEvent.WIZARD_OPENED, user_id=user.id)
 
 
+async def _send_goals_submenu(chat_id: int, user: User) -> None:
+    """Navigate back to the goals submenu (4-button screen)."""
+    from backend.bot.formatters.menu_formatter import format_submenu, get_submenu_hint
+    level = user.wealth_level if user else None
+    text, keyboard = format_submenu(user, "goals", level=level)
+    hint = get_submenu_hint("goals")
+    if hint:
+        text = f"{text}\n\n{hint}"
+    await send_message(chat_id=chat_id, text=text, reply_markup=keyboard)
+
+
 async def cancel_wizard(
     db: AsyncSession, chat_id: int, user: User
 ) -> bool:
@@ -204,7 +215,7 @@ async def cancel_wizard(
         return False
     await wizard_service.clear(db, user.id)
     analytics.track(GoalEvent.WIZARD_CANCELED, user_id=user.id)
-    await show_goals_list(db, chat_id, user)
+    await _send_goals_submenu(chat_id, user)
     return True
 
 
@@ -942,13 +953,9 @@ async def _dispatch(
         await show_goals_list(db, chat_id, user)
         return
     if action == "cancel":
-        # Issue #450 §4 — the button label is now "◀️ Quay về", so the
-        # right behaviour is to land the user on the goals list instead
-        # of a dead-end "Đã huỷ" message. We still clear wizard state
-        # so any in-progress draft is dropped before showing the list.
         await wizard_service.clear(db, user.id)
         analytics.track(GoalEvent.WIZARD_CANCELED, user_id=user.id)
-        await show_goals_list(db, chat_id, user)
+        await _send_goals_submenu(chat_id, user)
         return
     if action == "custom":
         await _handle_custom_pick(db, chat_id, user)

--- a/backend/bot/setup_commands.py
+++ b/backend/bot/setup_commands.py
@@ -41,7 +41,7 @@ BOT_COMMANDS: list[dict[str, str]] = [
     {"command": "start", "description": "Bắt đầu / Onboarding"},
     {"command": "menu", "description": "Menu chính"},
     {"command": "help", "description": "Hướng dẫn sử dụng"},
-    {"command": "dashboard", "description": "Mở Mini App dashboard"},
+    {"command": "dashboard", "description": "Mở Dashboard"},
     {"command": "baocaosang", "description": "Gửi lại briefing sáng"},
     {"command": "feedback", "description": "Gửi góp ý nhanh"},
     {"command": "about", "description": "Thông tin ứng dụng"},

--- a/backend/intent/handlers/query_cashflow.py
+++ b/backend/intent/handlers/query_cashflow.py
@@ -25,7 +25,7 @@ from backend.intent.handlers.query_expenses import (
     _TIME_LABELS_VI,
     _fetch_expenses,
 )
-from backend.intent.handlers.query_income import _SOURCE_ICONS, _SOURCE_LABELS
+from backend.wealth.income_types import get_icon as _income_icon, get_label as _income_label
 from backend.intent.intents import IntentResult
 from backend.intent.wealth_adapt import LevelStyle, decorate, resolve_style
 from backend.models.expense import Expense
@@ -282,8 +282,8 @@ def _top_income_sources(
         key = getattr(stream, "stream_type", None)
         if not isinstance(key, str) or not key:
             key = "other"
-        icon = _SOURCE_ICONS.get(key, "💰")
-        type_label = _SOURCE_LABELS.get(key, key)
+        icon = _income_icon(key)
+        type_label = _income_label(key)
         raw_name = getattr(stream, "name", None)
         name = (
             raw_name.strip()

--- a/backend/intent/handlers/query_income.py
+++ b/backend/intent/handlers/query_income.py
@@ -10,25 +10,8 @@ from backend.bot.formatters.money import format_money_full, format_money_short
 from backend.intent.handlers.base import IntentHandler
 from backend.intent.intents import IntentResult
 from backend.models.user import User
+from backend.wealth.income_types import get_icon, get_label
 from backend.wealth.models.income_stream import IncomeStream
-
-# Source type → user-facing Vietnamese label (mirrors income_streams
-# CHECK constraint values from the Phase 3A spec).
-_SOURCE_LABELS = {
-    "salary": "Lương",
-    "dividend": "Cổ tức",
-    "interest": "Lãi tiết kiệm",
-    "rental": "Cho thuê",
-    "other": "Thu nhập khác",
-}
-
-_SOURCE_ICONS = {
-    "salary": "💼",
-    "dividend": "📊",
-    "interest": "🏦",
-    "rental": "🏠",
-    "other": "💰",
-}
 
 
 class QueryIncomeHandler(IntentHandler):
@@ -83,8 +66,8 @@ class QueryIncomeHandler(IntentHandler):
             "",
         ]
         for s in streams:
-            icon = _SOURCE_ICONS.get(s.stream_type, "💰")
-            label = _SOURCE_LABELS.get(s.stream_type, s.stream_type)
+            icon = get_icon(s.stream_type)
+            label = get_label(s.stream_type)
             lines.append(
                 f"{icon} *{label}* — {s.name}: "
                 f"{format_money_short(s.monthly_equivalent)}/tháng"

--- a/backend/tests/test_goal_entry_handler.py
+++ b/backend/tests/test_goal_entry_handler.py
@@ -361,11 +361,11 @@ class TestCancel:
         db = _db(user)
         with patch.object(goal_entry.wizard_service, "clear",
                           AsyncMock()) as clear, \
-             patch.object(goal_entry, "show_goals_list", AsyncMock()) as show_list:
+             patch.object(goal_entry, "_send_goals_submenu", AsyncMock()) as nav:
             consumed = await goal_entry.cancel_wizard(db, 100, user)
         assert consumed is True
         clear.assert_awaited_once()
-        show_list.assert_awaited_once_with(db, 100, user)
+        nav.assert_awaited_once_with(100, user)
 
     async def test_cancel_noop_for_non_goal_flow(self):
         user = _user({"flow": "asset_add_cash", "step": "amount", "draft": {}})
@@ -478,7 +478,7 @@ class TestEditDateAutoRecalc:
 
 @pytest.mark.asyncio
 class TestCancelNavigatesToList:
-    async def test_cancel_callback_lands_on_goals_list(self):
+    async def test_cancel_callback_lands_on_goals_submenu(self):
         user = _user({
             "flow": goal_entry.FLOW_ADD, "step": "template", "draft": {},
         })
@@ -487,10 +487,9 @@ class TestCancelNavigatesToList:
                           AsyncMock(return_value=user)), \
              patch.object(goal_entry.wizard_service, "clear",
                           AsyncMock()) as clear, \
-             patch.object(goal_entry, "show_goals_list",
-                          AsyncMock()) as show, \
-             patch.object(goal_entry, "answer_callback", AsyncMock()), \
-             patch.object(goal_entry, "send_message", AsyncMock()):
+             patch.object(goal_entry, "_send_goals_submenu",
+                          AsyncMock()) as nav, \
+             patch.object(goal_entry, "answer_callback", AsyncMock()):
             await goal_entry.handle_goals_callback(
                 db,
                 {"id": "cb1", "data": "goals:cancel",
@@ -498,7 +497,7 @@ class TestCancelNavigatesToList:
                  "from": {"id": 100}},
             )
         clear.assert_awaited_once()
-        show.assert_awaited_once()
+        nav.assert_awaited_once()
 
 
 # ---------------------------------------------------------------------

--- a/content/menu_copy.yaml
+++ b/content/menu_copy.yaml
@@ -216,7 +216,7 @@ action_assets_manage:
 
     *3️⃣ Xem nhanh tổng tài sản*
     • Vào menu 💎 Tài sản — tổng tài sản hiển thị ngay phía trên
-  open_miniapp_button: "📊 Mở Mini App"
+  open_miniapp_button: "Mở Dashboard"
   back_button: "◀️ Quay về menu"
 
 # ============================================================


### PR DESCRIPTION
- goal_entry: "Quay về" cancel now navigates to goals submenu (4-button
  screen) instead of flat goals list; extracted _send_goals_submenu helper
  used by both _dispatch() and cancel_wizard()
- query_income: remove hardcoded _SOURCE_LABELS/_SOURCE_ICONS dicts that
  bypassed YAML; use get_label()/get_icon() from wealth.income_types so
  rental shows "BĐS cho thuê" (from income_types.yaml) instead of stale "Cho thuê"
- menu_copy.yaml + setup_commands: standardise all dashboard entry points
  to "Mở Dashboard" (was inconsistently "Mở Mini App")
- tests: update TestCancel + TestCancelNavigatesToList to assert
  _send_goals_submenu is called instead of show_goals_list

https://claude.ai/code/session_0185amQaki3Wasm7hHyVB3bt