### PR TITLE
fix(deploy): don't source .env in admin build (exit 127 on VN strings)

### DIFF
--- a/scripts/rebuild-finance-prod.sh
+++ b/scripts/rebuild-finance-prod.sh
@@ -241,13 +241,13 @@ if [[ "${SKIP_ADMIN_BUILD:-0}" == "1" ]]; then
     log "⏭  SKIP_ADMIN_BUILD=1 — bỏ qua admin build (image sẽ giữ SPA hiện có)"
 elif [[ -f "$ADMIN_SRC_DIR/package.json" ]]; then
     (
-        set -a
-        # shellcheck disable=SC1090
-        source "$ENV_FILE"
-        set +a
-        # VITE_API_BASE là build-time config của frontend — lấy từ .env nếu có,
-        # nếu không dùng default. Operator nên set trong .env cho đúng domain prod.
-        export VITE_API_BASE="${VITE_API_BASE:-https://admin.betien.vn/api/admin}"
+        # VITE_API_BASE là build-time config DUY NHẤT frontend cần (vite chỉ
+        # inline biến prefix VITE_). KHÔNG `source .env`: file theo định dạng
+        # docker-compose env-file — chứa string tiếng Việt có dấu cách/không
+        # quote, nên bash sẽ cố thực thi chúng như lệnh (".env: line N: 'Tài':
+        # command not found" → exit 127). Trích đúng 1 key, an toàn mọi nội dung.
+        VITE_API_BASE_ENV="$(grep -E '^VITE_API_BASE=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d '\r')"
+        export VITE_API_BASE="${VITE_API_BASE_ENV:-https://admin.betien.vn/api/admin}"
         log "  VITE_API_BASE=$VITE_API_BASE"
         npm --prefix "$ADMIN_SRC_DIR" install
         npm --prefix "$ADMIN_SRC_DIR" run build


### PR DESCRIPTION
## Vấn đề (prod deploy bị chặn)

`bash scripts/rebuild-finance-prod.sh` fail ngay phase **admin-build**:

```
/home/evg-user/FinanceAssistant/.env: line 34: $'T\303\240i': command not found
❌ Deploy FAILED at phase: admin-build (exit=127)
```

Phase admin-build dùng `set -a; source "$ENV_FILE"; set +a` để lấy `VITE_API_BASE`. Nhưng `.env` theo **định dạng docker-compose env-file** (không phải bash script) và chứa các chuỗi nội dung tiếng Việt có dấu cách, không quote — ví dụ `...=Tài sản...`. Khi `source`, bash cố chạy `Tài` như một câu lệnh → `command not found` → exit 127, chặn **mọi** lần deploy prod.

## Fix

Frontend chỉ tiêu thụ `VITE_API_BASE` (vite chỉ inline biến prefix `VITE_`, đã verify trong `betien-admin/`). Thay vì `source` cả file, trích đúng 1 key một cách an toàn:

```bash
VITE_API_BASE_ENV="$(grep -E '^VITE_API_BASE=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d '\r')"
export VITE_API_BASE="${VITE_API_BASE_ENV:-https://admin.betien.vn/api/admin}"
```

- Không còn thực thi nội dung `.env` như bash → miễn nhiễm với mọi string tiếng Việt/ký tự đặc biệt.
- Giữ nguyên fallback default prod.
- `tr -d '\r'` chịu được file CRLF.

## Test plan
- [x] `bash -n` syntax OK
- [x] Mô phỏng `.env` có dòng `PERSONA_MSG=Tài sản...` → trích đúng URL, không lỗi
- [x] Key thiếu → rơi về default `https://admin.betien.vn/api/admin`
- [ ] Sau khi promote sang prod: `bash scripts/rebuild-finance-prod.sh` chạy hết phase admin-build, SPA vào image, `/admin/` load đúng

## Lưu ý routing
Bug nằm trên cả `main` lẫn `prod`. PR này sửa `main` (single source of truth). Cần một release PR `main → prod` tiếp theo để unblock deploy prod.

https://claude.ai/code/session_01WNEcbpiFSkXiq4aLXjvE1E