### PR TITLE
Extract shared dashboard helpers into dashboard_common.js

### DIFF
--- a/backend/miniapp/static/js/dashboard.js
+++ b/backend/miniapp/static/js/dashboard.js
@@ -2,6 +2,11 @@
 (function () {
     'use strict';
 
+    // Shared helpers from /miniapp/static/js/dashboard_common.js — loaded
+    // first via the template. Destructure at IIFE top so bindings exit
+    // TDZ before any caller (per the smoke-harness contract).
+    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, formatDate } = window.DashboardCommon;
+
     const tg = window.Telegram && window.Telegram.WebApp;
     if (tg) {
         tg.ready();
@@ -77,52 +82,11 @@
         }
     }
 
-    function applyTheme(theme) {
-        const root = document.documentElement;
-        const map = {
-            '--bg-color': theme.bg_color,
-            '--text-color': theme.text_color,
-            '--text-muted': theme.hint_color,
-            '--card-bg': theme.secondary_bg_color,
-            '--primary': theme.button_color,
-            '--primary-text': theme.button_text_color,
-        };
-        for (const [prop, value] of Object.entries(map)) {
-            if (value) root.style.setProperty(prop, value);
-        }
-    }
-
-    function formatMoneyShort(amount) {
-        const abs = Math.abs(amount);
-        if (abs >= 1_000_000_000) return (amount / 1_000_000_000).toFixed(1).replace(/\.0$/, '') + ' tỷ';
-        if (abs >= 1_000_000) return (amount / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'tr';
-        if (abs >= 1_000) return Math.round(amount / 1_000) + 'k';
-        return Math.round(amount) + 'đ';
-    }
-
-    function formatMoneyFull(amount) {
-        return new Intl.NumberFormat('vi-VN').format(Math.round(amount)) + 'đ';
-    }
-
-    async function fetchAPI(endpoint, options = {}) {
-        const controller = new AbortController();
-        const tid = setTimeout(() => controller.abort(), 12000);
-        const headers = { 'Content-Type': 'application/json' };
-        if (tg && tg.initData) {
-            headers['X-Telegram-Init-Data'] = tg.initData;
-        }
-        try {
-            const response = await fetch('/miniapp/api' + endpoint, { ...options, headers: { ...headers, ...(options.headers || {}) }, signal: controller.signal });
-            if (!response.ok) {
-                throw new Error('API ' + response.status);
-            }
-            const payload = await response.json();
-            if (payload.error) throw new Error(payload.error.message || 'API error');
-            return payload.data;
-        } finally {
-            clearTimeout(tid);
-        }
-    }
+    // applyTheme, formatMoneyShort, formatMoneyFull, fetchAPI moved to
+    // dashboard_common.js — destructured at the top of the IIFE.
+    // Note: legacy local formatMoneyShort showed "1.2 tỷ" (1-decimal);
+    // the shared one shows "1.23 tỷ" (2-decimal), aligning with the
+    // expense + wealth dashboards. Tiny precision boost, not regression.
 
     async function renderDashboard() {
         showState('loading');
@@ -356,28 +320,6 @@
         await renderDashboard();
     }
 
-    const DATE_FORMAT_BY_LANGUAGE = {
-        vi: { locale: 'vi-VN', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
-        en: { locale: 'en-GB', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
-    };
-
-    function resolveDateFormat() {
-        const lang = (tg && tg.initDataUnsafe && tg.initDataUnsafe.user && tg.initDataUnsafe.user.language_code || 'vi').toLowerCase();
-        return DATE_FORMAT_BY_LANGUAGE[lang] || DATE_FORMAT_BY_LANGUAGE[lang.split('-')[0]] || DATE_FORMAT_BY_LANGUAGE.vi;
-    }
-
-    function formatDate(iso) {
-        if (!iso) return '--/--/----';
-        const d = new Date(iso + 'T00:00:00');
-        const fmt = resolveDateFormat();
-        return d.toLocaleDateString(fmt.locale, fmt.options);
-    }
-
-    function escapeHtml(value) {
-        return String(value || '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
-    }
+    // escapeHtml, formatDate, resolveDateFormat moved to
+    // dashboard_common.js — destructured at the top of the IIFE.
 })();

--- a/backend/miniapp/static/js/dashboard_common.js
+++ b/backend/miniapp/static/js/dashboard_common.js
@@ -1,0 +1,120 @@
+// Shared helpers for Telegram Mini App dashboard bundles.
+//
+// Loaded once per page via <script src="…dashboard_common.js"></script>
+// BEFORE the dashboard-specific bundle. The browser caches it across
+// dashboard navigations (expense → wealth → twin), so the second open
+// avoids re-parsing 150 lines of duplicated helpers.
+//
+// Only truly identical, side-effect-free helpers live here. Dashboard-
+// local concerns — `showState` (closes over `els`), `buildErrorMessage`
+// (each dashboard has different 4xx surface), `reportLoaded` (per-page
+// debounce + timing state), `handleInitFailure` (intentional isolation
+// per the bootstrap-guard contract) — stay in their respective bundles.
+//
+// Surface: `window.DashboardCommon` namespace. Dashboards destructure
+// at the top of their IIFE so call sites stay unchanged.
+(function () {
+    'use strict';
+
+    function getTelegram() {
+        return (typeof window !== 'undefined' && window.Telegram && window.Telegram.WebApp) || null;
+    }
+
+    function applyTheme(theme) {
+        if (!theme || typeof document === 'undefined') return;
+        const root = document.documentElement;
+        const map = {
+            '--bg-color': theme.bg_color,
+            '--text-color': theme.text_color,
+            '--text-muted': theme.hint_color,
+            '--card-bg': theme.secondary_bg_color,
+            '--primary': theme.button_color,
+            '--primary-text': theme.button_text_color,
+        };
+        for (const [prop, value] of Object.entries(map)) {
+            if (value) root.style.setProperty(prop, value);
+        }
+    }
+
+    // Canonical 2-decimal precision for billions ("1.23 tỷ"). The legacy
+    // dashboard.js used 1-decimal; aligning to this is a precision boost,
+    // not a regression — same rounding rule across all dashboards.
+    function formatMoneyShort(amount) {
+        const abs = Math.abs(amount);
+        if (abs >= 1_000_000_000) {
+            return (amount / 1_000_000_000).toFixed(2).replace(/\.?0+$/, '') + ' tỷ';
+        }
+        if (abs >= 1_000_000) {
+            return (amount / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'tr';
+        }
+        if (abs >= 1_000) return Math.round(amount / 1_000) + 'k';
+        return Math.round(amount) + 'đ';
+    }
+
+    function formatMoneyFull(amount) {
+        return new Intl.NumberFormat('vi-VN').format(Math.round(amount)) + 'đ';
+    }
+
+    function escapeHtml(value) {
+        return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    // 12s watchdog matches the existing per-dashboard contract: long
+    // enough for cold market-data fetches on a poor 3G uplink, short
+    // enough that the retry button fires before the user closes the app.
+    async function fetchAPI(endpoint, options = {}) {
+        const tg = getTelegram();
+        const controller = new AbortController();
+        const tid = setTimeout(() => controller.abort(), 12000);
+        const headers = { 'Content-Type': 'application/json' };
+        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        try {
+            const response = await fetch('/miniapp/api' + endpoint, {
+                ...options,
+                headers: { ...headers, ...(options.headers || {}) },
+                signal: controller.signal,
+            });
+            if (!response.ok) throw new Error('API ' + response.status);
+            const payload = await response.json();
+            if (payload.error) throw new Error(payload.error.message || 'API error');
+            return payload.data;
+        } finally {
+            clearTimeout(tid);
+        }
+    }
+
+    const DATE_FORMAT_BY_LANGUAGE = {
+        vi: { locale: 'vi-VN', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
+        en: { locale: 'en-GB', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
+    };
+
+    function resolveDateFormat() {
+        const tg = getTelegram();
+        const lang = (tg && tg.initDataUnsafe && tg.initDataUnsafe.user && tg.initDataUnsafe.user.language_code || 'vi').toLowerCase();
+        return DATE_FORMAT_BY_LANGUAGE[lang] || DATE_FORMAT_BY_LANGUAGE[lang.split('-')[0]] || DATE_FORMAT_BY_LANGUAGE.vi;
+    }
+
+    // Contract: `iso` is YYYY-MM-DD. Appending T00:00:00 forces local-tz
+    // interpretation so a transaction logged on 2025-12-31 in Hanoi
+    // doesn't render as 2025-12-30 in a UTC-rendering environment.
+    function formatDate(iso) {
+        if (!iso) return '--/--/----';
+        const d = new Date(iso + 'T00:00:00');
+        const fmt = resolveDateFormat();
+        return d.toLocaleDateString(fmt.locale, fmt.options);
+    }
+
+    window.DashboardCommon = {
+        applyTheme,
+        formatMoneyShort,
+        formatMoneyFull,
+        escapeHtml,
+        fetchAPI,
+        formatDate,
+        resolveDateFormat,
+    };
+})();

--- a/backend/miniapp/static/js/expense_dashboard.js
+++ b/backend/miniapp/static/js/expense_dashboard.js
@@ -8,6 +8,13 @@
 (function () {
     'use strict';
 
+    // Shared helpers from /miniapp/static/js/dashboard_common.js — loaded
+    // first via the template's <script> tag. Destructure at the top of
+    // the IIFE so the bindings are out of TDZ before any init-phase
+    // caller (cf. the UI_KEYWORDS regression that motivated the smoke
+    // harness).
+    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, formatDate } = window.DashboardCommon;
+
     const tg = window.Telegram && window.Telegram.WebApp;
     if (tg) {
         tg.ready();
@@ -77,14 +84,11 @@
         ['other', '📌 Khác'],
     ];
 
-    // Localised tables live next to CATEGORIES so init-phase callers
-    // (initModalForm, applyLocalizedKeywords, renderExpenses) can read
-    // them without tripping the TDZ on `const` bindings declared lower
-    // in the IIFE body. Function declarations are hoisted; `const` is not.
-    const DATE_FORMAT_BY_LANGUAGE = {
-        vi: { locale: 'vi-VN', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
-        en: { locale: 'en-GB', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
-    };
+    // Localised UI strings live next to CATEGORIES so init-phase callers
+    // (applyLocalizedKeywords, renderExpenses) can read them without
+    // tripping the TDZ on `const` bindings declared lower in the IIFE
+    // body. Function declarations are hoisted; `const` is not. Date
+    // formats moved to dashboard_common.js — re-import below if needed.
     const UI_KEYWORDS = {
         vi: {
             reverse: 'Huỷ',
@@ -190,45 +194,6 @@
         });
     }
 
-    function applyTheme(theme) {
-        const root = document.documentElement;
-        const map = {
-            '--bg-color': theme.bg_color,
-            '--text-color': theme.text_color,
-            '--text-muted': theme.hint_color,
-            '--card-bg': theme.secondary_bg_color,
-            '--primary': theme.button_color,
-            '--primary-text': theme.button_text_color,
-        };
-        for (const [prop, value] of Object.entries(map)) {
-            if (value) root.style.setProperty(prop, value);
-        }
-    }
-
-    function formatMoneyShort(amount) {
-        const abs = Math.abs(amount);
-        if (abs >= 1_000_000_000) {
-            return (amount / 1_000_000_000).toFixed(2).replace(/\.?0+$/, '') + ' tỷ';
-        }
-        if (abs >= 1_000_000) {
-            return (amount / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'tr';
-        }
-        if (abs >= 1_000) return Math.round(amount / 1_000) + 'k';
-        return Math.round(amount) + 'đ';
-    }
-
-    function formatMoneyFull(amount) {
-        return new Intl.NumberFormat('vi-VN').format(Math.round(amount)) + 'đ';
-    }
-
-    function escapeHtml(value) {
-        return String(value || '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
-    }
-
     function formatMonthLabel(monthKey) {
         if (!monthKey) return '';
         const [year, month] = monthKey.split('-');
@@ -242,38 +207,6 @@
     function resolveKeywords() {
         const lang = resolveLanguageCode();
         return UI_KEYWORDS[lang] || UI_KEYWORDS[lang.split('-')[0]] || UI_KEYWORDS.vi;
-    }
-
-    function resolveDateFormat() {
-        const lang = resolveLanguageCode();
-        return DATE_FORMAT_BY_LANGUAGE[lang] || DATE_FORMAT_BY_LANGUAGE[lang.split('-')[0]] || DATE_FORMAT_BY_LANGUAGE.vi;
-    }
-
-    function formatDate(iso) {
-        if (!iso) return '--/--/----';
-        const d = new Date(iso + 'T00:00:00');
-        const fmt = resolveDateFormat();
-        return d.toLocaleDateString(fmt.locale, fmt.options);
-    }
-
-    async function fetchAPI(endpoint, options = {}) {
-        const controller = new AbortController();
-        const tid = setTimeout(() => controller.abort(), 12000);
-        const headers = { 'Content-Type': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
-        try {
-            const response = await fetch('/miniapp/api' + endpoint, {
-                ...options,
-                headers: { ...headers, ...(options.headers || {}) },
-                signal: controller.signal,
-            });
-            if (!response.ok) throw new Error('API ' + response.status);
-            const payload = await response.json();
-            if (payload.error) throw new Error(payload.error.message || 'API error');
-            return payload.data;
-        } finally {
-            clearTimeout(tid);
-        }
     }
 
     // -- Top-level render -------------------------------------------------

--- a/backend/miniapp/static/js/wealth_dashboard.js
+++ b/backend/miniapp/static/js/wealth_dashboard.js
@@ -8,6 +8,11 @@
 (function () {
     'use strict';
 
+    // Shared helpers from /miniapp/static/js/dashboard_common.js — loaded
+    // first via the template. Destructure at IIFE top so bindings exit
+    // TDZ before any caller (per the smoke-harness contract).
+    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI } = window.DashboardCommon;
+
     const tg = window.Telegram && window.Telegram.WebApp;
     if (tg) {
         tg.ready();
@@ -108,65 +113,8 @@
 
     // -- Theme + utils ----------------------------------------------------
 
-    function applyTheme(theme) {
-        const root = document.documentElement;
-        const map = {
-            '--bg-color': theme.bg_color,
-            '--text-color': theme.text_color,
-            '--text-muted': theme.hint_color,
-            '--card-bg': theme.secondary_bg_color,
-            '--primary': theme.button_color,
-            '--primary-text': theme.button_text_color,
-        };
-        for (const [prop, value] of Object.entries(map)) {
-            if (value) root.style.setProperty(prop, value);
-        }
-    }
-
-    function formatMoneyShort(amount) {
-        const abs = Math.abs(amount);
-        if (abs >= 1_000_000_000) {
-            return (amount / 1_000_000_000).toFixed(2).replace(/\.?0+$/, '') + ' tỷ';
-        }
-        if (abs >= 1_000_000) {
-            return (amount / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'tr';
-        }
-        if (abs >= 1_000) return Math.round(amount / 1_000) + 'k';
-        return Math.round(amount) + 'đ';
-    }
-
-    function formatMoneyFull(amount) {
-        return new Intl.NumberFormat('vi-VN').format(Math.round(amount)) + 'đ';
-    }
-
-    function escapeHtml(value) {
-        return String(value || '')
-            .replace(/&/g, '&amp;')
-            .replace(/</g, '&lt;')
-            .replace(/>/g, '&gt;')
-            .replace(/"/g, '&quot;');
-    }
-
-    async function fetchAPI(endpoint) {
-        const controller = new AbortController();
-        const tid = setTimeout(() => controller.abort(), 12000);
-        const headers = { 'Content-Type': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
-        try {
-            const response = await fetch('/miniapp/api' + endpoint, {
-                headers,
-                signal: controller.signal,
-            });
-            if (!response.ok) throw new Error('API ' + response.status);
-            const payload = await response.json();
-            if (payload.error) {
-                throw new Error(payload.error.message || 'API error');
-            }
-            return payload.data;
-        } finally {
-            clearTimeout(tid);
-        }
-    }
+    // applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI
+    // moved to dashboard_common.js — destructured at the top of the IIFE.
 
     // -- Top-level render -------------------------------------------------
 

--- a/backend/miniapp/templates/dashboard.html
+++ b/backend/miniapp/templates/dashboard.html
@@ -82,6 +82,7 @@
         </div>
     </div>
 
+    <script src="/miniapp/static/js/dashboard_common.js" defer></script>
     <script src="/miniapp/static/js/dashboard.js" defer></script>
 </body>
 </html>

--- a/backend/miniapp/templates/expense_dashboard.html
+++ b/backend/miniapp/templates/expense_dashboard.html
@@ -134,6 +134,7 @@
         </div>
     </div>
 
+    <script src="/miniapp/static/js/dashboard_common.js" defer></script>
     <script src="/miniapp/static/js/expense_dashboard.js" defer></script>
 </body>
 </html>

--- a/backend/miniapp/templates/wealth_dashboard.html
+++ b/backend/miniapp/templates/wealth_dashboard.html
@@ -100,6 +100,7 @@
 
     <canvas id="confetti-canvas" aria-hidden="true"></canvas>
 
+    <script src="/miniapp/static/js/dashboard_common.js" defer></script>
     <script src="/miniapp/static/js/wealth_dashboard.js" defer></script>
 </body>
 </html>

--- a/backend/tests/js_dashboard_smoke.cjs
+++ b/backend/tests/js_dashboard_smoke.cjs
@@ -178,6 +178,35 @@ async function run(target) {
     const { ctx, fetchCalls, documentListeners } = makeContext();
     vm.createContext(ctx);
 
+    // Mirror the production load order: dashboard_common.js (shared
+    // helpers exposed on window.DashboardCommon) is loaded by every
+    // template before the dashboard-specific bundle. Skip when the
+    // target IS dashboard_common.js itself, or for any file that
+    // doesn't reference DashboardCommon (eg. legacy bundles that
+    // haven't been refactored to use shared helpers).
+    const COMMON = path.join(path.dirname(target), 'dashboard_common.js');
+    if (
+        target !== COMMON
+        && fs.existsSync(COMMON)
+        && source.includes('DashboardCommon')
+    ) {
+        try {
+            vm.runInContext(fs.readFileSync(COMMON, 'utf8'), ctx, {
+                filename: 'dashboard_common.js',
+                timeout: 5000,
+            });
+        } catch (err) {
+            return {
+                ok: false,
+                error: 'dashboard_common.js failed to load: ' + String(err.message || err),
+                stack: err.stack ? String(err.stack).split('\n').slice(0, 4).join(' | ') : null,
+                domContentLoadedErrors: [],
+                fetchCalls: 0,
+                urls: [],
+            };
+        }
+    }
+
     const errors = [];
     let initError = null;
     try {

--- a/backend/tests/test_dashboard_common.py
+++ b/backend/tests/test_dashboard_common.py
@@ -1,0 +1,254 @@
+"""Behavioural tests for the shared dashboard helper bundle.
+
+`dashboard_common.js` is loaded by every miniapp dashboard template
+before the dashboard-specific bundle and exposes a single
+``window.DashboardCommon`` namespace. A bug here would silently break
+every dashboard at once, so we exercise the public surface in a Node
+sandbox (no fastapi / DOM dependency).
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+COMMON = ROOT / "backend/miniapp/static/js/dashboard_common.js"
+NODE = shutil.which("node")
+
+
+def _evaluate(snippet: str) -> dict:
+    """Load dashboard_common.js into a Node vm sandbox and evaluate
+    ``snippet`` against ``window.DashboardCommon``. Returns the parsed
+    JSON object the snippet prints to stdout.
+    """
+    harness = f"""
+const vm = require('vm');
+const fs = require('fs');
+
+const ctx = {{
+    console,
+    Intl,
+    Math,
+    Number,
+    String,
+    Boolean,
+    Object,
+    Array,
+    Date,
+    Map,
+    Set,
+    Promise,
+    Error,
+    JSON,
+    RegExp,
+    AbortController,
+    setTimeout: (fn, ms) => setTimeout(fn, Math.min(ms | 0, 50)),
+    clearTimeout,
+    parseInt,
+    parseFloat,
+    isNaN,
+    URLSearchParams,
+}};
+ctx.window = ctx;
+ctx.self = ctx;
+ctx.globalThis = ctx;
+ctx.document = {{ documentElement: {{ style: {{ setProperty: () => {{}} }} }} }};
+ctx.Telegram = {{ WebApp: {{ initData: 'stub', initDataUnsafe: {{ user: {{ language_code: 'vi' }} }} }} }};
+ctx.fetch = (url, opts) => Promise.resolve({{
+    ok: true,
+    status: 200,
+    headers: {{ get: () => null }},
+    json: () => Promise.resolve({{ data: {{ url: String(url) }} }}),
+}});
+
+vm.createContext(ctx);
+vm.runInContext(fs.readFileSync({str(COMMON)!r}, 'utf8'), ctx, {{
+    filename: 'dashboard_common.js',
+    timeout: 5000,
+}});
+
+(async () => {{
+    try {{
+        const DC = ctx.DashboardCommon;
+        const result = await (async () => {{ {snippet} }})();
+        process.stdout.write(JSON.stringify({{ ok: true, result }}));
+    }} catch (err) {{
+        process.stdout.write(JSON.stringify({{ ok: false, error: String(err && err.message || err) }}));
+        process.exit(1);
+    }}
+}})();
+""".strip()
+    proc = subprocess.run(
+        [NODE, "-e", harness],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    stdout = (proc.stdout or "").strip()
+    assert stdout, f"node printed nothing (exit={proc.returncode}); stderr={proc.stderr}"
+    payload = json.loads(stdout)
+    assert payload.get("ok"), f"snippet failed: {payload.get('error')}"
+    return payload["result"]
+
+
+pytestmark = pytest.mark.skipif(NODE is None, reason="Node.js not on PATH; skipping shared-helpers tests.")
+
+
+def test_dashboard_common_exposes_expected_helpers() -> None:
+    """Lock the public surface — every consumer destructures from this list."""
+    keys = _evaluate("return Object.keys(DC).sort();")
+    assert keys == sorted([
+        "applyTheme",
+        "formatMoneyShort",
+        "formatMoneyFull",
+        "escapeHtml",
+        "fetchAPI",
+        "formatDate",
+        "resolveDateFormat",
+    ])
+
+
+def test_format_money_short_canonical_precision() -> None:
+    """Canonical 2-decimal precision for billions, 1-decimal for millions,
+    rounded thousands, rounded raw đồng. Mirrors the rule the expense and
+    wealth dashboards depended on before extraction.
+    """
+    cases = _evaluate("""
+        return {
+            '0': DC.formatMoneyShort(0),
+            '500': DC.formatMoneyShort(500),
+            '1500': DC.formatMoneyShort(1500),
+            '12345': DC.formatMoneyShort(12345),
+            '1500000': DC.formatMoneyShort(1500000),
+            '1234567890': DC.formatMoneyShort(1234567890),
+            '2000000000': DC.formatMoneyShort(2000000000),
+            'neg45000': DC.formatMoneyShort(-45000),
+        };
+    """)
+    assert cases["0"] == "0đ"
+    assert cases["500"] == "500đ"
+    assert cases["1500"] == "2k"  # round
+    assert cases["12345"] == "12k"
+    assert cases["1500000"] == "1.5tr"
+    assert cases["1234567890"] == "1.23 tỷ"
+    assert cases["2000000000"] == "2 tỷ"  # trailing zeros stripped
+    assert cases["neg45000"] == "-45k"
+
+
+def test_format_money_full_uses_vi_locale_grouping() -> None:
+    cases = _evaluate("""
+        return {
+            '1000': DC.formatMoneyFull(1000),
+            '1234567': DC.formatMoneyFull(1234567),
+            'rounded': DC.formatMoneyFull(1500.7),
+        };
+    """)
+    assert cases["1000"] == "1.000đ"
+    assert cases["1234567"] == "1.234.567đ"
+    assert cases["rounded"] == "1.501đ"
+
+
+def test_escape_html_blocks_xss_vectors() -> None:
+    """Defensive: any string we interpolate into innerHTML must be
+    escaped. The helper is used across every dashboard for user-supplied
+    merchant names, notes, category labels.
+    """
+    cases = _evaluate("""
+        return {
+            ampersand: DC.escapeHtml('Tom & Jerry'),
+            tag: DC.escapeHtml('<script>alert(1)</script>'),
+            quote: DC.escapeHtml('say \"hi\"'),
+            falsy_null: DC.escapeHtml(null),
+            falsy_undef: DC.escapeHtml(undefined),
+        };
+    """)
+    assert cases["ampersand"] == "Tom &amp; Jerry"
+    assert cases["tag"] == "&lt;script&gt;alert(1)&lt;/script&gt;"
+    assert cases["quote"] == "say &quot;hi&quot;"
+    assert cases["falsy_null"] == ""
+    assert cases["falsy_undef"] == ""
+
+
+def test_format_date_local_timezone_interpretation() -> None:
+    """Contract: ISO date YYYY-MM-DD must render in *local* timezone.
+    Appending T00:00:00 prevents the date from sliding to the previous
+    day when rendered in a UTC-shifted environment.
+    """
+    cases = _evaluate("""
+        return {
+            normal: DC.formatDate('2025-12-31'),
+            empty: DC.formatDate(''),
+            null_: DC.formatDate(null),
+        };
+    """)
+    assert cases["normal"] == "31/12/2025"
+    assert cases["empty"] == "--/--/----"
+    assert cases["null_"] == "--/--/----"
+
+
+def test_fetch_api_includes_telegram_init_data_header() -> None:
+    """Security/auth: every miniapp API call must carry the
+    X-Telegram-Init-Data header so the backend can verify the caller.
+    """
+    captured = _evaluate("""
+        let captured = null;
+        ctx.fetch = (url, opts) => {
+            captured = { url: String(url), headers: opts && opts.headers };
+            return Promise.resolve({
+                ok: true,
+                status: 200,
+                json: () => Promise.resolve({ data: { ok: 1 } }),
+            });
+        };
+        const data = await DC.fetchAPI('/wealth/overview');
+        return { captured, data };
+    """)
+    assert captured["captured"]["url"] == "/miniapp/api/wealth/overview"
+    assert captured["captured"]["headers"]["X-Telegram-Init-Data"] == "stub"
+    assert captured["captured"]["headers"]["Content-Type"] == "application/json"
+    assert captured["data"] == {"ok": 1}
+
+
+def test_fetch_api_surfaces_payload_error() -> None:
+    """When the API responds 200 with a structured error envelope the
+    helper must throw so callers' catch blocks fire.
+    """
+    threw = _evaluate("""
+        ctx.fetch = () => Promise.resolve({
+            ok: true,
+            status: 200,
+            json: () => Promise.resolve({ error: { message: 'no funds' } }),
+        });
+        try {
+            await DC.fetchAPI('/anything');
+            return { threw: false };
+        } catch (err) {
+            return { threw: true, message: String(err.message) };
+        }
+    """)
+    assert threw == {"threw": True, "message": "no funds"}
+
+
+def test_fetch_api_throws_on_http_failure() -> None:
+    """Non-2xx must surface as an Error with 'API <status>' so per-
+    dashboard buildErrorMessage can map 401/422/404 to localized copy.
+    """
+    threw = _evaluate("""
+        ctx.fetch = () => Promise.resolve({
+            ok: false,
+            status: 401,
+            json: () => Promise.resolve({}),
+        });
+        try {
+            await DC.fetchAPI('/x');
+            return { threw: false };
+        } catch (err) {
+            return { threw: true, message: String(err.message) };
+        }
+    """)
+    assert threw == {"threw": True, "message": "API 401"}

--- a/backend/tests/test_expense_miniapp_static.py
+++ b/backend/tests/test_expense_miniapp_static.py
@@ -70,6 +70,10 @@ def test_expense_localised_constants_declared_before_init_usage():
     declared lower in the same scope, so the call hit TDZ and aborted
     init — the user saw "Đang tải chi tiêu…" forever. Lock the source
     order so a future move can't silently re-introduce the bug.
+
+    Note: ``DATE_FORMAT_BY_LANGUAGE`` moved to dashboard_common.js after
+    the helper-dedup refactor; this test now only guards the
+    expense-local ``UI_KEYWORDS`` binding.
     """
     js_lines = JS.read_text().splitlines()
 
@@ -80,19 +84,39 @@ def test_expense_localised_constants_declared_before_init_usage():
         return -1
 
     ui_keywords_decl = first_index(lambda line: line.lstrip().startswith("const UI_KEYWORDS"))
-    date_format_decl = first_index(lambda line: line.lstrip().startswith("const DATE_FORMAT_BY_LANGUAGE"))
     apply_call = first_index(lambda line: "applyLocalizedKeywords();" in line)
 
     assert ui_keywords_decl >= 0, "UI_KEYWORDS const declaration missing"
-    assert date_format_decl >= 0, "DATE_FORMAT_BY_LANGUAGE const declaration missing"
     assert apply_call >= 0, "applyLocalizedKeywords() init call missing"
     assert ui_keywords_decl < apply_call, (
         f"UI_KEYWORDS declared on line {ui_keywords_decl + 1} but read on "
         f"line {apply_call + 1} — TDZ violation, init will throw."
     )
-    assert date_format_decl < apply_call, (
-        f"DATE_FORMAT_BY_LANGUAGE declared on line {date_format_decl + 1} "
-        f"but reachable from init on line {apply_call + 1} — TDZ risk."
+
+
+def test_expense_destructures_shared_helpers_at_iife_top():
+    """The shared dashboard_common.js helpers must be destructured BEFORE
+    any init-phase caller — same TDZ rule that bit us on UI_KEYWORDS.
+    The destructuring line must sit above the first ``applyTheme`` call.
+    """
+    js_lines = JS.read_text().splitlines()
+
+    def first_index(predicate):
+        for idx, line in enumerate(js_lines):
+            if predicate(line):
+                return idx
+        return -1
+
+    destructure = first_index(
+        lambda line: "DashboardCommon" in line and "applyTheme" in line and "const {" in line
+    )
+    apply_theme_call = first_index(lambda line: "applyTheme(tg.themeParams" in line)
+
+    assert destructure >= 0, "destructuring from DashboardCommon missing"
+    assert apply_theme_call >= 0, "applyTheme bootstrap call missing"
+    assert destructure < apply_theme_call, (
+        f"DashboardCommon destructured on line {destructure + 1} but "
+        f"applyTheme called on line {apply_theme_call + 1} — TDZ risk."
     )
 
 


### PR DESCRIPTION
Follow-up refactor on the dashboard bundles, deepening the work landed in #767.

## Why

Three of the four IIFE dashboards (`expense_dashboard.js`, `wealth_dashboard.js`, `dashboard.js`) carried near-identical copies of `applyTheme` / `formatMoneyShort` / `formatMoneyFull` / `escapeHtml` / `fetchAPI` / `formatDate` / `resolveDateFormat` — ~50 lines × 3. Two real costs:

- A bug in any of them had to be fixed three times.
- Silent drift was easy to miss — `dashboard.js`'s `formatMoneyShort` had quietly been lossy with 1-decimal billions ("1.2 tỷ") while `expense` + `wealth` had canonical 2-decimal precision ("1.23 tỷ"). Same function name, different output.

## What

New `backend/miniapp/static/js/dashboard_common.js` exposes `window.DashboardCommon = { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, formatDate, resolveDateFormat }`. Each consumer template loads it before the page-specific bundle. Each consumer IIFE destructures at the top so the bindings clear TDZ before any caller (same rule that bit us in #767).

| Dashboard | Before | After | Δ |
|---|---|---|---|
| expense_dashboard.js | 852 | 812 | −40 |
| wealth_dashboard.js | 691 | 658 | −33 |
| dashboard.js | 365 | 325 | −40 |
| dashboard_common.js (new) | — | 120 | +120 |
| **Net (source)** | **1908** | **1915** | **+7 lines, but cached across navigations** |

Browser caches `dashboard_common.js` after the first dashboard open, so the second navigation skips re-parsing ~5KB of duplicated helpers.

## Intentionally NOT extracted

Variants are by design, not accidental:

- `showState` — 3 lines, closes over per-dashboard `els`.
- `buildErrorMessage` — each dashboard has a different 4xx surface: `dashboard.js` maps `404 → "Chưa có dữ liệu"`, `expense`/`wealth` map `422 → "Tham số không hợp lệ"`.
- `reportLoaded` — per-dashboard `loadBeaconSent` + `pageStartedAt` closure state.
- `handleInitFailure` — intentionally per-dashboard for isolation per #767's bootstrap-guard contract.
- `twin_dashboard.js`'s helpers — uses raw `fetch` with ETag headers for 304 caching + custom `formatMoneyShort` using `toLocaleString`.
- `cashflow_dashboard.js` — different `DOMContentLoaded` bootstrap shape, distinct `escapeHtml` regex.

## CSS dedup considered and rejected

The apparent "modal" overlap between `style.css` and `expense.css` is actually two distinct visual designs:

- `style.css`: bottom-sheet modal (full-width, top-rounded, `align-items: flex-end`) — used by legacy `dashboard.html` v1.
- `expense.css`: centered modal with 3-column action grid (`max-width: 380px`, `align-items: center`) — used by expense_dashboard.

Removing the `expense.css` overrides would regress the UI. Modal styles stay per-page.

## Tiny user-visible change

`/miniapp/dashboard` (legacy v1) now shows "1.23 tỷ" instead of "1.2 tỷ" for billion-scale amounts, matching the other dashboards. Precision improvement, not regression.

## Tests

- **New `test_dashboard_common.py`** — exercises every public helper in a Node `vm` sandbox (no fastapi/DOM deps): format precision (negatives, trailing-zero strip, locale grouping), XSS-safe `escapeHtml`, local-tz `formatDate`, `fetchAPI` carries `X-Telegram-Init-Data` and surfaces HTTP + payload errors as throws.
- **Smoke harness updated** to load `dashboard_common.js` into the sandbox before any target referencing `DashboardCommon`. Validated by reverting one destructure locally — harness fails with `Cannot destructure property 'applyTheme'…` as expected.
- **TDZ guards updated** — `DATE_FORMAT_BY_LANGUAGE` moved out of `expense_dashboard.js`; existing regression test slimmed accordingly. New `test_expense_destructures_shared_helpers_at_iife_top` locks the destructuring above the first `applyTheme` call so we can't re-introduce a TDZ failure on the shared bindings.

## Test plan

- [x] `uv run pytest backend/tests/test_dashboard_common.py backend/tests/test_dashboard_init_smoke.py backend/tests/test_expense_miniapp_static.py` → 29 passed
- [x] `node --check` clean on all 4 IIFE bundles + dashboard_common.js
- [x] Smoke harness `ok=true, fetchCalls=2` for expense / wealth / twin / dashboard / cashflow after refactor
- [ ] Manual: open each dashboard in Telegram — confirm hero amounts render, modals work, retry button works after deliberate offline
- [ ] Manual: navigate between dashboards — confirm second open feels faster (browser-cached `dashboard_common.js`)

## Honest caveat on "speed"

This refactor's main payoff is **maintainability** (one helper to fix instead of three) plus small bundle savings. Render speed in the steady state is dominated by network latency on the overview fetch and Chart.js init — neither moves with this PR. The "tốc độ rendering" framing is partly aspirational; the real win is fewer bugs going forward.