### PR TITLE
Improve Twin mini-app suggestion contrast and remove build footer

### DIFF
--- a/backend/miniapp/routes.py
+++ b/backend/miniapp/routes.py
@@ -282,21 +282,8 @@ def _render_html_with_version(html_path: Path) -> str:
             bumped,
             count=1,
         )
-    # Inject a visible footer marker so users can read the running build
-    # straight from the dashboard — much faster than tailing server logs
-    # when verifying a deploy reached the VPS.
-    footer_html = (
-        '<div style="text-align:center;margin:18px 0 8px;font-size:11px;'
-        'opacity:0.45;letter-spacing:0.02em;font-family:system-ui,sans-serif;">'
-        f"build {_GIT_SHA} · assets {_STATIC_VERSION}"
-        "</div>"
-    )
     if _VERSION_MARKER_PATTERN.search(bumped):
-        bumped = _VERSION_MARKER_PATTERN.sub(lambda _m: footer_html, bumped, count=1)
-    else:
-        # Templates that haven't added the marker yet still get the footer
-        # right before </body> so the diagnostic is universal.
-        bumped = bumped.replace("</body>", footer_html + "\n</body>", 1)
+        bumped = _VERSION_MARKER_PATTERN.sub("", bumped, count=1)
     return bumped
 
 

--- a/backend/miniapp/static/css/twin.css
+++ b/backend/miniapp/static/css/twin.css
@@ -55,7 +55,7 @@
 .delta-badge-pill { padding: 3px 8px; border-radius: 999px; font-size: 12px; font-weight: 700; white-space: nowrap; }
 .delta-badge-pill.positive { background: rgba(20,184,166,.22); color: #0f766e; }
 .delta-badge-pill.negative { background: rgba(239,68,68,.12); color: #dc2626; }
-.savings-cta { margin-top: 10px; font-size: 14px; font-weight: 800; color: #7c2d12; line-height: 1.45; background: linear-gradient(135deg, rgba(251,146,60,.18), rgba(245,158,11,.24)); border: 1px solid rgba(217,119,6,.45); border-radius: 12px; padding: 10px 12px; box-shadow: inset 0 1px 0 rgba(255,255,255,.35); }
+.savings-cta { margin-top: 10px; font-size: 14px; font-weight: 800; color: #fff; line-height: 1.45; background: linear-gradient(135deg, rgba(251,146,60,.18), rgba(245,158,11,.24)); border: 1px solid rgba(217,119,6,.45); border-radius: 12px; padding: 10px 12px; box-shadow: inset 0 1px 0 rgba(255,255,255,.35); }
 
 
 


### PR DESCRIPTION
### Motivation
- Tăng khả năng đọc của dòng suggestion trong thẻ `So sánh Hiện tại vs Tối ưu` vì chữ hiện tại không đủ tương phản. 
- Loại bỏ dòng debug `build ... · assets ...` ở cuối Mini app để giao diện sạch và tập trung cho người dùng.

### Description
- Đổi màu chữ của phần suggestion bằng cách cập nhật `.savings-cta` sang `color: #fff` trong `backend/miniapp/static/css/twin.css` để cải thiện tương phản. 
- Bỏ chèn footer build/assets trong hàm render HTML bằng cách không thay thế marker `<!-- APP_VERSION_MARKER -->` (ở `backend/miniapp/routes.py`) nên dòng debug sẽ không hiển thị nữa. 
- Commit message bao gồm `Closes #NNN` như yêu cầu.

### Testing
- Chạy `pytest -q backend/tests/test_twin_miniapp_static.py` và tất cả tests đã pass (`5 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d2fb65728832f83cf75e51a0632eb)