### PR TITLE
fix(callbacks): fall back to send_message when txsrc edit fails (#799)

### DIFF
--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -122,13 +122,32 @@ async def _handle_source_selection_callback(
         "zalopay": "Ví ZaloPay",
         "viettelpay": "Ví ViettelPay",
     }.get(wallet_provider or source_type, "không liên kết nguồn")
-    await edit_message_text(
-        chat_id=chat_id,
-        message_id=message_id,
-        text=f"Đã ghi nhận {tx_sign}{float(expense.amount):,.0f}đ · {source_label}",
-        parse_mode=None,
-        reply_markup={"inline_keyboard": []},
+    confirmation_text = (
+        f"Đã ghi nhận {tx_sign}{float(expense.amount):,.0f}đ · {source_label}"
     )
+    # Issue #799: ``editMessageText`` silently returns ``None`` when the
+    # source-picker message is unreachable (deleted by the user, older
+    # than Telegram's 48h edit window, etc.). Without a fallback the
+    # user is stranded on the picker screen with no confirmation that
+    # the transaction landed. Always send a fresh ``sendMessage`` when
+    # the edit can't be confirmed so the user gets feedback either way.
+    edit_result = None
+    if chat_id is not None and message_id is not None:
+        edit_result = await edit_message_text(
+            chat_id=chat_id,
+            message_id=message_id,
+            text=confirmation_text,
+            parse_mode=None,
+            reply_markup={"inline_keyboard": []},
+        )
+    if edit_result is None and chat_id is not None:
+        logger.warning(
+            "txsrc confirmation edit returned None; sending fallback message "
+            "(chat_id=%s message_id=%s)",
+            chat_id,
+            message_id,
+        )
+        await send_message(chat_id, confirmation_text, parse_mode=None)
     if expense.transaction_type == "expense" and (expense.raw_data or {}).get(
         "source_warning"
     ):

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -1,0 +1,317 @@
+"""Regression tests for the transaction-source callback flow (`txsrc:*`,
+`txsrc_wallet:*`).
+
+Issue #799 reported that after a user typed "+20 tỷ lương" → tapped
+``e_wallet`` → tapped ``ZaloPay`` (callback ``txsrc_wallet:zalopay``),
+the database write succeeded but no confirmation message was ever sent
+back to Telegram. The user was left staring at the source-picker screen
+with no feedback.
+
+These tests pin the contract:
+  - The wallet-provider branch MUST call ``edit_message_text`` to
+    replace the picker with a confirmation line.
+  - It MUST also fire ``answer_callback`` so the user's tap spinner
+    clears.
+  - The wizard state is cleared after a successful save.
+  - A non-wallet source (``txsrc:cash``) follows the same contract.
+  - The intermediate ``txsrc:e_wallet`` tap swaps the keyboard without
+    creating an expense.
+"""
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.bot.handlers import callbacks
+
+
+def _money_in_state() -> dict:
+    return {
+        "flow": "transaction_source_select",
+        "step": "source_type",
+        "draft": {
+            "amount": 20_000_000_000.0,
+            "merchant": "lương",
+            "note": "+20 tỷ lương",
+            "transaction_type": "money_in",
+        },
+    }
+
+
+_SENTINEL = object()
+
+
+def _user(state=_SENTINEL) -> MagicMock:
+    """Build a fake user with ``wizard_state`` defaulting to a live
+    money-in source-picker flow. Pass ``state=None`` (explicitly) to
+    simulate an expired/cleared wizard."""
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.wizard_state = _money_in_state() if state is _SENTINEL else state
+    return user
+
+
+def _callback(data: str) -> dict:
+    return {
+        "id": "cbq-1",
+        "data": data,
+        "message": {"chat": {"id": 999}, "message_id": 42},
+        "from": {"id": 12345},
+    }
+
+
+def _expense(transaction_type: str = "money_in", amount: float = 20_000_000_000.0):
+    expense = SimpleNamespace(
+        id=uuid.uuid4(),
+        amount=amount,
+        transaction_type=transaction_type,
+        raw_data=None,
+    )
+    return expense
+
+
+@pytest.mark.asyncio
+async def test_txsrc_wallet_zalopay_sends_confirmation_message():
+    """The bug: ``txsrc_wallet:zalopay`` wrote to DB but never edited the
+    source-picker message. The user was stuck on the picker screen."""
+    user = _user()
+    db = MagicMock()
+    expense = _expense()
+
+    edit_text = AsyncMock(return_value={"ok": True})
+    answer = AsyncMock()
+    send = AsyncMock()
+    with patch.object(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        callbacks.expense_service,
+        "create_expense",
+        AsyncMock(return_value=expense),
+    ) as create, patch.object(
+        callbacks, "edit_message_text", edit_text
+    ), patch.object(
+        callbacks, "send_message", send
+    ), patch.object(
+        callbacks, "answer_callback", answer
+    ), patch(
+        "backend.services.wizard_service.clear", AsyncMock()
+    ) as wizard_clear:
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc_wallet:zalopay")
+        )
+
+    assert handled is True
+    create.assert_awaited_once()
+    wizard_clear.assert_awaited_once()
+    edit_text.assert_awaited_once()
+    edit_kwargs = edit_text.await_args.kwargs
+    assert edit_kwargs["chat_id"] == 999
+    assert edit_kwargs["message_id"] == 42
+    assert "+20,000,000,000" in edit_kwargs["text"]
+    assert "ZaloPay" in edit_kwargs["text"]
+    # No fallback send_message when edit succeeded.
+    send.assert_not_awaited()
+    answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_wallet_falls_back_to_send_when_edit_fails():
+    """Regression for #799: when ``edit_message_text`` silently returns
+    ``None`` (picker message deleted, >48h old, transient Telegram 4xx),
+    the handler must send a fresh confirmation so the user always gets
+    feedback. Without this fallback the user is stranded on the picker
+    even though the expense was written."""
+    user = _user()
+    db = MagicMock()
+    expense = _expense()
+
+    edit_text = AsyncMock(return_value=None)
+    send = AsyncMock()
+    answer = AsyncMock()
+    with patch.object(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        callbacks.expense_service,
+        "create_expense",
+        AsyncMock(return_value=expense),
+    ), patch.object(
+        callbacks, "edit_message_text", edit_text
+    ), patch.object(
+        callbacks, "send_message", send
+    ), patch.object(
+        callbacks, "answer_callback", answer
+    ), patch(
+        "backend.services.wizard_service.clear", AsyncMock()
+    ):
+        await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc_wallet:zalopay")
+        )
+
+    edit_text.assert_awaited_once()
+    send.assert_awaited_once()
+    sent_chat_id, sent_text = send.await_args.args[0], send.await_args.args[1]
+    assert sent_chat_id == 999
+    assert "+20,000,000,000" in sent_text
+    assert "ZaloPay" in sent_text
+    answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_wallet_uses_provider_label_for_each_wallet():
+    """Every wallet provider gets a friendly label, not the raw key."""
+    user = _user()
+    db = MagicMock()
+    expense = _expense()
+
+    cases = [
+        ("momo", "Momo"),
+        ("vnpay", "VNPay"),
+        ("zalopay", "ZaloPay"),
+        ("viettelpay", "ViettelPay"),
+    ]
+    for provider, expected_label in cases:
+        # Wizard state must look "active" each round because
+        # ``wizard_service.clear`` is the production teardown.
+        user.wizard_state = _money_in_state()
+        edit_text = AsyncMock(return_value={"ok": True})
+        with patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ), patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ), patch.object(
+            callbacks, "edit_message_text", edit_text
+        ), patch.object(
+            callbacks, "answer_callback", AsyncMock()
+        ), patch(
+            "backend.services.wizard_service.clear", AsyncMock()
+        ):
+            await callbacks._handle_source_selection_callback(
+                db, _callback(f"txsrc_wallet:{provider}")
+            )
+        edit_text.assert_awaited_once()
+        assert expected_label in edit_text.await_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_txsrc_cash_sends_confirmation_message():
+    """Non-wallet source path (``txsrc:cash``) follows the same contract:
+    the picker is replaced by a confirmation line."""
+    user = _user()
+    db = MagicMock()
+    expense = _expense()
+
+    edit_text = AsyncMock(return_value={"ok": True})
+    answer = AsyncMock()
+    with patch.object(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        callbacks.expense_service,
+        "create_expense",
+        AsyncMock(return_value=expense),
+    ), patch.object(
+        callbacks, "edit_message_text", edit_text
+    ), patch.object(
+        callbacks, "send_message", AsyncMock()
+    ), patch.object(
+        callbacks, "answer_callback", answer
+    ), patch(
+        "backend.services.wizard_service.clear", AsyncMock()
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:cash")
+        )
+
+    assert handled is True
+    edit_text.assert_awaited_once()
+    assert "Tiền mặt" in edit_text.await_args.kwargs["text"]
+    answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_skip_still_sends_confirmation_message():
+    """``txsrc:skip`` saves the expense without a source — the picker
+    must still be replaced so the user knows the write landed."""
+    user = _user()
+    db = MagicMock()
+    expense = _expense()
+
+    edit_text = AsyncMock(return_value={"ok": True})
+    with patch.object(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        callbacks.expense_service,
+        "create_expense",
+        AsyncMock(return_value=expense),
+    ), patch.object(
+        callbacks, "edit_message_text", edit_text
+    ), patch.object(
+        callbacks, "send_message", AsyncMock()
+    ), patch.object(
+        callbacks, "answer_callback", AsyncMock()
+    ), patch(
+        "backend.services.wizard_service.clear", AsyncMock()
+    ):
+        await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:skip")
+        )
+    edit_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_e_wallet_swaps_keyboard_without_creating_expense():
+    """The intermediate ``txsrc:e_wallet`` tap just replaces the keyboard
+    with the wallet-provider picker. It must NOT call ``create_expense``."""
+    user = _user()
+    db = MagicMock()
+
+    edit_markup = AsyncMock()
+    answer = AsyncMock()
+    create = AsyncMock()
+    with patch.object(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        callbacks.expense_service, "create_expense", create
+    ), patch.object(
+        callbacks, "edit_message_reply_markup", edit_markup
+    ), patch.object(
+        callbacks, "answer_callback", answer
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:e_wallet")
+        )
+
+    assert handled is True
+    create.assert_not_awaited()
+    edit_markup.assert_awaited_once()
+    answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_stale_wizard_state_does_not_call_create_expense():
+    """If the source-picker wizard already expired (state cleared),
+    we must NOT silently create a duplicate expense."""
+    user = _user(state=None)
+    db = MagicMock()
+
+    create = AsyncMock()
+    answer = AsyncMock()
+    with patch.object(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        callbacks.expense_service, "create_expense", create
+    ), patch.object(
+        callbacks, "answer_callback", answer
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc_wallet:zalopay")
+        )
+
+    assert handled is True
+    create.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert "hết hạn" in answer.await_args.kwargs["text"].lower()


### PR DESCRIPTION
Closes #799

## Triệu chứng

User gõ `+20 tỷ lương` → bot hỏi chọn nguồn → user chọn `e_wallet` → tap **ZaloPay** (callback `txsrc_wallet:zalopay`). Expense ghi DB thành công, nhưng:

- Không có message xác nhận
- Picker keyboard vẫn hiện ra → user phải bấm lại

Logs prod: tất cả DB ops xong → `UPDATE telegram_updates SET status='done'` chỉ 15 ms sau `INSERT transactions`, không có outbound Telegram call. Error log trống — không có exception.

## Root cause

`_handle_source_selection_callback` gọi `edit_message_text(...)` để thay picker bằng dòng xác nhận. Khi message gốc không edit được nữa — bị user xoá, quá 48h, hay Telegram trả 4xx transient — `send_telegram` log error và **trả về `None`** mà handler không xử lý.

Hệ quả:
- Không có message xác nhận nào lan tới user
- `answer_callback` chỉ hiện toast thoáng qua (nếu Telegram client còn poll kịp)
- User "stuck ở màn hình chọn nguồn" như issue mô tả

## Fix

Kiểm tra return value của `edit_message_text`. Nếu là `None` (edit fail) và còn `chat_id`, gửi message mới qua `send_message` với cùng nội dung. Log warning để các lần fail sau dễ tra cứu trong prod.

```python
edit_result = await edit_message_text(...)
if edit_result is None and chat_id is not None:
    logger.warning("txsrc confirmation edit returned None; sending fallback message ...")
    await send_message(chat_id, confirmation_text, parse_mode=None)
```

Happy path không đổi: nếu edit thành công thì không gửi thêm message nào.

## Test plan

Regression test mới `backend/tests/test_callbacks_source_selection.py` (7 tests, all green):
- ✅ `txsrc_wallet:zalopay` gửi đúng text + label "Ví ZaloPay", không gửi extra `send_message` khi edit OK
- ✅ **Khi `edit_message_text` trả `None`, fallback `send_message` chạy** (regression cho #799)
- ✅ Mỗi provider Momo/VNPay/ZaloPay/ViettelPay render đúng label
- ✅ `txsrc:cash` gửi label "Tiền mặt"
- ✅ `txsrc:skip` vẫn gửi xác nhận
- ✅ `txsrc:e_wallet` chỉ đổi keyboard, không tạo expense
- ✅ State đã hết hạn → không tạo expense duplicate, alert "Yêu cầu này đã hết hạn"

Các test suite liên quan vẫn pass: `test_callbacks_change_category`, `test_callbacks_receipt_flow`, `test_callback_keyboards`, `test_intent/test_message_router` — 40 passed total.

## Manual prod verification sau deploy

- Tap ZaloPay từ picker → thấy "Đã ghi nhận +X · Ví ZaloPay" hoặc dưới dạng message mới nếu picker không edit được
- Tap Momo/VNPay/ViettelPay → tương tự
- Tap "Bỏ qua nguồn" → vẫn có xác nhận
- Watch logs cho warning `txsrc confirmation edit returned None` để biết tần suất fallback fire