### PR TITLE
9th release: promote main to prod (2026-05-25) — fix admin-build .env source

### DIFF
--- a/scripts/rebuild-finance-prod.sh
+++ b/scripts/rebuild-finance-prod.sh
@@ -241,13 +241,13 @@ if [[ "${SKIP_ADMIN_BUILD:-0}" == "1" ]]; then
     log "⏭  SKIP_ADMIN_BUILD=1 — bỏ qua admin build (image sẽ giữ SPA hiện có)"
 elif [[ -f "$ADMIN_SRC_DIR/package.json" ]]; then
     (
-        set -a
-        # shellcheck disable=SC1090
-        source "$ENV_FILE"
-        set +a
-        # VITE_API_BASE là build-time config của frontend — lấy từ .env nếu có,
-        # nếu không dùng default. Operator nên set trong .env cho đúng domain prod.
-        export VITE_API_BASE="${VITE_API_BASE:-https://admin.betien.vn/api/admin}"
+        # VITE_API_BASE là build-time config DUY NHẤT frontend cần (vite chỉ
+        # inline biến prefix VITE_). KHÔNG `source .env`: file theo định dạng
+        # docker-compose env-file — chứa string tiếng Việt có dấu cách/không
+        # quote, nên bash sẽ cố thực thi chúng như lệnh (".env: line N: 'Tài':
+        # command not found" → exit 127). Trích đúng 1 key, an toàn mọi nội dung.
+        VITE_API_BASE_ENV="$(grep -E '^VITE_API_BASE=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d '\r')"
+        export VITE_API_BASE="${VITE_API_BASE_ENV:-https://admin.betien.vn/api/admin}"
         log "  VITE_API_BASE=$VITE_API_BASE"
         npm --prefix "$ADMIN_SRC_DIR" install
         npm --prefix "$ADMIN_SRC_DIR" run build


### PR DESCRIPTION
## 9th release — promote main → prod (2026-05-25)

Promote `main` (`984c212`) → `prod` (`9e516e4`).

### Nội dung release (content diff vs prod)

Chỉ mang sang prod thay đổi của **#831** — fix prod deploy bị chặn ở phase admin-build.

| File | Thay đổi |
|---|---|
| `scripts/rebuild-finance-prod.sh` | Bỏ `set -a; source .env` ở phase admin-build; trích đúng `VITE_API_BASE` an toàn |

→ **1 file changed, +7 / −7**

### Vì sao cần release này

`bash scripts/rebuild-finance-prod.sh` fail ngay phase admin-build:

```
.env: line 34: $'T\303\240i': command not found
❌ Deploy FAILED at phase: admin-build (exit=127)
```

`.env` theo định dạng docker-compose env-file (chứa string tiếng Việt không quote), nên `source` nó trong bash khiến shell chạy "Tài..." như câu lệnh → exit 127, chặn **mọi** lần deploy prod. #831 thay bằng trích đúng 1 key `VITE_API_BASE`.

### Lưu ý history

Sau #829 (dùng "Create a merge commit"), `prod` và `main` đã **chung gốc** (`merge-base = ddf13c0`). Release này là 3-way merge sạch, diff đúng 1 file — không còn nhiễu unrelated-history.

### Sau khi merge
- [ ] Trên prod: `git checkout prod && git pull --ff-only origin prod`
- [ ] `bash scripts/rebuild-finance-prod.sh` — verify chạy hết phase admin-build, admin SPA vào image, `/admin/` load đúng, working tree sạch

https://claude.ai/code/session_01WNEcbpiFSkXiq4aLXjvE1E

---
_Generated by [Claude Code](https://claude.ai/code/session_01WNEcbpiFSkXiq4aLXjvE1E)_