### PR TITLE
feat(day-change): show absolute amount + % on dashboard, menu & briefing

### DIFF
--- a/backend/bot/formatters/movers.py
+++ b/backend/bot/formatters/movers.py
@@ -66,26 +66,44 @@ def format_movers_line(
     return " · ".join(parts)
 
 
+def _signed_amount(amount, formatter) -> str:
+    """Render a Decimal/int amount with explicit sign and short money fmt."""
+    from decimal import Decimal
+
+    value = Decimal(amount or 0)
+    sign = "+" if value >= 0 else "−"
+    return f"{sign}{formatter(abs(value))}"
+
+
 def format_movers_block(
     total_pct: float | None,
     movers: Iterable[AssetMover],
     *,
     limit: int = 6,
+    total_amount=None,
+    amount_formatter=None,
 ) -> str:
     """Format the headline + per-asset breakdown across two lines.
 
-    Example::
+    With ``total_amount`` + ``amount_formatter`` (e.g. ``format_money_short``)
+    the headline includes the absolute change too::
 
-        📊 +4.0% so với hôm qua
+        📈 +217 tỷ (+3.0%) so với hôm qua
         VIC +15.0% · MSB +2.0% · BTC −1.2%
 
-    When ``total_pct`` is ``None`` (e.g. no baseline) the headline is
-    omitted; when there are no movers the breakdown line is omitted.
+    Without them the headline shows just the percent (kept for surfaces
+    that haven't wired up the amount yet). When ``total_pct`` is ``None``
+    the headline is omitted; when there are no movers the breakdown line
+    is omitted.
     """
     lines: list[str] = []
     if total_pct is not None and abs(total_pct) >= 0.05:
         icon = "📈" if total_pct > 0 else "📉"
-        lines.append(f"{icon} {_signed_pct(total_pct)} so với hôm qua")
+        if total_amount is not None and amount_formatter is not None:
+            amt = _signed_amount(total_amount, amount_formatter)
+            lines.append(f"{icon} {amt} ({_signed_pct(total_pct)}) so với hôm qua")
+        else:
+            lines.append(f"{icon} {_signed_pct(total_pct)} so với hôm qua")
     elif total_pct is not None:
         lines.append("➖ Đi ngang so với hôm qua")
     detail = format_movers_line(movers, limit=limit)

--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -697,6 +697,7 @@ async def _action_assets_net_worth(
     language. If the stored-current calculation takes at least 700ms, the
     user gets an explicit waiting sentence before the final total.
     """
+    from backend.bot.formatters.money import format_money_short
     from backend.bot.formatters.movers import format_movers_block
     from backend.intent.wealth_adapt import decorate, style_for_level
     from backend.wealth.ladder import detect_level
@@ -735,6 +736,8 @@ async def _action_assets_net_worth(
     movers_block = format_movers_block(
         total_pct=change_day.change_percentage if change_day.previous > 0 else None,
         movers=movers,
+        total_amount=change_day.change_absolute if change_day.previous > 0 else None,
+        amount_formatter=format_money_short,
     )
     if movers_block:
         lines.extend(["", movers_block])

--- a/backend/miniapp/static/js/wealth_dashboard.js
+++ b/backend/miniapp/static/js/wealth_dashboard.js
@@ -184,12 +184,12 @@
     function renderHero(data) {
         els.netWorth.textContent = formatMoneyFull(data.net_worth || 0);
 
-        // User asked for "chỉ cần tổng tăng giảm %" vs hôm qua, with
-        // color + icon. We render just the percent (no absolute amount)
-        // and tag the hero-change element with .up / .down / .flat so
-        // CSS can paint it green/red/neutral.
+        // Show both absolute amount and % vs hôm qua, e.g. "+217 tỷ (3%)".
+        // Color + icon tag the .hero-change element via .up / .down / .flat
+        // so CSS paints it green / red / neutral.
         const change = data.change_day || { amount: 0, pct: 0 };
         const pct = Number(change.pct || 0);
+        const amount = Number(change.amount || 0);
         const tolerance = 0.05;  // < 0.05% reads as "flat" — UI sugar
         let direction = 'flat';
         let icon = '➖';
@@ -200,7 +200,12 @@
             direction = 'down'; icon = '📉'; sign = '−';
         }
         els.changeIcon.textContent = icon;
-        els.changeAmount.textContent = `${sign}${Math.abs(pct).toFixed(1)}%`;
+        const absAmount = formatMoneyShort(Math.abs(amount));
+        const absPct = Math.abs(pct).toFixed(1);
+        els.changeAmount.textContent =
+            direction === 'flat'
+                ? '0₫ (0.0%)'
+                : `${sign}${absAmount} (${sign}${absPct}%)`;
         els.changePeriod.textContent = 'so với hôm qua';
         const heroChange = els.changeIcon.parentElement;
         if (heroChange) {

--- a/backend/tests/test_movers_formatter.py
+++ b/backend/tests/test_movers_formatter.py
@@ -60,6 +60,34 @@ def test_format_movers_block_with_positive_total():
     assert "VIC +15.0%" in block
 
 
+def test_format_movers_block_with_amount_includes_both():
+    """When caller passes total_amount + formatter, headline shows both."""
+    from decimal import Decimal
+
+    block = format_movers_block(
+        total_pct=3.0,
+        movers=[_mover("VIC", "stock", 15.0)],
+        total_amount=Decimal("217_000_000_000"),
+        amount_formatter=lambda v: f"{v / Decimal('1000000000'):.0f} tỷ",
+    )
+    assert "+217 tỷ" in block
+    assert "+3.0%" in block
+    assert "so với hôm qua" in block
+
+
+def test_format_movers_block_with_negative_amount_uses_real_minus():
+    from decimal import Decimal
+
+    block = format_movers_block(
+        total_pct=-2.5,
+        movers=[_mover("BTC", "crypto", -10.0)],
+        total_amount=Decimal("-50_000_000"),
+        amount_formatter=lambda v: f"{v / Decimal('1000000'):.0f}tr",
+    )
+    assert "−50tr" in block  # real minus sign
+    assert "−2.5%" in block
+
+
 def test_format_movers_block_with_negative_total():
     block = format_movers_block(total_pct=-2.5, movers=[_mover("BTC", "crypto", -10.0)])
     assert block.startswith("📉 −2.5% so với hôm qua")


### PR DESCRIPTION
## Summary

Khôi phục format **`+amount (%)`** cho delta "so với hôm qua" trên cả 3 surface — đáp lại yêu cầu user sau PR #530.

### Format chuẩn (giống dashboard cũ)

```
📈 +217 tỷ (+3.0%) so với hôm qua
```

### Thay đổi từng surface

| Surface | Trước | Sau |
|---|---|---|
| **Dashboard hero (Mini App)** | `+12.3% so với hôm qua` | `+217 tỷ (+12.3%) so với hôm qua` |
| **Tài sản → Tổng tài sản (Telegram)** | `📈 +4.0% so với hôm qua` | `📈 +217 tỷ (+4.0%) so với hôm qua` |
| **Morning briefing** | Đã có dạng `Hôm nay: +X tr (+X.X%)` — không đổi | (giữ nguyên — đã consistent) |

### Implementation

- `format_movers_block` nhận thêm `total_amount` + `amount_formatter` để render absolute number.
- Dùng dấu trừ thật `−` cho negative, đồng bộ với dashboard hero.
- Deadband 0.05% giữ nguyên — flat hiển thị `0₫ (0.0%)`.
- Movers list per-asset bên dưới headline giữ nguyên (chỉ %).

## Test plan

- [x] Unit tests pass: 2 cases mới trong `test_movers_formatter.py` phủ positive + negative amount headline
- [x] `ruff check` clean
- [ ] Verify trên staging: dashboard hero + Tài sản menu hiển thị `+amount (pct%)` sau khi backend restart
- [ ] Morning briefing render 06:30 sáng mai không bị regress

https://claude.ai/code/session_01KtAe4QoczgUREJCzzDeHZz

---
_Generated by [Claude Code](https://claude.ai/code/session_01KtAe4QoczgUREJCzzDeHZz)_