### PR TITLE
fix(callbacks): align expired-undo wording with Mini App reverse flow

### DIFF
--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -403,7 +403,7 @@ async def _handle_undo_transaction(*, db, user, args, callback_id, chat_id, mess
     if age > UNDO_WINDOW_SECONDS:
         await answer_callback(
             callback_id,
-            text="Quá muộn để hủy — dùng nút 🗑 Xóa nhé",
+            text="Hết hạn huỷ nhanh — mở Mini App rồi bấm ↩️ Huỷ giao dịch nhé",
             show_alert=True,
         )
         return
@@ -457,7 +457,7 @@ async def _handle_undo_transaction_batch(
     if age > UNDO_WINDOW_SECONDS:
         await answer_callback(
             callback_id,
-            text="Quá muộn để hủy — dùng nút 🗑 Xóa nhé",
+            text="Hết hạn huỷ nhanh — mở Mini App rồi bấm ↩️ Huỷ giao dịch nhé",
             show_alert=True,
         )
         return


### PR DESCRIPTION
## Summary
- Updates `backend/bot/handlers/callbacks.py:406, 460` (both single and batch undo handlers) so when the inline ↶ Hủy window expires, the alert points users to the Mini App ↩️ Huỷ (reverse) flow instead of the retired 🗑 Xóa button.
- Aligns Telegram wording with the Mini App copy already shipped for #722 (`expense_dashboard.js`: `reverse: 'Huỷ'`, confirmation `'Huỷ giao dịch này?'`).

Before:
```
Quá muộn để hủy — dùng nút 🗑 Xóa nhé
```
After:
```
Hết hạn huỷ nhanh — mở Mini App rồi bấm ↩️ Huỷ giao dịch nhé
```

Closes #722

(Issue #720 is already shipped on main via the `transactions` table migration — not part of this PR; mentioned by auto-PR boilerplate.)

## Test plan
- [ ] In Telegram, log an expense and wait past `UNDO_WINDOW_SECONDS`, then tap ↶ Hủy — confirm the alert shows the new wording.
- [ ] Repeat with a batch (multi-row) entry to exercise `_handle_undo_transaction_batch`.
- [ ] Confirm Mini App reverse flow still works after the legacy callback alert appears (i.e. wording matches the actual UX).

https://claude.ai/code/session_01V7YcoV63xAeV12CnizbipJ