### PR TITLE
ci(auto-pr): skip release branches in auto-pr trigger

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -5,6 +5,10 @@ on:
     branches:
       - "claude/**"
       - "codex/**"
+      # Release branches promote main → prod via a PR opened manually (base
+      # prod). Chúng bằng đúng main nên auto-pr's `gh pr create --base main`
+      # luôn fail "no commits between" → CI đỏ giả. Exclude để không kích hoạt.
+      - "!claude/merge-prod-release-**"
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Loại release branch (`claude/merge-prod-release-*`) khỏi trigger của `auto-pr.yml`.

**Vấn đề:** workflow `auto-pr.yml` chạy trên mọi push `claude/**` và cố `gh pr create --base main`. Release branch (promote main → prod, mở PR thủ công base=`prod`) **bằng đúng main** → GitHub từ chối "no commits between main and branch" → check `create-pr` đỏ giả mỗi lần release (vừa thấy ở PR #829).

**Fix:** thêm pattern phủ định `!claude/merge-prod-release-**` vào `on.push.branches`. GitHub Actions đánh giá pattern theo thứ tự, negative override positive đứng trước → release branch không kích hoạt workflow nữa.

## Test plan
- [ ] Release branch tiếp theo (`claude/merge-prod-release-N-*`) push lên → workflow `auto-pr` KHÔNG chạy → không còn check `create-pr` đỏ giả.
- [ ] Branch `claude/**` thường vẫn trigger auto-pr như cũ.

https://claude.ai/code/session_01WNEcbpiFSkXiq4aLXjvE1E