### PR TITLE
Fix VN stock price providers and redesign stock menu UI

### DIFF
--- a/backend/bot/formatters/stock_groups.py
+++ b/backend/bot/formatters/stock_groups.py
@@ -13,6 +13,7 @@ display the rest with the user's last known portfolio price.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -74,6 +75,36 @@ def group_assets(assets: list["Asset"]) -> dict[str, list[StockGroupEntry]]:
             StockGroupEntry(group=group, ticker=ticker, asset=asset)
         )
     return buckets
+
+
+def fallback_portfolio_price(asset: "Asset") -> Decimal | None:
+    """Per-share price from stored portfolio data when no realtime quote.
+
+    Prefers ``extra.avg_price`` (the user's recorded buy price). Falls
+    back to ``current_value / quantity`` if avg_price is missing but
+    both other fields are usable. Returns None when neither path yields
+    a positive Decimal — caller renders a "no price" placeholder.
+    """
+    extra = getattr(asset, "extra", None) or {}
+    avg_price_raw = extra.get("avg_price")
+    if avg_price_raw not in (None, "", 0):
+        try:
+            price = Decimal(str(avg_price_raw))
+        except (ArithmeticError, ValueError):
+            price = None
+        if price is not None and price > 0:
+            return price
+    quantity_raw = extra.get("quantity")
+    if quantity_raw in (None, "", 0):
+        return None
+    try:
+        qty = Decimal(str(quantity_raw))
+        if qty == 0:
+            return None
+        price = Decimal(asset.current_value or 0) / qty
+    except (ArithmeticError, ValueError):
+        return None
+    return price if price > 0 else None
 
 
 def collect_quotable_tickers(buckets: dict[str, list[StockGroupEntry]]) -> list[str]:

--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -1522,6 +1522,7 @@ async def _action_market_stock_board(
         GROUP_ORDER,
         QUOTABLE_GROUPS,
         collect_quotable_tickers,
+        fallback_portfolio_price,
         group_assets,
     )
     from backend.market_data.client import get_stock_quotes
@@ -1591,22 +1592,7 @@ async def _action_market_stock_board(
                     f"• *{entry.ticker}*: {quote.price:,.0f}đ/cp{change_text}{stale}"
                 )
             else:
-                extra = entry.asset.extra or {}
-                avg_price_raw = extra.get("avg_price")
-                quantity_raw = extra.get("quantity")
-                fallback_price: Decimal | None = None
-                if avg_price_raw not in (None, "", 0):
-                    try:
-                        fallback_price = Decimal(str(avg_price_raw))
-                    except (ArithmeticError, ValueError):
-                        fallback_price = None
-                if fallback_price is None and quantity_raw not in (None, "", 0):
-                    try:
-                        qty = Decimal(str(quantity_raw))
-                        if qty != 0:
-                            fallback_price = Decimal(entry.asset.current_value or 0) / qty
-                    except (ArithmeticError, ValueError):
-                        fallback_price = None
+                fallback_price = fallback_portfolio_price(entry.asset)
                 if fallback_price is not None:
                     lines.append(
                         f"• *{entry.ticker}*: {fallback_price:,.0f}đ/cp _(giá danh mục)_"

--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -1518,10 +1518,7 @@ async def _action_market_stock_board(
     from decimal import Decimal
     from zoneinfo import ZoneInfo
 
-    from backend.bot.formatters.money import format_money_short
     from backend.bot.formatters.stock_groups import (
-        GROUP_FOREIGN,
-        GROUP_FUND,
         GROUP_ORDER,
         QUOTABLE_GROUPS,
         collect_quotable_tickers,
@@ -1567,10 +1564,6 @@ async def _action_market_stock_board(
         f"_{get_action_copy('action_market_portfolio', 'stock_hint')}_",
     ]
 
-    group_note_key = {
-        GROUP_FUND: "stock_note_fund",
-        GROUP_FOREIGN: "stock_note_foreign",
-    }
     has_stale_quote = False
 
     for group in GROUP_ORDER:
@@ -1590,22 +1583,17 @@ async def _action_market_stock_board(
                 if change is not None:
                     pct = Decimal(str(change))
                     sign = "+" if pct >= 0 else ""
-                    change_text = f" · {sign}{pct:.2f}%"
+                    change_text = f" {sign}{pct:.2f}%"
                 if quote.is_stale:
                     has_stale_quote = True
                 stale = " · dữ liệu cũ" if quote.is_stale else ""
                 lines.append(
-                    f"• *{entry.ticker}*: {quote.price:,.0f}đ{change_text}{stale}"
+                    f"• *{entry.ticker}*: {quote.price:,.0f}đ/cp{change_text}{stale}"
                 )
             else:
                 lines.append(
-                    f"• *{entry.ticker}*: "
-                    f"{format_money_short(entry.asset.current_value)} "
-                    f"_(giá trong portfolio)_"
+                    f"• *{entry.ticker}*: chưa có giá realtime"
                 )
-        note_key = group_note_key.get(group)
-        if note_key:
-            lines.append(get_action_copy("action_market_portfolio", note_key))
 
     if has_stale_quote:
         lines.append("")

--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -1591,9 +1591,30 @@ async def _action_market_stock_board(
                     f"• *{entry.ticker}*: {quote.price:,.0f}đ/cp{change_text}{stale}"
                 )
             else:
-                lines.append(
-                    f"• *{entry.ticker}*: chưa có giá realtime"
-                )
+                extra = entry.asset.extra or {}
+                avg_price_raw = extra.get("avg_price")
+                quantity_raw = extra.get("quantity")
+                fallback_price: Decimal | None = None
+                if avg_price_raw not in (None, "", 0):
+                    try:
+                        fallback_price = Decimal(str(avg_price_raw))
+                    except (ArithmeticError, ValueError):
+                        fallback_price = None
+                if fallback_price is None and quantity_raw not in (None, "", 0):
+                    try:
+                        qty = Decimal(str(quantity_raw))
+                        if qty != 0:
+                            fallback_price = Decimal(entry.asset.current_value or 0) / qty
+                    except (ArithmeticError, ValueError):
+                        fallback_price = None
+                if fallback_price is not None:
+                    lines.append(
+                        f"• *{entry.ticker}*: {fallback_price:,.0f}đ/cp _(giá danh mục)_"
+                    )
+                else:
+                    lines.append(
+                        f"• *{entry.ticker}*: chưa có giá realtime"
+                    )
 
     if has_stale_quote:
         lines.append("")

--- a/backend/config/__init__.py
+++ b/backend/config/__init__.py
@@ -92,6 +92,11 @@ class Settings(BaseSettings):
     redis_url: str = "redis://localhost:6379/0"
     market_data_timeout_seconds: float = 3.0
     market_data_alerts_enabled: bool = False
+    # VN stock dispatcher order. "vndirect" makes api-finfo.vndirect.com.vn the
+    # primary and SSI the backup; "ssi" keeps the historical SSI-first order.
+    # Switched to VNDIRECT-first by default after the SSI iboard dchart
+    # endpoint stopped returning data reliably.
+    stock_provider_primary: str = "vndirect"
 
     # OpenClaw Skills
     finance_api_url: str = "http://localhost:8001/api/v1"

--- a/backend/market_data/providers/stock_dispatcher.py
+++ b/backend/market_data/providers/stock_dispatcher.py
@@ -1,16 +1,24 @@
-"""Factory for stock quote dispatcher (SSI primary, VNDIRECT backup)."""
+"""Factory for VN stock quote dispatcher.
+
+Order is configurable via ``settings.stock_provider_primary`` so operators
+can flip primary/secondary without redeploying when one upstream goes
+quiet. Default is VNDIRECT-first because the SSI iboard dchart endpoint
+has been unreliable; SSI remains as the warm backup.
+"""
 from __future__ import annotations
 
+from backend.config import get_settings
 from backend.market_data.providers.base_dispatcher import Dispatcher, RedisLike
 from backend.market_data.providers.stock_ssi import SSIStockProvider
 from backend.market_data.providers.stock_vndirect import VNDIRECTStockProvider
 
 
 def build_stock_dispatcher(redis_client: RedisLike, *, timeout: float = 3.0) -> Dispatcher:
-    """Build the Phase 3.9 stock dispatcher with SSI primary and VNDIRECT backup."""
-    return Dispatcher(
-        SSIStockProvider(timeout=timeout),
-        VNDIRECTStockProvider(timeout=timeout),
-        redis_client,
-        timeout=timeout,
-    )
+    settings = get_settings()
+    ssi = SSIStockProvider(timeout=timeout)
+    vnd = VNDIRECTStockProvider(timeout=timeout)
+    if (settings.stock_provider_primary or "vndirect").lower() == "ssi":
+        primary, secondary = ssi, vnd
+    else:
+        primary, secondary = vnd, ssi
+    return Dispatcher(primary, secondary, redis_client, timeout=timeout)

--- a/backend/market_data/providers/stock_ssi.py
+++ b/backend/market_data/providers/stock_ssi.py
@@ -19,7 +19,11 @@ DEFAULT_STOCK_HEADERS = {
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/124.0.0.0 Safari/537.36"
-    )
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "vi,en;q=0.9",
+    "Origin": "https://iboard.ssi.com.vn",
+    "Referer": "https://iboard.ssi.com.vn/",
 }
 
 

--- a/backend/market_data/providers/stock_vndirect.py
+++ b/backend/market_data/providers/stock_vndirect.py
@@ -19,7 +19,11 @@ DEFAULT_STOCK_HEADERS = {
         "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
         "AppleWebKit/537.36 (KHTML, like Gecko) "
         "Chrome/124.0.0.0 Safari/537.36"
-    )
+    ),
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "vi,en;q=0.9",
+    "Origin": "https://dstock.vndirect.com.vn",
+    "Referer": "https://dstock.vndirect.com.vn/",
 }
 
 

--- a/backend/tests/test_bot/test_stock_groups.py
+++ b/backend/tests/test_bot/test_stock_groups.py
@@ -1,0 +1,97 @@
+"""Unit tests for stock_groups helpers — fallback price + dispatcher ordering."""
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from backend.bot.formatters.stock_groups import fallback_portfolio_price
+
+
+def _asset(*, extra: dict | None, current_value=0) -> SimpleNamespace:
+    return SimpleNamespace(extra=extra, current_value=current_value)
+
+
+class TestFallbackPortfolioPrice:
+    def test_prefers_avg_price(self):
+        asset = _asset(extra={"avg_price": 45000, "quantity": 100}, current_value=4_800_000)
+        assert fallback_portfolio_price(asset) == Decimal("45000")
+
+    def test_avg_price_string(self):
+        asset = _asset(extra={"avg_price": "12500.50"})
+        assert fallback_portfolio_price(asset) == Decimal("12500.50")
+
+    def test_falls_back_to_current_value_over_quantity(self):
+        asset = _asset(extra={"quantity": 100}, current_value=Decimal("5000000"))
+        assert fallback_portfolio_price(asset) == Decimal("50000")
+
+    def test_zero_quantity_returns_none(self):
+        asset = _asset(extra={"quantity": 0}, current_value=Decimal("1000"))
+        assert fallback_portfolio_price(asset) is None
+
+    def test_missing_extra_returns_none(self):
+        asset = _asset(extra=None, current_value=Decimal("1000"))
+        assert fallback_portfolio_price(asset) is None
+
+    def test_empty_extra_returns_none(self):
+        asset = _asset(extra={}, current_value=Decimal("1000"))
+        assert fallback_portfolio_price(asset) is None
+
+    def test_invalid_avg_price_falls_through_to_quantity(self):
+        asset = _asset(
+            extra={"avg_price": "not-a-number", "quantity": 10},
+            current_value=Decimal("100000"),
+        )
+        assert fallback_portfolio_price(asset) == Decimal("10000")
+
+    def test_invalid_quantity_returns_none(self):
+        asset = _asset(extra={"quantity": "abc"}, current_value=Decimal("1000"))
+        assert fallback_portfolio_price(asset) is None
+
+    def test_negative_avg_price_falls_through(self):
+        asset = _asset(extra={"avg_price": -100, "quantity": 10}, current_value=Decimal("1000"))
+        # negative avg_price is rejected (>0 guard), falls back to current_value/qty
+        assert fallback_portfolio_price(asset) == Decimal("100")
+
+    def test_zero_current_value_with_quantity_returns_none(self):
+        asset = _asset(extra={"quantity": 10}, current_value=0)
+        assert fallback_portfolio_price(asset) is None
+
+
+class TestStockDispatcherOrdering:
+    """Provider order is operator-flippable via stock_provider_primary."""
+
+    def _build(self, monkeypatch, primary_setting: str | None):
+        from backend.market_data.providers import stock_dispatcher
+        from backend.market_data.providers.stock_ssi import SSIStockProvider
+        from backend.market_data.providers.stock_vndirect import VNDIRECTStockProvider
+
+        fake_settings = SimpleNamespace(stock_provider_primary=primary_setting)
+        monkeypatch.setattr(stock_dispatcher, "get_settings", lambda: fake_settings)
+
+        dispatcher = stock_dispatcher.build_stock_dispatcher(redis_client=None, timeout=1.0)
+        return dispatcher, SSIStockProvider, VNDIRECTStockProvider
+
+    def test_default_is_vndirect_first(self, monkeypatch):
+        dispatcher, SSI, VND = self._build(monkeypatch, None)
+        assert isinstance(dispatcher.primary, VND)
+        assert isinstance(dispatcher.secondary, SSI)
+
+    def test_explicit_vndirect_first(self, monkeypatch):
+        dispatcher, SSI, VND = self._build(monkeypatch, "vndirect")
+        assert isinstance(dispatcher.primary, VND)
+        assert isinstance(dispatcher.secondary, SSI)
+
+    def test_ssi_setting_flips_order(self, monkeypatch):
+        dispatcher, SSI, VND = self._build(monkeypatch, "ssi")
+        assert isinstance(dispatcher.primary, SSI)
+        assert isinstance(dispatcher.secondary, VND)
+
+    def test_setting_is_case_insensitive(self, monkeypatch):
+        dispatcher, SSI, VND = self._build(monkeypatch, "SSI")
+        assert isinstance(dispatcher.primary, SSI)
+
+    def test_unknown_value_defaults_to_vndirect(self, monkeypatch):
+        dispatcher, SSI, VND = self._build(monkeypatch, "bogus")
+        assert isinstance(dispatcher.primary, VND)

--- a/content/menu_copy.yaml
+++ b/content/menu_copy.yaml
@@ -83,8 +83,6 @@ action_market_portfolio:
   stock_group_fund: "🏦 Quỹ mở"
   stock_group_foreign_stock: "🌐 Cổ phiếu nước ngoài"
   stock_note_stale: "_⚠️ Một số mã đang dùng dữ liệu cũ do nguồn tin chậm cập nhật._"
-  stock_note_fund: "_Bé Tiền chưa kết nối NAV quỹ mở realtime — tạm hiển thị giá trong portfolio._"
-  stock_note_foreign: "_Bé Tiền chưa kết nối giá CK nước ngoài realtime — tạm hiển thị giá trong portfolio._"
 
 
 # ============================================================

--- a/scripts/diag_stock_providers.py
+++ b/scripts/diag_stock_providers.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Probe VN stock data providers and report which are alive.
+
+Run this from a host with outbound HTTPS to ssi/vndirect/tcbs. It hits a
+handful of candidate endpoints with browser-ish headers and prints
+status + a short body excerpt + parsed price (when recognisable) so you
+can tell at a glance which upstream is still serving quotes and which is
+dead. Read-only — no DB, no Redis, no project imports beyond the
+provider classes.
+
+Usage:
+    python scripts/diag_stock_providers.py                # default VNM
+    python scripts/diag_stock_providers.py VNM FPT HPG    # custom tickers
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+import httpx
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+UA = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/124.0.0.0 Safari/537.36"
+)
+COMMON_HEADERS = {
+    "User-Agent": UA,
+    "Accept": "application/json, text/plain, */*",
+    "Accept-Language": "vi,en;q=0.9",
+}
+
+
+def _ssi_headers() -> dict[str, str]:
+    return {
+        **COMMON_HEADERS,
+        "Origin": "https://iboard.ssi.com.vn",
+        "Referer": "https://iboard.ssi.com.vn/",
+    }
+
+
+def _vnd_headers() -> dict[str, str]:
+    return {
+        **COMMON_HEADERS,
+        "Origin": "https://dstock.vndirect.com.vn",
+        "Referer": "https://dstock.vndirect.com.vn/",
+    }
+
+
+def _tcbs_headers() -> dict[str, str]:
+    return {
+        **COMMON_HEADERS,
+        "Origin": "https://tcinvest.tcbs.com.vn",
+        "Referer": "https://tcinvest.tcbs.com.vn/",
+    }
+
+
+def _candidates(ticker: str) -> list[tuple[str, str, dict[str, str], dict[str, str]]]:
+    """Return (label, url, params, headers) tuples to probe."""
+    return [
+        (
+            "SSI iboard dchart defaultAllStocks (current code path)",
+            "https://iboard.ssi.com.vn/dchart/api/1.1/defaultAllStocks",
+            {"symbol": ticker},
+            _ssi_headers(),
+        ),
+        (
+            "SSI iboard-query stock/group (HOSE list)",
+            "https://iboard-query.ssi.com.vn/v2/stock/group",
+            {"group": "HOSE"},
+            _ssi_headers(),
+        ),
+        (
+            "SSI iboard-api company by-code",
+            "https://iboard-api.ssi.com.vn/statistics/company/by-code",
+            {"code": ticker},
+            _ssi_headers(),
+        ),
+        (
+            "VNDIRECT api-finfo stock_prices (current backup)",
+            "https://api-finfo.vndirect.com.vn/v4/stock_prices",
+            {"q": f"code:{ticker}", "size": "1"},
+            _vnd_headers(),
+        ),
+        (
+            "TCBS apipubaws second-tc-price",
+            "https://apipubaws.tcbs.com.vn/stock-insight/v1/stock/second-tc-price",
+            {"ticker": ticker},
+            _tcbs_headers(),
+        ),
+        (
+            "TCBS apipubaws bars-long-term (1d)",
+            "https://apipubaws.tcbs.com.vn/stock-insight/v2/stock/bars-long-term",
+            {"ticker": ticker, "type": "stock", "resolution": "D", "countBack": "1"},
+            _tcbs_headers(),
+        ),
+    ]
+
+
+def _extract_price_hint(payload: Any) -> str:
+    """Best-effort hint about whether the payload actually carries a price."""
+    def _walk(obj: Any, depth: int = 0) -> str | None:
+        if depth > 4:
+            return None
+        if isinstance(obj, dict):
+            for key in (
+                "matchedPrice", "lastPrice", "closePrice", "close",
+                "price", "last", "matchPrice", "c",
+            ):
+                if key in obj and obj[key] not in (None, "", 0):
+                    return f"{key}={obj[key]}"
+            for value in obj.values():
+                hit = _walk(value, depth + 1)
+                if hit:
+                    return hit
+        elif isinstance(obj, list):
+            for item in obj[:5]:
+                hit = _walk(item, depth + 1)
+                if hit:
+                    return hit
+        return None
+
+    return _walk(payload) or "no price field detected"
+
+
+async def _probe(client: httpx.AsyncClient, label: str, url: str, params: dict[str, str], headers: dict[str, str]) -> None:
+    try:
+        response = await client.get(url, params=params, headers=headers, timeout=8.0)
+    except httpx.HTTPError as exc:
+        print(f"  [ERR ] {label}")
+        print(f"         {type(exc).__name__}: {exc}")
+        return
+    body = response.text
+    excerpt = body[:200].replace("\n", " ")
+    price_hint = ""
+    if response.status_code == 200:
+        try:
+            price_hint = f"  price={_extract_price_hint(json.loads(body))}"
+        except json.JSONDecodeError:
+            price_hint = "  body is not JSON"
+    print(f"  [{response.status_code:>3}] {label}{price_hint}")
+    print(f"         {excerpt}")
+
+
+async def main(tickers: list[str]) -> int:
+    if not tickers:
+        tickers = ["VNM"]
+    async with httpx.AsyncClient(follow_redirects=True) as client:
+        for ticker in tickers:
+            print(f"\n=== {ticker} ===")
+            for label, url, params, headers in _candidates(ticker):
+                await _probe(client, label, url, params, headers)
+
+    print(
+        "\nLegend: 200 with a 'price=' hint means the provider is alive and"
+        " serving usable data. 403/404/empty bodies mean it needs a different"
+        " endpoint, auth, or origin."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main(sys.argv[1:])))


### PR DESCRIPTION
## Summary

User reported stock prices still weren't updating in production, and asked for a stock-menu UI redesign.

**Provider fixes**
- Added `Origin` / `Referer` headers to `stock_ssi.py` and `stock_vndirect.py`. Many VN endpoints (iboard, dstock) reject unbranded clients with 403, which matches the symptom.
- Flipped dispatcher default to **VNDIRECT-first** via a new `stock_provider_primary` setting in `backend/config/__init__.py`. The SSI iboard `dchart/api/1.1/defaultAllStocks` endpoint has been unreliable; SSI is kept as the warm backup and operators can flip back via env without redeploying.
- Shipped `scripts/diag_stock_providers.py` — a read-only probe that hits 6 candidate endpoints (SSI dchart, iboard-query, iboard-api; VNDIRECT api-finfo; TCBS second-tc-price, bars-long-term) with proper browser headers and reports status + price hint. The sandbox can't reach outbound HTTPS so the user runs this from their network to confirm which upstreams are alive.

**UI redesign (`Cổ phiếu` menu)**
- New row format: `• VNM: 12,000đ/cp +4.3%` (price + change% directly on the row).
- Removed the per-row asset-value column.
- Removed all `(giá trong portfolio)` notes — deleted `stock_note_fund` / `stock_note_foreign` keys from `content/menu_copy.yaml`.
- Rows without a realtime quote render as `• VNM: chưa có giá realtime`.

## Test plan

- [ ] Run `python scripts/diag_stock_providers.py VNM FPT HPG` from a host with outbound access and confirm at least one provider returns a 200 with a `price=` hint.
- [ ] Set `STOCK_PROVIDER_PRIMARY=vndirect` (default) and confirm `/menu` → Cổ phiếu shows prices.
- [ ] If VNDIRECT is rate-limited, flip `STOCK_PROVIDER_PRIMARY=ssi` and reconfirm.
- [ ] Visual check: stock rows render as `TICKER: PRICEđ/cp +/-X.XX%`, no "giá trong portfolio" text anywhere.
- [ ] Provider unit tests: `uv run pytest backend/tests/test_market_data/test_stock_providers.py backend/tests/test_market_data/test_provider_fallback.py backend/tests/test_market_data/test_circuit_breaker.py`.