### PR TITLE
fix(transactions): make amount NUMERIC(20,2) to fix INT4 overflow (#801)

### DIFF
--- a/alembic/versions/20260522_fix_transactions_amount_numeric.py
+++ b/alembic/versions/20260522_fix_transactions_amount_numeric.py
@@ -1,0 +1,50 @@
+"""fix transactions.amount: BIGINT -> NUMERIC(20, 2)
+
+Issue #801 — money-in > 2.1 tỷ VND failed with asyncpg
+``value out of range``. Root cause: the ``Transaction.amount`` ORM
+attribute was declared ``Mapped[int]``, which SQLAlchemy compiles to
+``Integer`` for parameter binding. asyncpg then validated bind values
+against the INT4 range even though the underlying column was created as
+BIGINT. CLAUDE.md mandates ``NUMERIC(20, 2)`` for money columns; this
+migration aligns the database with the convention used by
+``expenses.amount`` so that schema, model, and bind types all agree.
+
+The conversion is lossless: BIGINT values fit comfortably inside
+NUMERIC(20, 2).
+
+Revision ID: 20260522fixtxamt
+Revises: 20260521creditcards
+Create Date: 2026-05-22
+"""
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260522fixtxamt"
+down_revision = "20260521creditcards"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "transactions",
+        "amount",
+        type_=sa.Numeric(20, 2),
+        existing_type=sa.BigInteger(),
+        existing_nullable=False,
+        postgresql_using="amount::numeric(20,2)",
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "transactions",
+        "amount",
+        type_=sa.BigInteger(),
+        existing_type=sa.Numeric(20, 2),
+        existing_nullable=False,
+        postgresql_using="amount::bigint",
+    )

--- a/backend/models/transaction.py
+++ b/backend/models/transaction.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
+from decimal import Decimal
 
-from sqlalchemy import DateTime, ForeignKey, Index, String, Text, text
+from sqlalchemy import DateTime, ForeignKey, Index, Numeric, String, Text, text
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -18,7 +19,7 @@ class Transaction(Base):
     source_asset_id: Mapped[uuid.UUID | None] = mapped_column(UUID(as_uuid=True), ForeignKey("assets.id", ondelete="SET NULL"))
     source_type: Mapped[str] = mapped_column(String(32), nullable=False)
     source_label: Mapped[str] = mapped_column(String(120), nullable=False)
-    amount: Mapped[int] = mapped_column(nullable=False)
+    amount: Mapped[Decimal] = mapped_column(Numeric(20, 2), nullable=False)
     direction: Mapped[str] = mapped_column(String(16), nullable=False)
     note: Mapped[str | None] = mapped_column(Text)
     category: Mapped[str | None] = mapped_column(String(100))

--- a/backend/services/expense_service.py
+++ b/backend/services/expense_service.py
@@ -269,7 +269,7 @@ async def _create_transaction_record(db: AsyncSession, user_id: uuid.UUID, expen
         source_asset_id=expense.source_asset_id,
         source_type=expense.source_type or "expense_category",
         source_label=_source_label(expense.source_type),
-        amount=int(Decimal(str(expense.amount or 0))),
+        amount=Decimal(str(expense.amount or 0)),
         direction="inflow" if expense.transaction_type == TRANSACTION_TYPE_MONEY_IN else "outflow",
         note=expense.note or expense.merchant,
         category=expense.category,

--- a/backend/tests/test_transactions_schema.py
+++ b/backend/tests/test_transactions_schema.py
@@ -1,0 +1,54 @@
+"""Schema-level guards for the ``Transaction`` ledger.
+
+Issue #801 reproduced after #799: a money-in larger than ~2.1 tỷ VND
+(INT4 max = 2,147,483,647) failed with asyncpg ``value out of range``.
+The model declared ``amount: Mapped[int]``, which SQLAlchemy compiles
+to ``Integer`` for parameter binding regardless of the column's actual
+SQL type. Even after the migration created the column as BIGINT, the
+ORM still bound INT4 and asyncpg rejected the value.
+
+The #799 regression test mocked ``create_expense``, so it never
+exercised the ORM bind path and could not catch this. These checks
+verify the model definition directly — no DB or mocks needed — so a
+future contributor who switches the column back to ``int`` or
+``BigInteger`` will see a red test, not a production crash on big
+salary money-ins.
+
+CLAUDE.md mandates ``NUMERIC(20, 2)`` for money columns. The asserts
+below pin that contract.
+"""
+from __future__ import annotations
+
+from sqlalchemy import Numeric
+
+from backend.models.transaction import Transaction
+
+
+class TestTransactionAmountColumn:
+    def test_amount_is_numeric_not_integer(self):
+        """Bug #801: ``Mapped[int]`` made SQLAlchemy bind INT4, which
+        asyncpg rejects for values > 2,147,483,647 (≈2.1 tỷ VND).
+        Money columns must be ``Numeric`` — see CLAUDE.md."""
+        col = Transaction.__table__.columns["amount"]
+        assert isinstance(col.type, Numeric), (
+            f"Transaction.amount must be Numeric (CLAUDE.md money "
+            f"convention); got {type(col.type).__name__}. Reverting to "
+            f"Integer/BigInteger reintroduces issue #801."
+        )
+
+    def test_amount_precision_holds_practical_vnd_amounts(self):
+        """NUMERIC(20, 2) holds values up to ~10^18 — well beyond any
+        plausible single-transaction VND amount, and matches the
+        precision used by ``expenses.amount`` family columns."""
+        col = Transaction.__table__.columns["amount"]
+        assert col.type.precision == 20, (
+            f"Transaction.amount precision must be 20 to match the money "
+            f"convention; got {col.type.precision}."
+        )
+        assert col.type.scale == 2
+
+    def test_amount_is_not_null(self):
+        """Every ledger row must have an amount — half-written
+        transactions would corrupt the wealth rollup."""
+        col = Transaction.__table__.columns["amount"]
+        assert col.nullable is False


### PR DESCRIPTION
Closes #801.

## Root cause

Money-in transactions > 2.1 tỷ VND failed with asyncpg `value out of range` on `INSERT INTO transactions` with `amount=3,000,000,000`.

`Transaction.amount` was declared `Mapped[int]` in the ORM model, which SQLAlchemy compiles to `Integer` (INT4) for parameter binding **regardless of the underlying SQL column type**. asyncpg then validated bind values against the INT4 range [-2,147,483,647 … 2,147,483,647] even though the migration (`x3expense719_transactions.py`) had created the column as `BigInteger`. The ORM declaration was the source of truth for binding, not the DB schema.

This also violated the CLAUDE.md money convention: "Always use Decimal, never float … NUMERIC(20,2) for money". `expenses.amount` is `Numeric(15, 2)`; `transactions.amount` should follow the same pattern.

## Why #799's test didn't catch it

The #799 regression test (`test_callbacks_source_selection.py`) patched `expense_service.create_expense` with `AsyncMock(return_value=expense)`. The mock skipped the ORM persistence path entirely, so the INT4 overflow never fired during the test. The bug returned the next time a user typed `+3 tỷ`.

## Fix (three layers + a guard)

1. **Model** (`backend/models/transaction.py`): `amount: Mapped[Decimal] = mapped_column(Numeric(20, 2), nullable=False)` — stops SQLAlchemy from binding INT4.
2. **Service** (`backend/services/expense_service.py:272`): drop the lossy `int(Decimal(...))` cast in `_create_transaction_record`; pass `Decimal` directly.
3. **Migration** (`alembic/versions/20260522_fix_transactions_amount_numeric.py`): `ALTER COLUMN transactions.amount` from `BIGINT → NUMERIC(20, 2)` with `USING amount::numeric(20,2)`. Lossless widening; descends from current head `20260521creditcards`.
4. **Regression guard** (`backend/tests/test_transactions_schema.py`): three schema-introspection tests that fail if a future change reverts `amount` to `Integer` / `BigInteger` or drops the NOT NULL constraint. Pure model inspection — no DB or mocks needed, so it actually runs in CI.

## Test plan

- [x] `pytest backend/tests/test_transactions_schema.py` — 3 new tests pass.
- [x] `pytest backend/tests/test_callbacks_source_selection.py` — 7 prior #799 tests still pass.
- [x] `pytest backend/tests/test_expense_enhancement.py backend/tests/test_callbacks_change_category.py` — 11 expense / callback tests still pass.
- [x] `ruff check` on all modified files — clean.
- [x] `alembic heads` — single head (`20260522fixtxamt`), chain intact.
- [ ] Manual smoke after deploy: `+3 tỷ` and `+20 tỷ` money-in flows complete with a confirmation message and the asset balance updates.