### PR TITLE
fix(deploy): build admin SPA inside Docker, drop host npm dependency

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -44,3 +44,10 @@ yarn-debug.log*
 # --- Build artifacts ---
 dist/
 build/
+
+# --- Admin SPA: artifacts dựng lại trong Docker (stage admin-build) ---
+# Patterns trên (`node_modules/`, `dist/`) chỉ match ở root context, KHÔNG
+# match nested. Loại tường minh để `COPY betien-admin/ ./` không kéo
+# node_modules/dist của host đè lên layer `npm install` đã cache.
+betien-admin/node_modules/
+betien-admin/dist/

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,3 +1,27 @@
+# =============================================================================
+# Stage 1: build admin SPA (betien-admin)
+# =============================================================================
+# Build SPA NGAY TRONG image — host prod KHÔNG cần node/npm (deploy chạy trong
+# namespace không có npm). Trước đây script build trên host rồi mới docker build;
+# cách đó fail "npm: command not found". Multi-stage chỉ cần docker trên host.
+FROM node:22-slim AS admin-build
+WORKDIR /admin
+
+# Cài deps trước (tách layer để cache khi source đổi mà deps không đổi).
+COPY betien-admin/package.json betien-admin/package-lock.json ./
+RUN npm install
+
+# Source + build. VITE_API_BASE là build-time config (vite chỉ inline VITE_*),
+# truyền vào qua compose build.args (đọc từ .env), fallback domain prod.
+COPY betien-admin/ ./
+ARG VITE_API_BASE=https://admin.betien.vn/api/admin
+ENV VITE_API_BASE=$VITE_API_BASE
+RUN npm run build
+# → /admin/dist
+
+# =============================================================================
+# Stage 2: backend runtime (Python)
+# =============================================================================
 FROM python:3.11-slim
 
 # Thiết lập thư mục làm việc gốc trong container
@@ -16,6 +40,11 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy toàn bộ nội dung thư mục FinanceAssistant vào /app
 # Điều này sẽ tạo ra cấu trúc /app/backend/... bên trong container
 COPY . .
+
+# Admin SPA đã build từ stage 1 → đúng nơi backend serve (_ADMIN_STATIC =
+# backend/static/admin, mount tại "/"). Đặt SAU `COPY . .` để ghi đè thư mục
+# rỗng/cũ từ context (backend/static/admin bị gitignore nên context không có).
+COPY --from=admin-build /admin/dist /app/backend/static/admin
 
 # Đảm bảo Python nhận diện thư mục /app để import được package backend
 ENV PYTHONPATH=/app

--- a/deploy/production/docker-compose.yml
+++ b/deploy/production/docker-compose.yml
@@ -51,6 +51,10 @@ services:
     build:
       context: ../..
       dockerfile: backend/Dockerfile
+      args:
+        # Build-time config cho admin SPA (stage `admin-build`). Nội suy từ
+        # repo-root .env vì `dc` chạy compose với `--env-file ../../.env`.
+        VITE_API_BASE: ${VITE_API_BASE:-https://admin.betien.vn/api/admin}
     container_name: finance-backend
     env_file:
       - ../../.env
@@ -78,6 +82,9 @@ services:
     build:
       context: ../..
       dockerfile: backend/Dockerfile
+      args:
+        # Cùng args với backend để chia sẻ build cache (cùng Dockerfile/context).
+        VITE_API_BASE: ${VITE_API_BASE:-https://admin.betien.vn/api/admin}
     container_name: finance-scheduler
     env_file:
       - ../../.env

--- a/scripts/rebuild-finance-prod.sh
+++ b/scripts/rebuild-finance-prod.sh
@@ -3,12 +3,13 @@
 # rebuild-finance-prod.sh — Production deploy (Docker-based)
 # =============================================================================
 # Pipeline:
-#   pre-flight → git pull → DB backup → docker compose down → build + up --wait
-#   → smoke test → admin SPA rebuild → cleanup → notify
+#   pre-flight → git pull → DB backup → admin-build check → docker compose down
+#   → build (admin SPA build TRONG image) + up --wait → smoke test → cleanup → notify
 #
 # Khác với deploy/production/deploy.sh (minimal): script này bổ sung
 # safety guards: DB snapshot trước migrate, rollback handler, Telegram notify,
-# admin SPA rebuild, image prune. Đây là entry point mặc định cho prod deploy.
+# image prune. Admin SPA được build trong Docker multi-stage (host không cần
+# npm). Đây là entry point mặc định cho prod deploy.
 #
 # Usage:
 #   bash scripts/rebuild-finance-prod.sh
@@ -20,7 +21,6 @@
 #   BACKEND_PORT      (default: 8002, mapped on host)
 #   HEALTH_TIMEOUT    (default: 120s)
 #   SKIP_BACKUP       (1 = bỏ qua DB snapshot — KHÔNG khuyến nghị)
-#   SKIP_ADMIN_BUILD  (1 = bỏ qua rebuild admin SPA)
 #   SKIP_PRUNE        (1 = bỏ qua docker image prune)
 # =============================================================================
 
@@ -226,38 +226,22 @@ else
     fi
 fi
 
-# ── [3/7] admin SPA build (PHẢI trước docker build) ────────────
-# backend/Dockerfile dùng `COPY . .` → SPA chỉ vào image nếu đã build SẴN vào
-# backend/static/admin TRƯỚC `docker build`. Build sau sẽ không lọt vào image.
-# KHÔNG dùng deploy_admin.sh: script đó cho kiến trúc systemctl+caddy cũ
-# (`systemctl restart betien-api`, `caddy reload`) — không áp dụng cho prod
-# Docker, nơi container ở bước [5] tự serve static. Migration + seed cũng chạy
-# trong container (alembic ở startup; seed_admin ở bước [6]).
-DEPLOY_PHASE="admin-build"
-step "[3/7] Build admin SPA → backend/static/admin (trước docker build)"
+# ── [3/7] admin SPA — build TRONG Docker (host không cần npm) ──
+# SPA build bằng multi-stage trong backend/Dockerfile (stage `admin-build`) rồi
+# COPY vào image ở bước [5]. Host CHỈ cần docker — KHÔNG cần node/npm (deploy
+# chạy trong namespace không có npm → cách build-trên-host cũ fail "npm: command
+# not found"). VITE_API_BASE truyền vào build qua compose build.args, nội suy từ
+# .env (dc dùng `--env-file`). Migration + seed vẫn chạy trong container
+# (alembic ở startup; seed_admin ở bước [6]).
+DEPLOY_PHASE="admin-build-check"
+step "[3/7] Admin SPA build trong Docker (host không cần npm)"
 ADMIN_SRC_DIR="$PROJECT_DIR/betien-admin"
-ADMIN_STATIC_DIR="$PROJECT_DIR/backend/static/admin"
-if [[ "${SKIP_ADMIN_BUILD:-0}" == "1" ]]; then
-    log "⏭  SKIP_ADMIN_BUILD=1 — bỏ qua admin build (image sẽ giữ SPA hiện có)"
-elif [[ -f "$ADMIN_SRC_DIR/package.json" ]]; then
-    (
-        # VITE_API_BASE là build-time config DUY NHẤT frontend cần (vite chỉ
-        # inline biến prefix VITE_). KHÔNG `source .env`: file theo định dạng
-        # docker-compose env-file — chứa string tiếng Việt có dấu cách/không
-        # quote, nên bash sẽ cố thực thi chúng như lệnh (".env: line N: 'Tài':
-        # command not found" → exit 127). Trích đúng 1 key, an toàn mọi nội dung.
-        VITE_API_BASE_ENV="$(grep -E '^VITE_API_BASE=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d '\r')"
-        export VITE_API_BASE="${VITE_API_BASE_ENV:-https://admin.betien.vn/api/admin}"
-        log "  VITE_API_BASE=$VITE_API_BASE"
-        npm --prefix "$ADMIN_SRC_DIR" install
-        npm --prefix "$ADMIN_SRC_DIR" run build
-    ) 2>&1 | tee -a "$LOG_FILE"
-    rm -rf "${ADMIN_STATIC_DIR:?}"/*
-    mkdir -p "$ADMIN_STATIC_DIR"
-    cp -R "$ADMIN_SRC_DIR/dist/." "$ADMIN_STATIC_DIR/"
-    log "Admin SPA → $ADMIN_STATIC_DIR (sẽ được COPY vào image ở bước [5])"
+if [[ -f "$ADMIN_SRC_DIR/package.json" ]]; then
+    VITE_API_BASE_ENV="$(grep -E '^VITE_API_BASE=' "$ENV_FILE" | head -n1 | cut -d= -f2- | tr -d '\r')"
+    log "  betien-admin/ sẽ được build trong image ở bước [5]"
+    log "  VITE_API_BASE=${VITE_API_BASE_ENV:-https://admin.betien.vn/api/admin} (truyền qua compose build.args)"
 else
-    log "ℹ️  $ADMIN_SRC_DIR/package.json không tồn tại — bỏ qua admin build"
+    log "ℹ️  $ADMIN_SRC_DIR/package.json không tồn tại — image sẽ không có admin SPA"
 fi
 
 # ── [4/7] compose down ─────────────────────────────────────────


### PR DESCRIPTION
## Vấn đề (prod deploy vẫn bị chặn sau #831/#832)

Sau khi sửa lỗi `source .env` (exit 127), deploy chạy tiếp tới bước build admin SPA rồi fail:

```
[3/7] Build admin SPA ...
  VITE_API_BASE=https://finance.nuitruc.ai/api/admin
scripts/rebuild-finance-prod.sh: line 252: npm: command not found
❌ Deploy FAILED at phase: admin-build (exit=127)
```

Deploy chạy trong **namespace không có npm** (node có ở `/usr/local/bin/node` nhưng npm không nằm trên PATH của namespace deploy). Cách cũ build SPA **trên host** trước `docker build` nên phụ thuộc npm trên host → không đáng tin.

## Fix — build SPA trong Docker (multi-stage)

| File | Thay đổi |
|---|---|
| `backend/Dockerfile` | Thêm stage `admin-build` (`node:22-slim`): `npm install` + `npm run build` betien-admin → `COPY --from` dist vào `backend/static/admin` ở stage Python |
| `deploy/production/docker-compose.yml` | `backend` + `scheduler` thêm `build.args.VITE_API_BASE` (nội suy từ `.env` vì `dc` dùng `--env-file`) |
| `scripts/rebuild-finance-prod.sh` | Bỏ build npm trên host ở bước [3]; giờ chỉ là bước kiểm tra/log. Bỏ override `SKIP_ADMIN_BUILD` (không còn áp dụng) |
| `.dockerignore` | Loại tường minh `betien-admin/node_modules/` + `dist/` (patterns gốc chỉ match root, không match nested) để source COPY không đè layer `npm install` |

→ Host **chỉ cần docker**. `VITE_API_BASE` truyền build-time qua compose build.args; backend serve SPA tại `/` từ `_ADMIN_STATIC = backend/static/admin` (mount sẵn có).

## Verify

- [x] `bash -n scripts/rebuild-finance-prod.sh` OK, không còn ref `ADMIN_STATIC_DIR`/`SKIP_ADMIN_BUILD`
- [x] compose YAML parse OK, `build.args.VITE_API_BASE` đúng ở cả backend + scheduler
- [x] `betien-admin/package-lock.json` tồn tại (cho `COPY` + `npm install`); vite outDir mặc định = `dist`
- [ ] ⚠️ **Chưa build thử được** — container dev này không có docker daemon. Verify thật khi prod chạy `bash scripts/rebuild-finance-prod.sh`: qua phase build, SPA vào image, `/admin/` load đúng

## Routing
Sửa trên `main`. Cần release PR `main → prod` tiếp theo để unblock deploy prod (history đã chung gốc từ #829 nên release sẽ sạch).

https://claude.ai/code/session_01WNEcbpiFSkXiq4aLXjvE1E