### PR TITLE
docs(agents): guardrails to stop agents from clobbering prod .env

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# AGENTS.md — Operating rules for automation agents
+
+Rules for **any** automation agent acting on this repo or the prod server:
+the OpenClaw Telegram bot (`finance-devops` skill), Claude Code, CI bots, etc.
+Read this before running shell commands or editing files. For architecture and
+coding conventions see [CLAUDE.md](CLAUDE.md).
+
+---
+
+## ⛔ NEVER touch `.env` — production secrets, NO backup
+
+- **`.env`** (repo root, and the prod copy at `$PROD_PROJECT_DIR/.env`) holds
+  real production secrets: DB password, API keys, Telegram bot token,
+  `ADMIN_JWT_SECRET`. It is **gitignored, dockerignored, and backed up
+  NOWHERE** — if it is overwritten or deleted, the secrets are gone for good.
+- ❌ NEVER create, overwrite, truncate, move, or delete `.env`.
+- ❌ NEVER run `cp .env.example .env`, `> .env`, `mv … .env`, `rm .env`, or any
+  command that writes `.env` — **not even to "initialize" or "set up" the
+  project**. This is exactly how the prod `.env` was once destroyed.
+- ✅ `.env.example` is a **key-name reference only** (placeholders, never real
+  values). If `.env` is missing or looks like the unfilled template, **STOP and
+  ask the admin** — do not attempt to recreate it.
+
+> Recovery note: a running container created with `env_file: .env` carries the
+> values in its `Config.Env` (`docker inspect <container>`). That is the only
+> fallback — do not destroy such a container before secrets are recovered.
+
+---
+
+## Destructive / irreversible actions — confirm first
+
+Get explicit admin confirmation **in the same request** before:
+
+- `rm -rf`, `git reset --hard`, `git push --force`, `git clean -f`
+- `docker volume rm`, deleting containers/volumes that hold data
+- `DROP TABLE` / destructive SQL — the DB has **no auto-revert** on migration;
+  treat every schema change as irreversible.
+
+When you hit an obstacle, find the root cause — do not bypass safety checks
+(`--no-verify`, force flags) or delete state to "make the error go away".
+
+---
+
+## Prod / deploy operations
+
+- Run prod operations **only** through the `finance-devops` skill scripts
+  (`openclaw-skills/finance-devops/scripts/*.sh`). Do not run ad-hoc commands
+  that mutate prod state (files, containers, volumes, config) outside them.
+- Only admins (`ADMIN_USER_IDS`) may trigger devops actions.
+- Deploys go `main → prod` via PR; never push substantive changes straight to
+  `main`/`prod`. See [CLAUDE.md](CLAUDE.md) → *Forbidden Actions*.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,8 @@
 ### 1. Clone & setup env
 
 ```bash
-cp .env.example .env
+# KHÔNG đè .env đã tồn tại — .env chứa secrets thật và KHÔNG có backup ở đâu cả.
+[ -f .env ] || cp .env.example .env
 # Điền credentials vào .env
 ```
 

--- a/openclaw-skills/finance-devops/SKILL.md
+++ b/openclaw-skills/finance-devops/SKILL.md
@@ -33,6 +33,20 @@ Script tự verify `OPENCLAW_USER_ID` (Telegram user_id do OpenClaw inject) matc
 SSH dùng key-based auth (không password). Key chỉ tồn tại trên server chạy
 OpenClaw bot, không bao giờ commit vào repo.
 
+## ⛔ Guardrails — thao tác file trên prod
+
+- **TUYỆT ĐỐI KHÔNG đụng `$PROD_PROJECT_DIR/.env`** — chứa secrets prod thật và
+  **KHÔNG có backup ở đâu cả**. Đè hoặc xóa = mất secrets vĩnh viễn.
+  - ❌ KHÔNG `cp .env.example .env`, `> .env`, `rm .env`, `mv … .env` — kể cả
+    để "khởi tạo" project. (Đây đúng là cách `.env` prod từng bị phá.)
+  - ✅ Nếu `.env` thiếu / giống template → **DỪNG, báo admin**, đừng tự tạo lại.
+    `.env.example` chỉ là tham chiếu tên key (placeholder, không có giá trị thật).
+- Chỉ chạy thao tác prod qua các script trong skill này (`deploy.sh`,
+  `status.sh`, `logs.sh`, `rollback.sh`). KHÔNG chạy lệnh ad-hoc làm thay đổi
+  state prod (xóa file/container/volume, sửa config) ngoài các script đó.
+- Hành động destructive (`rm -rf`, xóa container/volume, force-push) → confirm
+  với admin trước. Xem [AGENTS.md](../../AGENTS.md) cho quy tắc đầy đủ.
+
 ### Required env vars (set trên OpenClaw host)
 
 | Var | Ví dụ | Ghi chú |
@@ -50,8 +64,8 @@ OpenClaw bot, không bao giờ commit vào repo.
 bash scripts/deploy.sh
 ```
 SSH vào prod → chạy `scripts/rebuild-finance-prod.sh` → stream output về Telegram.
-Script đó tự lo: git pull, DB backup, docker compose down + build + up --wait,
-smoke test, admin SPA rebuild, rollback nếu fail.
+Script đó tự lo: git pull, DB backup, docker compose down + build + up --wait
+(admin SPA build TRONG Docker multi-stage ở bước build), smoke test, rollback nếu fail.
 
 **Lưu ý**: deploy chỉ chạy từ branch `prod` trên prod server. Nếu code chưa
 merge vào `prod`, deploy sẽ refuse.
@@ -114,14 +128,15 @@ Services:
 | pre-flight | env keys, dirty tree, branch check | abort, no changes |
 | git-pull | fetch + ff-only merge | abort, no changes |
 | db-backup | pg_dump qua docker exec → `.backups/` | abort, no changes |
-| admin-build | npm + vite build → `backend/static/admin` (**trước** docker build, để `COPY . .` bake vào image) | abort, services running |
+| admin-build | check/log (SPA build TRONG Docker, không build trên host) | abort, services running |
 | compose-down | graceful tear down | abort, manual recovery |
-| compose-up | build + `up -d --wait` | **rollback** (rebuild old SHA) |
+| compose-up | build (gồm admin SPA build trong image) + `up -d --wait` | **rollback** (rebuild old SHA) |
 | smoke-test | /health, alembic current, redis ping, seed_admin (idempotent) | **rollback** |
 | cleanup | docker image prune, log rotation | warn only |
 
-> **Lưu ý kiến trúc:** admin SPA phải build **trước** `docker build` (không
-> phải sau), vì `backend/Dockerfile` dùng `COPY . .` để đưa
-> `backend/static/admin` vào image. Script **không** dùng `deploy_admin.sh`
-> (script đó cho kiến trúc systemctl+caddy cũ). `backend/static/admin/` đã được
-> gitignore nên build artifact không làm bẩn working tree.
+> **Lưu ý kiến trúc:** admin SPA được build **trong Docker multi-stage**
+> (`backend/Dockerfile` stage `admin-build`: `node:22-slim` chạy `npm install`
+> + `vite build`, rồi `COPY --from` dist vào `backend/static/admin`). Host
+> **chỉ cần docker** — không cần node/npm (deploy chạy trong namespace không có
+> npm). `VITE_API_BASE` truyền build-time qua compose `build.args` (nội suy từ
+> `.env`). Script **không** dùng `deploy_admin.sh` (kiến trúc systemctl+caddy cũ).


### PR DESCRIPTION
## Bối cảnh

Một automation agent (OpenClaw bot) đã phá mất `.env` prod khi chạy `cp .env.example .env` để "khởi tạo" project. `.env` chứa secrets thật (`POSTGRES_PASSWORD`, API keys, bot token, `ADMIN_JWT_SECRET`) và **không có backup ở đâu** → mất giá trị. Đã search toàn repo: không script nào tự ghi `.env`; foot-gun duy nhất là dòng `cp .env.example .env` trong README mà agent làm theo.

## Hardening lớp docs (theo lựa chọn)

| File | Thay đổi |
|---|---|
| `AGENTS.md` (mới) | Quy tắc cho mọi automation agent: **KHÔNG tạo/đè/xóa `.env`**; `.env.example` chỉ là tham chiếu tên key; confirm hành động destructive; chỉ chạy prod ops qua skill `finance-devops`. Kèm ghi chú khôi phục secrets từ `docker inspect` container. |
| `openclaw-skills/finance-devops/SKILL.md` | Thêm mục **⛔ Guardrails — thao tác file trên prod**. Đồng thời cập nhật mô tả admin-build đã lỗi thời (SPA giờ build trong Docker multi-stage sau #833). |
| `README.md` | `cp .env.example .env` → `[ -f .env ] || cp .env.example .env` — lệnh trong docs không bao giờ đè `.env` đã có. |

## Lưu ý
- Đây là **lớp mềm** (agent đọc chỉ dẫn). Để bảo vệ cứng, nên làm thêm OS-level trên prod: `sudo chattr +i .env` (bất biến — deploy chỉ đọc nên không ảnh hưởng). Chưa đưa vào lần này theo yêu cầu.
- Devops scripts (`status/logs/rollback.sh`) chỉ **đọc** `.env` qua `--env-file`, không ghi — không phải thủ phạm.

## Test plan
- [x] Không còn ref admin-build lỗi thời trong SKILL.md
- [x] README copy idempotent
- [x] AGENTS.md nêu rõ quy tắc .env + khôi phục

https://claude.ai/code/session_01WNEcbpiFSkXiq4aLXjvE1E