### PR TITLE
fix(expense-dashboard): add missing credit_cards migration

### DIFF
--- a/alembic/versions/20260521_credit_cards.py
+++ b/alembic/versions/20260521_credit_cards.py
@@ -1,0 +1,148 @@
+"""credit cards table + expenses.source_credit_card_id link
+
+PR #778 (Issue #774) introduced ``backend.models.credit_card.CreditCard``
+(table ``credit_cards``) and a new ``Expense.source_credit_card_id``
+column with a FK into it, but shipped without an Alembic migration.
+On any deploy that ran ``alembic upgrade head``, the ORM model and the
+database schema diverged: every ``select(Expense)`` query emits SQL
+referencing ``expenses.source_credit_card_id`` and PostgreSQL replies
+with ``UndefinedColumn``. The Mini App expense dashboard's overview
+endpoint catches that and returns a generic 500
+("Không tải được dữ liệu chi tiêu, thử lại nhé."), which is the symptom
+users hit when opening /miniapp/expense.
+
+This migration adds the missing schema in one transaction so prod can
+``alembic upgrade head`` and the dashboard recovers. It also extends
+``ck_expenses_source_type`` to accept ``'credit_card'`` — without that,
+the credit-card source flow inserts would fail the check even once the
+column exists.
+
+Revision ID: 20260521creditcards
+Revises: 20260521r6mergeheads
+Create Date: 2026-05-21
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+
+revision = "20260521creditcards"
+down_revision = "20260521r6mergeheads"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Column types, nullability, and defaults mirror
+    # ``backend/models/credit_card.py`` exactly so a subsequent
+    # ``alembic revision --autogenerate`` doesn't propose a diff. The
+    # model declares Python-side defaults (datetime.utcnow,
+    # Decimal("0")) rather than DB server_defaults; we follow suit.
+    op.create_table(
+        "credit_cards",
+        sa.Column(
+            "id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+            nullable=False,
+        ),
+        sa.Column(
+            "user_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=False,
+        ),
+        sa.Column("bank_name", sa.String(length=120), nullable=False),
+        sa.Column("closing_date", sa.Integer(), nullable=False),
+        sa.Column("debt_balance", sa.Numeric(15, 2), nullable=False),
+        sa.Column(
+            "created_at", sa.DateTime(timezone=True), nullable=False
+        ),
+        sa.Column(
+            "updated_at", sa.DateTime(timezone=True), nullable=False
+        ),
+        sa.UniqueConstraint(
+            "user_id", "bank_name", name="uq_credit_cards_user_bank_name"
+        ),
+        # Cheap defence-in-depth on top of the schema validators in
+        # ``backend/schemas/credit_card.py`` so direct SQL writes can't
+        # poison the table with impossible values.
+        sa.CheckConstraint(
+            "closing_date BETWEEN 1 AND 31",
+            name="ck_credit_cards_closing_date",
+        ),
+        sa.CheckConstraint(
+            "debt_balance >= 0",
+            name="ck_credit_cards_debt_balance_non_negative",
+        ),
+    )
+    # ``ix_<table>_<col>`` is the name SQLAlchemy auto-assigns to a
+    # column-level ``index=True``. Using the same name here keeps the
+    # ORM model and the schema in sync — autogenerate won't propose to
+    # rename / recreate it on the next run.
+    op.create_index("ix_credit_cards_user_id", "credit_cards", ["user_id"])
+    op.create_index(
+        "idx_credit_cards_user_created",
+        "credit_cards",
+        ["user_id", "created_at"],
+    )
+
+    op.add_column(
+        "expenses",
+        sa.Column(
+            "source_credit_card_id",
+            postgresql.UUID(as_uuid=True),
+            nullable=True,
+        ),
+    )
+    op.create_foreign_key(
+        "fk_expenses_source_credit_card",
+        "expenses",
+        "credit_cards",
+        ["source_credit_card_id"],
+        ["id"],
+        ondelete="SET NULL",
+    )
+    # Partial index — most expense rows have no credit-card source, so a
+    # full index would waste space. Mirrors the existing
+    # ``idx_expenses_source_asset`` pattern.
+    op.create_index(
+        "idx_expenses_source_credit_card",
+        "expenses",
+        ["source_credit_card_id"],
+        postgresql_where=sa.text("source_credit_card_id IS NOT NULL"),
+    )
+
+    # ``ck_expenses_source_type`` from 20260513_expense_enhancement only
+    # allows ('cash', 'bank_account', 'e_wallet'). The credit-card source
+    # flow inserts ``source_type='credit_card'``, so without widening
+    # this constraint the new flow would fail at INSERT time even after
+    # the column exists.
+    op.drop_constraint("ck_expenses_source_type", "expenses", type_="check")
+    op.create_check_constraint(
+        "ck_expenses_source_type",
+        "expenses",
+        "source_type IS NULL OR source_type IN "
+        "('cash', 'bank_account', 'e_wallet', 'credit_card')",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_expenses_source_type", "expenses", type_="check")
+    op.create_check_constraint(
+        "ck_expenses_source_type",
+        "expenses",
+        "source_type IS NULL OR source_type IN ('cash', 'bank_account', 'e_wallet')",
+    )
+
+    op.drop_index("idx_expenses_source_credit_card", table_name="expenses")
+    op.drop_constraint(
+        "fk_expenses_source_credit_card", "expenses", type_="foreignkey"
+    )
+    op.drop_column("expenses", "source_credit_card_id")
+
+    op.drop_index("idx_credit_cards_user_created", table_name="credit_cards")
+    op.drop_index("ix_credit_cards_user_id", table_name="credit_cards")
+    op.drop_table("credit_cards")

--- a/backend/miniapp/routes.py
+++ b/backend/miniapp/routes.py
@@ -12,6 +12,7 @@
 from __future__ import annotations
 
 import hashlib
+import logging
 import re
 import time
 from pathlib import Path
@@ -29,6 +30,8 @@ from backend.services import (
     intent_metrics,
     wealth_dashboard_service,
 )
+
+logger = logging.getLogger(__name__)
 
 _HERE = Path(__file__).parent
 _TEMPLATES_DIR = _HERE / "templates"
@@ -644,6 +647,11 @@ def _serialize_expense_item(expense) -> dict:
             if getattr(expense, "source_asset_id", None)
             else None
         ),
+        "source_credit_card_id": (
+            str(expense.source_credit_card_id)
+            if getattr(expense, "source_credit_card_id", None)
+            else None
+        ),
     }
 
 
@@ -773,6 +781,17 @@ async def get_expense_dashboard_overview(
                 "money_in_total": sum(float(e.amount or 0) for e in money_in),
             }
         except Exception as exc:  # noqa: BLE001
+            # Log the underlying DB / ORM error before flattening to a
+            # generic 500. The Mini App only renders the localized
+            # message ("Không tải được dữ liệu chi tiêu, thử lại nhé."),
+            # so without this log a schema drift (e.g. PR #778 adding
+            # ``expenses.source_credit_card_id`` to the ORM with no
+            # matching Alembic migration) is invisible — exactly the
+            # failure mode that motivated this catch.
+            logger.exception(
+                "expense_dashboard.overview failed",
+                extra={"user_id": str(user.id), "month": month_key},
+            )
             raise HTTPException(
                 status_code=500,
                 detail="Không tải được dữ liệu chi tiêu, thử lại nhé.",


### PR DESCRIPTION
## Summary

Fixes the Mini App expense dashboard ("Chi tiêu của tôi") returning **"Không tải được dữ liệu, thử lại nhé."** since #778 merged earlier today. Third attempt at this bug — prior fixes (#771, #779) addressed adjacent issues but missed the actual root cause, which is a schema drift, not a UI / cache problem.

Closes #771
Closes #774
Closes #778
Closes #779

## Root cause

PR #778 (Issue #774) added:

- `backend/models/credit_card.py` — new `CreditCard` ORM (table `credit_cards`)
- `Expense.source_credit_card_id` column on `backend/models/expense.py` with a FK into `credit_cards`

…but shipped **no Alembic migration**. Once deployed:

- `alembic upgrade head` runs without creating either the new table or the new column
- Every `select(Expense)` query in the codebase emits SQL referencing `expenses.source_credit_card_id` — including `expense_service.list_expenses`, `dashboard_service.get_recent_transactions`, `goal_projection`, `recurring_detector`, etc.
- PostgreSQL responds `UndefinedColumn`
- `/miniapp/api/expense-dashboard/overview` catches it with a bare `except Exception` and re-raises as a generic 500 with the localized message users see in the screenshot.

The two prior fix attempts diagnosed the *symptoms* (CSS modal sync in #771, multi-head merge in #779) but did not touch the model⇄DB drift.

## Fix

### 1. `alembic/versions/20260521_credit_cards.py` — new migration

Descends from the current head `20260521r6mergeheads`:

- Creates `credit_cards` (columns / nullability / indexes mirror the ORM exactly so `alembic revision --autogenerate` won't propose a diff next run).
- Adds `expenses.source_credit_card_id` (nullable UUID) with FK `fk_expenses_source_credit_card` (`ON DELETE SET NULL`) into `credit_cards.id`.
- Adds partial index `idx_expenses_source_credit_card` (`WHERE source_credit_card_id IS NOT NULL`) — mirrors the existing `idx_expenses_source_asset` pattern so most expense rows pay no index cost.
- Widens `ck_expenses_source_type` to include `'credit_card'`. Without this, the credit-card source flow would still fail at INSERT time even after the column exists (the old check only allowed `cash | bank_account | e_wallet`).
- Verified end-to-end against a live PostgreSQL 16 instance: `upgrade()` then `downgrade()` both clean, and `INSERT ... source_type='credit_card'` passes the new constraint (would have failed before).

### 2. `backend/miniapp/routes.py`

- `get_expense_dashboard_overview` now `logger.exception`s the underlying SQL / ORM error before flattening to the localized 500. The previous code swallowed the original exception text — which is exactly why this schema drift went undiagnosed for two attempts. Future schema drifts of this shape will now show up immediately in Sentry / app logs with the actual `UndefinedColumn` line.
- `_serialize_expense_item` now serializes `source_credit_card_id` alongside `source_asset_id` so the JSON payload is symmetric.

## Why this is safe

- **Consistency:** Schema now matches the ORM 1-to-1. No autogenerate noise on the next migration.
- **Performance:** Partial index keeps index size small (most rows have `source_credit_card_id = NULL`); no extra round-trip on dashboard reads — the existing 30s per-`(user, month)` cache in `routes.py` is unchanged.
- **UI/UX:** The Mini App's `expense_dashboard.js` already had a multi-layered failure ladder (init guard, retry button, stale-snapshot retention) — the dashboard self-heals on next load once the migration applies, with no client cache bust needed because the JS payload didn't change.
- **Security:** Migration adds a `CHECK` constraint to bound `closing_date` and `debt_balance` server-side as defence-in-depth on top of the Pydantic validators. No new endpoints, no new auth surfaces.

## Test plan

- [x] `python -m pytest tests/test_credit_card_service.py tests/test_expense_transaction_logic.py tests/bot/test_signed_transaction_parser.py` — all green
- [x] `ruff check` on changed files — clean
- [x] Applied `upgrade()` to a real PostgreSQL 16 instance, confirmed `credit_cards` table + `expenses.source_credit_card_id` column + new FK + updated CHECK constraint all present
- [x] Confirmed `INSERT INTO expenses (source_type) VALUES ('credit_card')` now passes the check (would have failed before)
- [x] Ran `downgrade()` — table dropped, column dropped, original check constraint restored
- [x] `alembic.script.ScriptDirectory.get_heads()` returns a single head (`20260521creditcards`)
- [ ] Verify on staging: deploy, run `alembic upgrade head`, open `/miniapp/expense` — dashboard should load instead of showing the error modal

https://claude.ai/code/session_0185MBHHoXAzKfLkYCHCNu7G