### PR TITLE
fix(miniapp): surface chat menu button failures and warn on ngrok-free tunnels

### DIFF
--- a/backend/bot/setup_menu_button.py
+++ b/backend/bot/setup_menu_button.py
@@ -41,6 +41,34 @@ from backend.services.telegram_service import send_telegram
 
 logger = logging.getLogger(__name__)
 
+# Tunnel hostnames that always serve ngrok's abuse interstitial to any
+# request whose User-Agent starts with ``Mozilla`` (i.e. every Telegram
+# WebView on iOS / Android / Desktop). The interstitial replaces our
+# dashboard HTML with a "Visit Site" warning page that the WebView either
+# renders blank (mobile) or hides below the panel fold — users see a
+# blank Mini App. ngrok-free has NO programmatic bypass: the only
+# escape hatches are the user manually clicking "Visit Site" (sets a
+# per-WebView cookie that doesn't persist across sessions) or upgrading
+# to a paid plan / custom domain. We can't fix this at runtime, but we
+# CAN make the failure mode loud at boot so the next person who points
+# the bot at ngrok-free.dev gets a clear pointer instead of a blank
+# panel mystery.
+_NGROK_FREE_INTERSTITIAL_SUFFIXES = (".ngrok-free.dev", ".ngrok-free.app")
+
+
+def _is_ngrok_free_interstitial_host(base_url: str) -> bool:
+    """Return True if ``base_url`` will trigger ngrok's free-tier abuse
+    interstitial on every Telegram WebView open.
+
+    Hostname check only — ngrok rotates the LHS subdomain on every restart
+    of a free tunnel, so we match on the suffix.
+    """
+    try:
+        host = (urlsplit(base_url).hostname or "").lower()
+    except ValueError:
+        return False
+    return any(host.endswith(suffix) for suffix in _NGROK_FREE_INTERSTITIAL_SUFFIXES)
+
 
 def _bumped_mini_app_url(base: str, build_hash: str) -> str:
     """Return ``{base}/miniapp/wealth?b={build_hash}`` preserving any existing
@@ -74,27 +102,51 @@ async def setup_chat_menu_button(build_hash: str) -> dict | None:
     call OVERRIDES whatever was configured manually. Idempotent: calling it
     twice with identical args is a no-op on Telegram's side.
 
-    Returns ``None`` (and logs once at INFO) when the bot token or
-    ``miniapp_base_url`` aren't configured — dev/CI typically has no public
-    HTTPS URL to advertise, and Telegram rejects ``http://`` URLs on
-    ``web_app``. Errors don't propagate so a transient Telegram 5xx during
-    deploy can't fail the boot — the lifespan hook still wraps in
-    try/except, but skipping cleanly is the more useful default.
+    Returns ``None`` when the bot token or ``miniapp_base_url`` aren't
+    configured — dev/CI typically has no public HTTPS URL to advertise, and
+    Telegram rejects ``http://`` URLs on ``web_app``. Errors don't
+    propagate so a transient Telegram 5xx during deploy can't fail the
+    boot — the lifespan hook still wraps in try/except, but skipping
+    cleanly is the more useful default.
+
+    Failure surfacing: every outcome is logged at WARNING or higher so it
+    reaches the launchd-captured stderr log (root logger has no INFO
+    handler by default, hence using WARNING for the "we acted but
+    something is off" cases). Previously a Telegram 4xx response made
+    ``send_telegram`` return ``None`` and this function returned silently
+    — operators had no signal that the menu URL was stale until they
+    tapped the button and saw a blank panel.
     """
     settings = get_settings()
 
     if not settings.telegram_bot_token:
-        logger.info(
+        logger.warning(
             "Skipping chat menu button setup: TELEGRAM_BOT_TOKEN not configured"
         )
         return None
 
     if not settings.miniapp_base_url:
-        logger.info(
+        logger.warning(
             "Skipping chat menu button setup: MINIAPP_BASE_URL not configured "
             "(dev/CI without public HTTPS); BotFather's manual config still applies"
         )
         return None
+
+    if _is_ngrok_free_interstitial_host(settings.miniapp_base_url):
+        # The button URL is still set so devs can poke at the panel
+        # manually after clicking through the interstitial, but anyone
+        # opening this from a Telegram chat will see a blank screen.
+        logger.warning(
+            "MINIAPP_BASE_URL=%s points at an ngrok-free tunnel — Telegram "
+            "WebView will be blocked by ngrok's abuse interstitial "
+            "(ERR_NGROK_6024), users see a BLANK MINI APP on chat menu "
+            "button tap. Switch to a Cloudflare named tunnel (see "
+            "scripts/tunnel-named-setup.sh) or upgrade to a paid ngrok "
+            "plan with a custom domain. Inline-keyboard 'Mở dashboard' "
+            "buttons hit the same wall — they only appear to work because "
+            "Telegram caches the bypass cookie from a prior manual click.",
+            settings.miniapp_base_url,
+        )
 
     url = _bumped_mini_app_url(settings.miniapp_base_url, build_hash)
     payload = {
@@ -105,10 +157,26 @@ async def setup_chat_menu_button(build_hash: str) -> dict | None:
         }
     }
     result = await send_telegram("setChatMenuButton", payload)
-    if result is not None:
-        logger.info(
-            "Chat menu button synced: text=%r url=%s",
+    if result is None:
+        # ``send_telegram`` already logged the HTTP status + body at ERROR,
+        # but the context that would have made it actionable (which call,
+        # what URL, what label) lived only in this caller's locals — so we
+        # re-log it here. The bot keeps running with whatever menu button
+        # BotFather has on file, which may be stale or even un-set.
+        logger.error(
+            "Chat menu button sync FAILED — Telegram rejected setChatMenuButton "
+            "(text=%r url=%s). Users keep the previously-registered button URL "
+            "until the next successful boot. Check the preceding "
+            "'Telegram API error' line for the response body; common causes: "
+            "URL not HTTPS, host not publicly reachable, or BUTTON_URL_INVALID "
+            "from a malformed tunnel hostname.",
             settings.miniapp_menu_label,
             url,
         )
+        return None
+    logger.warning(
+        "Chat menu button synced: text=%r url=%s",
+        settings.miniapp_menu_label,
+        url,
+    )
     return result

--- a/backend/tests/test_setup_menu_button.py
+++ b/backend/tests/test_setup_menu_button.py
@@ -8,12 +8,14 @@ and graceful skip when prerequisites are missing.
 """
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from backend.bot.setup_menu_button import (
     _bumped_mini_app_url,
+    _is_ngrok_free_interstitial_host,
     setup_chat_menu_button,
 )
 
@@ -135,3 +137,149 @@ class TestSetupChatMenuButton:
         ):
             result = await setup_chat_menu_button("abc1234")
             assert result is None
+
+    @pytest.mark.asyncio
+    async def test_logs_error_with_actionable_context_on_api_failure(
+        self, fake_settings, caplog
+    ):
+        # The previous contract was "quiet None" — a Telegram 4xx left
+        # operators with no signal until they tapped the button and
+        # saw a blank panel. The new contract: send_telegram's existing
+        # "Telegram API error: ..." log is augmented here with the URL
+        # and label so a grep tells the whole story.
+        caplog.set_level(logging.ERROR, logger="backend.bot.setup_menu_button")
+        with patch(
+            "backend.bot.setup_menu_button.send_telegram",
+            AsyncMock(return_value=None),
+        ):
+            await setup_chat_menu_button("abc1234")
+        error_records = [
+            r for r in caplog.records
+            if r.name == "backend.bot.setup_menu_button"
+            and r.levelno >= logging.ERROR
+        ]
+        assert error_records, "missing ERROR log on Telegram API failure"
+        message = error_records[-1].getMessage()
+        assert "FAILED" in message
+        assert "https://example.com/miniapp/wealth?b=abc1234" in message
+        assert "💰 Tài sản" in message
+
+    @pytest.mark.asyncio
+    async def test_logs_warning_with_url_on_success(
+        self, fake_settings, mock_telegram, caplog
+    ):
+        # WARNING level (not INFO) so the success line reaches
+        # backend.error.log under the default uvicorn logging config —
+        # root logger only has a stderr WARNING handler. The diagnostic
+        # is what tells deploy verification "yes, the menu URL really
+        # is the new one".
+        caplog.set_level(logging.WARNING, logger="backend.bot.setup_menu_button")
+        await setup_chat_menu_button("abc1234")
+        warning_records = [
+            r for r in caplog.records
+            if r.name == "backend.bot.setup_menu_button"
+            and r.levelno == logging.WARNING
+        ]
+        assert warning_records, "missing WARNING log on success"
+        joined = " ".join(r.getMessage() for r in warning_records)
+        assert "Chat menu button synced" in joined
+        assert "https://example.com/miniapp/wealth?b=abc1234" in joined
+
+    @pytest.mark.asyncio
+    async def test_warns_on_ngrok_free_dev_host(
+        self, fake_settings, mock_telegram, caplog
+    ):
+        # ngrok-free.dev/.app trigger ngrok's abuse interstitial on any
+        # Mozilla-prefixed UA — i.e. every Telegram WebView. The button
+        # is still registered (devs may bypass via a manual click-through)
+        # but we surface a loud WARNING with the upgrade path so the
+        # blank-panel mystery doesn't repeat itself.
+        fake_settings.miniapp_base_url = (
+            "https://unluckily-appointee-siesta.ngrok-free.dev"
+        )
+        caplog.set_level(logging.WARNING, logger="backend.bot.setup_menu_button")
+        await setup_chat_menu_button("abc1234")
+        warning_msgs = [
+            r.getMessage() for r in caplog.records
+            if r.name == "backend.bot.setup_menu_button"
+            and r.levelno == logging.WARNING
+        ]
+        assert any("ngrok-free" in m for m in warning_msgs), (
+            f"expected ngrok-free warning, got: {warning_msgs}"
+        )
+        # Telegram is still called — registration is best-effort.
+        mock_telegram.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_warns_on_ngrok_free_app_host(
+        self, fake_settings, mock_telegram, caplog
+    ):
+        # ngrok migrated free domains from .dev to .app over time;
+        # both still serve the interstitial.
+        fake_settings.miniapp_base_url = "https://abc.ngrok-free.app"
+        caplog.set_level(logging.WARNING, logger="backend.bot.setup_menu_button")
+        await setup_chat_menu_button("abc1234")
+        warning_msgs = [
+            r.getMessage() for r in caplog.records
+            if r.name == "backend.bot.setup_menu_button"
+            and r.levelno == logging.WARNING
+        ]
+        assert any("ngrok-free" in m for m in warning_msgs)
+
+    @pytest.mark.asyncio
+    async def test_does_not_warn_on_safe_tunnel_hosts(
+        self, fake_settings, mock_telegram, caplog
+    ):
+        # Cloudflare quick-tunnels and named tunnels don't have an
+        # interstitial; the warning must not fire there or it'd
+        # cry-wolf operators into ignoring the real signal.
+        for safe_url in (
+            "https://random-words.trycloudflare.com",
+            "https://bot.nuitruc.ai",
+            "https://app.example.com",
+        ):
+            caplog.clear()
+            fake_settings.miniapp_base_url = safe_url
+            caplog.set_level(
+                logging.WARNING,
+                logger="backend.bot.setup_menu_button",
+            )
+            await setup_chat_menu_button("abc1234")
+            warning_msgs = [
+                r.getMessage() for r in caplog.records
+                if r.name == "backend.bot.setup_menu_button"
+                and r.levelno == logging.WARNING
+            ]
+            assert not any("ngrok-free" in m for m in warning_msgs), (
+                f"false-positive ngrok warning for {safe_url}: {warning_msgs}"
+            )
+
+
+class TestNgrokFreeDetection:
+    """Pin the hostname-matching contract used by the startup warning."""
+
+    @pytest.mark.parametrize("base_url", [
+        "https://abc.ngrok-free.dev",
+        "https://abc.ngrok-free.dev/",
+        "https://abc.ngrok-free.dev/miniapp/wealth",
+        "https://abc.ngrok-free.app",
+        "https://nested.subdomain.ngrok-free.dev",
+        "HTTPS://CAPITALIZED.NGROK-FREE.DEV",  # case-insensitive
+    ])
+    def test_detects_interstitial_hosts(self, base_url):
+        assert _is_ngrok_free_interstitial_host(base_url) is True
+
+    @pytest.mark.parametrize("base_url", [
+        # Safe tunnels / production hosts:
+        "https://app.example.com",
+        "https://random.trycloudflare.com",
+        "https://bot.nuitruc.ai",
+        # Substring traps — must NOT match in the middle of a host:
+        "https://ngrok-free.dev.evil.com",
+        "https://my-ngrok-free.dev-clone.com",
+        # Empty / invalid:
+        "",
+        "not-a-url",
+    ])
+    def test_does_not_flag_safe_hosts(self, base_url):
+        assert _is_ngrok_free_interstitial_host(base_url) is False


### PR DESCRIPTION
## Summary
- Make `setup_chat_menu_button` log an explicit ERROR (with URL + label) when Telegram rejects `setChatMenuButton` — previously the failure was silent and operators only discovered it when a user tapped the menu button and saw a blank panel.
- Promote the success log line from INFO to WARNING so it reaches the launchd-captured `backend.error.log` under uvicorn's default logging config (root logger has no INFO handler, so the existing success line was being dropped on the floor).
- Detect `*.ngrok-free.dev` / `*.ngrok-free.app` at startup and log a loud WARNING with the upgrade path. Telegram WebView always sends a `Mozilla`-prefixed User-Agent, and ngrok-free reliably serves its abuse interstitial (ERR_NGROK_6024) on that UA — there is no programmatic bypass, so this is a configuration smell we have to surface, not a problem we can fix at runtime.

## Why this matters

The bug pattern we kept hitting: someone switches the dev tunnel, taps the bot's menu button, and lands on a blank Mini App while inline-keyboard "Mở dashboard" buttons (from briefings, /menu) appear to work. Two ingredients made the failure invisible:

1. The Python `setup_chat_menu_button` was the source of truth for the menu URL but its `logger.info` lines never reached the file, and `send_telegram` returning None on a Telegram 4xx didn't trigger any additional log surface.
2. A separate `scripts/update-menu-button.sh` (local, untracked) hand-built `${BASE}/miniapp/wealth` without the `?b=<build_hash>` cache buster, overwriting Python's correct URL whenever someone ran it after a tunnel switch — making the next user tap hit a URL Telegram had cached from the previous deploy.

Investigation log: in `backend.error.log` we found:
```
Telegram API error: 400 {"ok":false,"error_code":400,"description":"Bad Request: BUTTON_URL_INVALID"}
```
fired from `send_telegram` at startup. The caller (`setup_chat_menu_button`) saw the None return and exited cleanly — no other signal. With this PR, that error line is followed by:
```
Chat menu button sync FAILED — Telegram rejected setChatMenuButton (text='💰 Tài sản' url=https://...wealth?b=abc1234). Users keep the previously-registered button URL until the next successful boot. ...
```

## What this does NOT fix

The ngrok-free interstitial is a tunnel-provider problem, not a code problem. The PR makes the misconfiguration loud at boot but does not silence it. To actually serve the Mini App via ngrok-free, the only options are: user manually clicks "Visit Site" once per WebView session (unreliable on mobile), or upgrade to a Cloudflare named tunnel / paid ngrok with custom domain. The accompanying tunnel switch on the dev machine is being tracked separately.

## Test plan
- [x] `uv run pytest backend/tests/test_setup_menu_button.py backend/tests/test_miniapp_wealth_routes.py` — 63 tests pass
- [x] New tests pin: ERROR log includes URL + label on failure, WARNING log on success, ngrok-free.dev/.app warn, safe hosts (trycloudflare, custom domains) do NOT warn, substring traps (`ngrok-free.dev.evil.com`) do NOT warn
- [ ] Operator verification: after merging + restarting backend, `backend.error.log` shows `Chat menu button synced: text='💰 Tài sản' url=...?b=<hash>` and `getChatMenuButton` returns the same URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)