### PR TITLE
fix(phase-4.3): post-release-5 Codex findings (admin metrics, edit asset, recompute)

### DIFF
--- a/backend/api/admin/twin_metrics.py
+++ b/backend/api/admin/twin_metrics.py
@@ -29,6 +29,10 @@ router = APIRouter(prefix="/twin-metrics", tags=["admin-twin-metrics"])
 CACHE_TTL_SECONDS = 15 * 60
 _RANGE_RE = r"^(7d|14d|30d|90d|custom)$"
 _SEGMENTS = {"starter", "young_pro", "mass_affluent", "hnw"}
+_ACTION_EVENT_KEYS = {
+    "action_suggestion.shown": "suggested",
+    "action_suggestion.complete": "completed",
+}
 
 
 def _admin_tenant_id(admin: AdminUser) -> int:
@@ -82,7 +86,7 @@ def _wealth_subquery():
             PortfolioAsset.user_id.label("user_id"),
             func.coalesce(func.sum(asset_value), 0).label("net_worth"),
         )
-        .where(PortfolioAsset.is_active.is_(True))
+        .where(PortfolioAsset.deleted_at.is_(None))
         .group_by(PortfolioAsset.user_id)
         .subquery()
     )
@@ -248,14 +252,16 @@ async def loop_health(
             .where(
                 Event.timestamp >= start,
                 Event.timestamp < end,
-                Event.event_type.in_(["twin_action_suggested", "twin_action_completed", "twin_return_after_action"]),
+                Event.event_type.in_(list(_ACTION_EVENT_KEYS.keys())),
                 *user_filter,
             )
             .group_by(func.date(Event.timestamp), Event.event_type)
         )).all()
         totals = Counter()
         for day, event_type, count in action_rows:
-            key = str(event_type).replace("twin_action_", "").replace("twin_", "")
+            key = _ACTION_EVENT_KEYS.get(str(event_type))
+            if not key:
+                continue
             day_counts[day][key] += int(count or 0)
             totals[key] += int(count or 0)
         trend = []
@@ -279,11 +285,9 @@ async def loop_health(
             select(TwinViewEvent.user_id).join(User, User.id == TwinViewEvent.user_id).outerjoin(wealth_sq, wealth_sq.c.user_id == User.id).where(TwinViewEvent.created_at >= start, TwinViewEvent.created_at < end, TwinViewEvent.event_type.in_(["story_opened", "screen_viewed"]), *user_filter)
         )).scalars().all())
         completed_users = set((await db.execute(
-            select(Event.user_id).join(User, User.id == Event.user_id).outerjoin(wealth_sq, wealth_sq.c.user_id == User.id).where(Event.timestamp >= start, Event.timestamp < end, Event.event_type == "twin_action_completed", *user_filter)
+            select(Event.user_id).join(User, User.id == Event.user_id).outerjoin(wealth_sq, wealth_sq.c.user_id == User.id).where(Event.timestamp >= start, Event.timestamp < end, Event.event_type == "action_suggestion.complete", *user_filter)
         )).scalars().all())
-        returned_users = set((await db.execute(
-            select(Event.user_id).join(User, User.id == Event.user_id).outerjoin(wealth_sq, wealth_sq.c.user_id == User.id).where(Event.timestamp >= start, Event.timestamp < end + timedelta(days=7), Event.event_type == "twin_return_after_action", *user_filter)
-        )).scalars().all())
+        returned_users: set = set()
         loop_closed = len(triggered_users & viewed_users & completed_users & returned_users)
         loop_rate = _pct(loop_closed, len(triggered_users))
         action_completion = _pct(totals["completed"], totals["suggested"])

--- a/backend/intent/handlers/action_edit_asset.py
+++ b/backend/intent/handlers/action_edit_asset.py
@@ -75,9 +75,17 @@ def _parse_quantity(text: str) -> Decimal | None:
     m = _QUANTITY_SUFFIX_RE.search(text)
     if not m:
         return None
-    raw = m.group("num").replace(",", "").replace(".", "")
-    if not raw.isdigit():
-        return None
+    raw = m.group("num")
+    if "," in raw and "." in raw:
+        # Mixed separators: treat the rightmost as decimal, the other as thousands.
+        if raw.rfind(",") > raw.rfind("."):
+            raw = raw.replace(".", "").replace(",", ".")
+        else:
+            raw = raw.replace(",", "")
+    else:
+        # Single (or no) separator: in VN inputs "," is the decimal mark; "."
+        # is also commonly used. Normalize either to a Decimal-friendly dot.
+        raw = raw.replace(",", ".")
     try:
         return Decimal(raw)
     except Exception:

--- a/backend/twin/services/on_demand_recompute.py
+++ b/backend/twin/services/on_demand_recompute.py
@@ -87,7 +87,12 @@ async def _debounced_process(user_id: uuid.UUID) -> None:
 
 async def process_pending(pending: PendingRecompute) -> TwinRecomputeLog | None:
     if pending.user_id in _locks:
+        # Another recompute is in flight. Re-queue and schedule a fresh debounce
+        # so we don't rely on a future event to drain `_pending`.
         _pending[pending.user_id] = pending
+        task = asyncio.create_task(_debounced_process(pending.user_id))
+        _tasks.add(task)
+        task.add_done_callback(_tasks.discard)
         return None
     _locks.add(pending.user_id)
     try:


### PR DESCRIPTION
## Summary

Codex flagged 1 P1 + 3 P2 issues against PR #699 (release 5 promotion). Release is on hold; these fix the underlying bugs in main first.

### P1 — `backend/api/admin/twin_metrics.py:85`
`_wealth_subquery` referenced `PortfolioAsset.is_active`, which the model does not define (only `deleted_at`). Every `/api/admin/twin-metrics/*` endpoint would raise `AttributeError` before executing SQL. Replaced with `PortfolioAsset.deleted_at.is_(None)` to match the model's soft-delete convention.

### P2 — `backend/api/admin/twin_metrics.py:251`
Loop Health query filtered for `twin_action_suggested` / `twin_action_completed` / `twin_return_after_action`, but the actual emitters (`twin_callback_handler.py`, `return_tease_service.py`) write `action_suggestion.shown` / `action_suggestion.complete` / `action_suggestion.dismissed`. The dashboard would always report zero suggestions/completions and misleading alerts. Switched to a `_ACTION_EVENT_KEYS` mapping over the real event names.

Note: `twin_return_after_action` has **no producer anywhere in the codebase**. Rather than keep a query that always returns 0 against a non-existent event, `returned_users` is now an empty set and `return_after_action_pct` stays at 0 until the emitter is wired (out of scope here — should be a separate Phase 4.3 follow-up).

### P2 — `backend/intent/handlers/action_edit_asset.py:68`
`_parse_quantity` stripped both `.` and `,` before parsing, so `0.5 BTC` became `5` and `1,5 chỉ` became `15` — a 10×/100× error on fractional crypto/gold inline edits. New logic:
- Mixed separators → rightmost is decimal, the other is thousands.
- Single separator → normalize `,` to `.` (vi-VN decimal comma) before `Decimal()`.

### P2 — `backend/twin/services/on_demand_recompute.py:90`
When `process_pending` ran while a prior recompute held the per-user lock, it re-queued the pending entry into `_pending` but did **not** schedule a new `_debounced_process` task. Subsequent events would merge into the existing `_pending[user_id]` entry and also skip scheduling, so the recompute could stay stuck indefinitely until something else drained `_pending`. Fix: schedule a fresh debounced task when re-queueing under lock.

## Test plan

- [ ] `uv run ruff check` clean (verified locally)
- [ ] Admin Twin dashboard endpoints respond 200 with wealth/cohort filters
- [ ] After a user taps a Twin action button, Loop Health `suggested` / `completed` counters increment
- [ ] Edit `0.5 BTC` / `1,5 chỉ` → asset row stores quantity `0.5` / `1.5`, recomputed `current_value` matches
- [ ] Trigger two rapid expense events on one user; observe second event still produces a recompute after the first releases the lock
- [ ] After this merges, refresh release branch `claude/merge-release-5-prod-VOXQH` from main and re-request review on #699

## Follow-up (out of scope)

- Wire a `twin_return_after_action` (or equivalent) emitter so the Loop Health return metric is meaningful.

https://claude.ai/code/session_019yZCGhfEVjdtCtQqY9Fjm2