### PR TITLE
Add i18n baseline and navigation fallback docs (Closes #NNN)

### DIFF
--- a/db-model.md
+++ b/db-model.md
@@ -1,0 +1,34 @@
+# Database Model
+
+The model must do three things well: move fast for prototype, keep permissions auditable, and scale without painful migrations.
+
+## Principles
+
+- Wiki is immutable snapshots; no in-place update.
+- JSONB for fast-changing payloads: message content, agent config, wiki content.
+- Add indexes only for real queries.
+- Locale-aware rendering data must be explicit (`language_code`, `date_format`, `timezone`) to avoid frontend guesswork.
+
+## Key improvements over old version
+
+```mermaid
+erDiagram
+```
+
+### `agent_runs`
+- `id`, `organization_id`, `user_id`, `status`, `period_start`, `period_end`, `input_token`, `output_token`, `error`, `result_version_id`, `run_at`, `created_at`
+- Index: `(organization_id, status, run_at DESC)`
+
+### `user_preferences` (for i18n foundation + UI consistency)
+- `id`, `organization_id`, `user_id`, `language_code`, `date_format`, `timezone`, `created_at`, `updated_at`
+- `date_format` is locale-driven token (example: `dd/MM/yyyy` for `vi-VN`, `MM/dd/yyyy` for `en-US`).
+- Unique: `(organization_id, user_id)`
+
+### `navigation_events` (for fallback telemetry + UX audit)
+- `id`, `organization_id`, `user_id`, `event_type`, `source_menu`, `target_menu`, `fallback_reason`, `metadata`, `created_at`
+- Event `event_type = menu_fallback` is emitted whenever route recovery is triggered.
+- Index: `(organization_id, event_type, created_at DESC)`
+
+### `access_grants`
+- `id`, `organization_id`, `grantor_user_id`, `grantee_user_id`, `resource_type`, `resource_id`, `action`, `expires_at`, `revoked_at`, `created_at`
+- Index: `(organization_id, grantee_user_id, resource_type, resource_id)` where `revoked_at is null`

--- a/strategy.md
+++ b/strategy.md
@@ -1,0 +1,21 @@
+# Strategy
+
+If not met: do not move to MVP.
+
+1. Keep target segment focus.
+2. Keep trust guardrails explicit.
+3. Observe weekly operating metrics:
+   - System: extraction success rate, P95 latency, cost per active user.
+4. **Add internal trust risk explicitly**:
+   - Founder access is also logged and visible to owners.
+5. **Add UI navigation + date consistency baseline**:
+   - In flow `Twin -> Lộ trình`, CTA `Quay về Twin` must always route to `Twin menu root`, never remain in `Lộ trình` stack.
+   - Any missing route or invalid state must fallback to `Twin menu root` and log telemetry (`fallback_reason`, `source_menu`, `target_menu`).
+   - All user-facing date rendering uses locale-driven format policy: `vi-VN => dd/MM/yyyy` as default baseline.
+
+## 6-week execution plan
+
+- Any decision deviating from docs must be updated within 24h.
+- Permission and pipeline changes require cross-review.
+- Instrument from day one: token, job status, deny/allow audits.
+- UI/UX consistency is mandatory: menu fallback, date format, and language behavior must be deterministic across all screens.


### PR DESCRIPTION
### Motivation
- Đảm bảo frontend không phải đoán ngôn ngữ/format: khai báo rõ `language_code`, `date_format`, `timezone` để đồng nhất hiển thị ngày/locale. 
- Ghi nhận fallback navigation và telemetry để tránh bị kẹt trong stack menu và có trace khi route recovery xảy ra.

### Description
- Thêm `db-model.md` mới với nguyên tắc i18n và hai schema mới: `user_preferences` (stores `language_code`, `date_format`, `timezone`) và `navigation_events` (captures `fallback_reason`, `source_menu`, `target_menu`).
- Thêm `strategy.md` mới với quy định bắt buộc cho fallback của flow `Twin -> Lộ trình` và baseline hiển thị ngày theo locale (`vi-VN => dd/MM/yyyy`).
- Commit message và PR body chứa `Closes #NNN` để tự động đóng issue khi merge.

### Testing
- No automated unit or integration tests were run for these docs changes.
- Repository operations and PR creation succeeded (`git add`/`git commit` and PR body created) without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0c317ffce4832f86137bddd6952f42)