### PR TITLE
Add credit-card list and inline add-card wizard from Expense menu

### DIFF
--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -193,6 +193,19 @@ async def handle_transaction_callback(
 
     if data.startswith("txsrc:") or data.startswith("txsrc_wallet:"):
         return await _handle_source_selection_callback(db, callback_query)
+    if data == "expense:credit:add":
+        from backend.bot.handlers.credit_card_entry import start_credit_card_create
+
+        from_user = callback_query.get("from") or {}
+        telegram_id = from_user.get("id")
+        message = callback_query.get("message") or {}
+        chat_id = message.get("chat", {}).get("id")
+        user = await get_user_by_telegram_id(db, telegram_id) if telegram_id else None
+        if not user or chat_id is None:
+            return True
+        await start_credit_card_create(db, chat_id, user)
+        await answer_callback(callback_query["id"])
+        return True
 
     prefix, args = parse_callback(data)
 

--- a/backend/bot/handlers/credit_card_entry.py
+++ b/backend/bot/handlers/credit_card_entry.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+from decimal import Decimal
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.bot.formatters.money import format_money_full
+from backend.schemas.credit_card import CreditCardCreate
+from backend.services import wizard_service
+from backend.services.credit_card_service import create_credit_card, list_credit_cards
+from backend.services.dashboard_service import get_user_by_telegram_id
+from backend.services.telegram_service import send_message
+
+FLOW_CREDIT_CARD_ADD = "credit_card_add"
+
+
+def _credit_card_footer_keyboard() -> dict:
+    return {
+        "inline_keyboard": [
+            [{"text": "+ Thêm tài sản khác", "callback_data": "expense:credit:add"}],
+            [{"text": "Xong", "callback_data": "menu:expenses"}],
+            [{"text": "Huỷ tài sản vừa nhập", "callback_data": "expense:credit:undo_last"}],
+        ]
+    }
+
+
+async def show_credit_cards_list(db: AsyncSession, chat_id: int, user) -> None:
+    cards = await list_credit_cards(db, user.id)
+    if not cards:
+        text = "💳 *Thẻ tín dụng*\n\nBạn chưa có thẻ tín dụng nào."
+    else:
+        lines = ["💳 *Danh sách thẻ tín dụng*"]
+        for idx, card in enumerate(cards, start=1):
+            lines.append(
+                f"\n{idx}. *{card.bank_name}*"
+                f"\n- Hạn mức: {format_money_full(float(Decimal(str(card.debt_balance or 0))))}"
+                f"\n- Ngày thanh toán: {card.closing_date}"
+            )
+        text = "\n".join(lines)
+
+    await send_message(
+        chat_id=chat_id,
+        text=text,
+        parse_mode="Markdown",
+        reply_markup={
+            "inline_keyboard": [
+                [{"text": "+ Thêm thẻ tín dụng", "callback_data": "expense:credit:add"}],
+                [{"text": "Quay về", "callback_data": "menu:expenses"}],
+            ]
+        },
+    )
+
+
+async def start_credit_card_create(db: AsyncSession, chat_id: int, user) -> None:
+    await wizard_service.start_flow(
+        db,
+        user.id,
+        FLOW_CREDIT_CARD_ADD,
+        step="bank_name",
+        draft={},
+    )
+    await send_message(
+        chat_id=chat_id,
+        text="🏦 <b>Ngân hàng phát hành?</b> (Ví dụ: MSB, BIDV, Vietinbank...)",
+        parse_mode="HTML",
+    )
+
+
+async def handle_credit_card_text_input(db: AsyncSession, message: dict) -> bool:
+    text = (message.get("text") or "").strip()
+    if not text:
+        return False
+    chat_id = message["chat"]["id"]
+    telegram_id = (message.get("from") or {}).get("id")
+    user = await get_user_by_telegram_id(db, telegram_id)
+    if user is None or not user.wizard_state:
+        return False
+    flow = wizard_service.get_flow(user.wizard_state)
+    if flow != FLOW_CREDIT_CARD_ADD:
+        return False
+    step = wizard_service.get_step(user.wizard_state)
+    draft = wizard_service.get_draft(user.wizard_state)
+
+    if step == "bank_name":
+        bank = text.strip()
+        if not bank:
+            await send_message(chat_id=chat_id, text="Bạn nhập tên ngân hàng giúp mình nhé.")
+            return True
+        await wizard_service.update_step(db, user.id, step="credit_limit", draft_patch={"bank_name": bank})
+        await send_message(chat_id=chat_id, text="💰 <b>Hạn mức tín dụng?</b> (Ví dụ: 100tr, 250 triệu...)", parse_mode="HTML")
+        return True
+
+    if step == "credit_limit":
+        from backend.wealth.amount_parser import parse_amount
+
+        limit = parse_amount(text)
+        if limit is None or limit <= 0:
+            await send_message(chat_id=chat_id, text="Bạn nhập hạn mức hợp lệ nhé. Ví dụ: <code>100tr</code>", parse_mode="HTML")
+            return True
+        await wizard_service.update_step(db, user.id, step="closing_date", draft_patch={"credit_limit": float(limit)})
+        await send_message(chat_id=chat_id, text="📅 <b>Ngày thanh toán hàng tháng?</b> (từ 1 đến 31)", parse_mode="HTML")
+        return True
+
+    if step == "closing_date":
+        if not text.isdigit() or not (1 <= int(text) <= 31):
+            await send_message(chat_id=chat_id, text="Bạn nhập ngày từ <code>1</code> đến <code>31</code> nhé.", parse_mode="HTML")
+            return True
+        bank_name = (draft.get("bank_name") or "").strip()
+        try:
+            card = await create_credit_card(
+                db,
+                user.id,
+                CreditCardCreate(
+                    bank_name=bank_name,
+                    closing_date=int(text),
+                    debt_balance=float(draft.get("credit_limit") or 0),
+                ),
+            )
+        except ValueError:
+            await send_message(chat_id=chat_id, text="Tên ngân hàng này đã tồn tại. Bạn thử tên khác nhé.")
+            return True
+        await wizard_service.clear(db, user.id)
+        await send_message(
+            chat_id=chat_id,
+            text=(
+                "✅ Đã thêm thẻ tín dụng thành công:\n"
+                f"- Ngân hàng: <b>{card.bank_name}</b>\n"
+                f"- Hạn mức: <b>{format_money_full(float(Decimal(str(card.debt_balance or 0))))}</b>\n"
+                f"- Ngày thanh toán: <b>{card.closing_date}</b>"
+            ),
+            parse_mode="HTML",
+            reply_markup=_credit_card_footer_keyboard(),
+        )
+        return True
+
+    return False

--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -1105,27 +1105,10 @@ async def _action_expenses_ocr_prompt(
 async def _action_expenses_credit_cards(
     *, db: AsyncSession, user: User, chat_id: int, message_id: int | None
 ) -> None:
-    """Guide user to use the new credit-card source flow safely and quickly."""
-    title = get_action_copy("action_expenses_credit_cards", "title")
-    body = get_action_copy("action_expenses_credit_cards", "body")
-    text = f"{title}\n\n{body}"
-    await send_message(
-        chat_id=chat_id,
-        text=text,
-        parse_mode="Markdown",
-        reply_markup={
-            "inline_keyboard": [
-                [
-                    {
-                        "text": get_action_copy(
-                            "action_expenses_credit_cards", "back_button"
-                        ),
-                        "callback_data": "menu:expenses",
-                    }
-                ]
-            ]
-        },
-    )
+    """Render all credit cards + actions to add or go back."""
+    from backend.bot.handlers.credit_card_entry import show_credit_cards_list
+
+    await show_credit_cards_list(db, chat_id, user)
     analytics.track(
         "menu_action",
         user_id=user.id,

--- a/backend/tests/test_credit_card_entry_handler.py
+++ b/backend/tests/test_credit_card_entry_handler.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_show_credit_cards_list_has_buttons(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    sent = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.list_credit_cards",
+        AsyncMock(return_value=[]),
+    )
+
+    await credit_card_entry.show_credit_cards_list(db=None, chat_id=1, user=SimpleNamespace(id=1))
+    rows = sent["reply_markup"]["inline_keyboard"]
+    assert rows[0][0]["callback_data"] == "expense:credit:add"
+    assert rows[1][0]["callback_data"] == "menu:expenses"
+
+
+@pytest.mark.asyncio
+async def test_credit_card_wizard_happy_path(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    user = SimpleNamespace(id=1, wizard_state={"flow": credit_card_entry.FLOW_CREDIT_CARD_ADD, "step": "bank_name", "draft": {}})
+    sent = []
+
+    async def fake_send_message(*args, **kwargs):
+        sent.append(kwargs.get("text") if kwargs else args[1])
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr("backend.bot.handlers.credit_card_entry.get_user_by_telegram_id", AsyncMock(return_value=user), raising=False)
+
+    async def fake_update_step(db, user_id, step, draft_patch):
+        user.wizard_state["step"] = step
+        user.wizard_state["draft"].update(draft_patch)
+
+    monkeypatch.setattr("backend.bot.handlers.credit_card_entry.wizard_service.update_step", fake_update_step)
+    monkeypatch.setattr("backend.bot.handlers.credit_card_entry.wizard_service.clear", AsyncMock())
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.create_credit_card",
+        AsyncMock(return_value=SimpleNamespace(bank_name="MSB", debt_balance=100000000, closing_date=20)),
+    )
+
+    msg = {"chat": {"id": 1}, "from": {"id": 1}}
+    assert await credit_card_entry.handle_credit_card_text_input(None, {**msg, "text": "MSB"})
+    assert await credit_card_entry.handle_credit_card_text_input(None, {**msg, "text": "100tr"})
+    assert await credit_card_entry.handle_credit_card_text_input(None, {**msg, "text": "20"})
+    assert any("Đã thêm thẻ tín dụng thành công" in s for s in sent)

--- a/backend/workers/telegram_worker.py
+++ b/backend/workers/telegram_worker.py
@@ -74,6 +74,7 @@ async def route_update(data: dict) -> None:
     from backend.bot.handlers import about_handler as about_handlers
     from backend.bot.handlers import asset_entry as asset_entry_handlers
     from backend.bot.handlers import briefing as briefing_handlers
+    from backend.bot.handlers import credit_card_entry as credit_card_entry_handlers
     from backend.bot.handlers import goal_entry as goal_entry_handlers
     from backend.bot.handlers import income_entry as income_entry_handlers
     from backend.bot.handlers import life_event_entry as life_event_entry_handlers
@@ -118,6 +119,7 @@ async def route_update(data: dict) -> None:
                     dashboard_service=dashboard_service,
                     handle_report_command=handle_report_command,
                     handle_text_message=handle_text_message,
+                    credit_card_entry_handlers=credit_card_entry_handlers,
                     OnboardingStep=OnboardingStep,
                     analytics=analytics,
                 )
@@ -194,6 +196,7 @@ async def _handle_message(
     dashboard_service,
     handle_report_command,
     handle_text_message,
+    credit_card_entry_handlers,
     OnboardingStep,
     analytics,
 ):
@@ -575,6 +578,11 @@ async def _handle_message(
         # year / amount / duration replies while a life_event_* flow is
         # active so the user's "2028" doesn't reach the NL expense parser.
         consumed = await life_event_entry_handlers.handle_life_event_text_input(
+            db, message
+        )
+        if consumed:
+            return resolved_user.id
+        consumed = await credit_card_entry_handlers.handle_credit_card_text_input(
             db, message
         )
         if consumed:


### PR DESCRIPTION
### Motivation
- Replace the placeholder Expense → Credit Cards screen with a real list view and allow adding a new credit card immediately from that menu without redirecting to the main card page.
- Provide an inline 4-step wizard for creating a new credit card so text replies drive the same smooth flow as other asset wizards.

### Description
- Added a new handler module `backend/bot/handlers/credit_card_entry.py` implementing `show_credit_cards_list`, `start_credit_card_create`, and `handle_credit_card_text_input` to list cards and run the 4-step wizard (`bank_name`, `credit_limit`, `closing_date`, success message) and a footer keyboard with `+ Thêm tài sản khác`, `Xong`, and `Huỷ tài sản vừa nhập`.
- Wired the Expenses submenu to render the new list by calling `show_credit_cards_list` from `backend/bot/handlers/menu_handler.py`.
- Routed the inline button `expense:credit:add` in `backend/bot/handlers/callbacks.py` to open the wizard immediately via `start_credit_card_create`.
- Hooked the wizard text handler into the Telegram worker by passing `credit_card_entry_handlers` into `_handle_message` and calling `handle_credit_card_text_input` when `wizard_state` is active in `backend/workers/telegram_worker.py`.
- Added unit tests in `backend/tests/test_credit_card_entry_handler.py` covering the list buttons and the happy-path wizard flow, and replaced a money formatter import to use `format_money_full` for display.
- Commit message contains `Closes #NNN`.

### Testing
- Ran `pytest -q backend/tests/test_credit_card_entry_handler.py` and the suite passed: 2 tests, 0 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1407b9b8a0832f839a59dbf1a32d27)