### PR TITLE
Add Life Insurance (BHNT) asset type: keyboard, dispatcher and starter with tests

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -215,6 +215,21 @@ async def cancel_wizard(db: AsyncSession, chat_id: int, user: User) -> bool:
     return True
 
 
+async def _start_life_insurance_create(
+    db: AsyncSession, chat_id: int, user: User
+) -> None:
+    """Route BHNT button to the Life Assurance create/list action."""
+    await wizard_service.clear(db, user.id)
+    from backend.bot.handlers.menu_handler import _action_assets_life_insurance
+
+    await _action_assets_life_insurance(
+        db=db,
+        user=user,
+        chat_id=chat_id,
+        message_id=None,
+    )
+
+
 async def list_assets(db: AsyncSession, chat_id: int, user: User) -> None:
     """Handle /taisan — display all active assets for the user."""
     assets = await asset_service.get_user_assets(db, user.id)
@@ -2856,6 +2871,7 @@ async def _dispatch_asset_action(
             AssetType.CRYPTO.value: _start_crypto_subtype_pick,
             AssetType.GOLD.value: _start_gold_subtype_pick,
             AssetType.REAL_ESTATE.value: _start_real_estate_subtype_pick,
+            AssetType.LIFE_INSURANCE.value: _start_life_insurance_create,
         }
         starter = starters.get(arg)
         if starter is None:
@@ -2869,7 +2885,6 @@ async def _dispatch_asset_action(
             return
         await starter(db, chat_id, user)
         return
-
     if action == "cash_subtype" and arg:
         await _handle_cash_subtype_pick(db, chat_id, user, arg)
         return

--- a/backend/bot/keyboards/asset_keyboard.py
+++ b/backend/bot/keyboards/asset_keyboard.py
@@ -124,7 +124,7 @@ def _pagination_row(
 
 
 def asset_type_picker_keyboard() -> InlineKeyboardMarkup:
-    """Layout 6 asset types in a 3×2 grid for thumb-friendly tapping."""
+    """Layout asset types for thumb-friendly tapping."""
     return {
         "inline_keyboard": [
             [
@@ -166,6 +166,14 @@ def asset_type_picker_keyboard() -> InlineKeyboardMarkup:
                     "text": "📦 Khác",
                     "callback_data": build_callback(
                         CB_ASSET_ADD, "type", AssetType.OTHER.value
+                    ),
+                },
+            ],
+            [
+                {
+                    "text": "🛡️ Bảo hiểm nhân thọ (BHNT)",
+                    "callback_data": build_callback(
+                        CB_ASSET_ADD, "type", AssetType.LIFE_INSURANCE.value
                     ),
                 },
             ],

--- a/backend/tests/test_asset_entry_handler.py
+++ b/backend/tests/test_asset_entry_handler.py
@@ -328,6 +328,47 @@ async def test_callback_type_picker_routes_to_crypto_starter():
 
 
 @pytest.mark.asyncio
+async def test_callback_type_picker_routes_to_life_insurance_starter():
+    user = _user()
+    db = _db(user)
+    with (
+        patch.object(
+            asset_entry, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            asset_entry, "_start_life_insurance_create", AsyncMock()
+        ) as starter,
+        patch.object(asset_entry, "answer_callback", AsyncMock()),
+    ):
+        await asset_entry.handle_asset_callback(
+            db,
+            {
+                "id": "cb1",
+                "data": "asset_add:type:life_insurance",
+                "message": {"chat": {"id": 100}, "message_id": 1},
+                "from": {"id": 100},
+            },
+        )
+    starter.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_start_life_insurance_create_clears_wizard_and_calls_action():
+    user = _user({"flow": asset_entry.FLOW_PICKER, "step": "type", "draft": {}})
+    db = _db(user)
+    with (
+        patch.object(asset_entry.wizard_service, "clear", AsyncMock()) as clear,
+        patch(
+            "backend.bot.handlers.menu_handler._action_assets_life_insurance",
+            AsyncMock(),
+        ) as life_action,
+    ):
+        await asset_entry._start_life_insurance_create(db, 100, user)
+    clear.assert_awaited_once_with(db, user.id)
+    life_action.assert_awaited_once()
+
+
+@pytest.mark.asyncio
 async def test_crypto_subtype_bitcoin_advances_to_quantity():
     user = _user(
         {


### PR DESCRIPTION
### Motivation

- Expose Life Insurance (BHNT) as an asset type so users can add/view life assurance assets from the asset picker.
- Route the BHNT button to the existing Life Assurance flow in the menu handler and ensure any active asset wizard state is cleared first.

### Description

- Add a `🛡️ Bảo hiểm nhân thọ (BHNT)` button to `asset_type_picker()` so the life insurance type is selectable in the asset type keyboard.
- Implement `_start_life_insurance_create` to clear the wizard via `wizard_service.clear` and call the life insurance action `backend.bot.handlers.menu_handler._action_assets_life_insurance`.
- Wire `AssetType.LIFE_INSURANCE` into the asset-type `starters` mapping in `_dispatch_asset_action` so selecting the type routes to the new starter.
- Add unit tests in `backend/tests/test_asset_entry_handler.py` to assert callback routing to the life insurance starter and that `_start_life_insurance_create` clears the wizard and calls the menu action.

### Testing

- Added `test_callback_type_picker_routes_to_life_insurance_starter` and `test_start_life_insurance_create_clears_wizard_and_calls_action` in `backend/tests/test_asset_entry_handler.py` and ran the asset entry tests with `pytest backend/tests/test_asset_entry_handler.py -q`.
- The new tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11921049b8832fa10ddd76ff78c92c)