### PR TITLE
Unify LLM token pricing into a single source of truth

### DIFF
--- a/backend/agent/limits.py
+++ b/backend/agent/limits.py
@@ -49,14 +49,49 @@ COST_HARD_LIMIT_DAILY_USD = 20.0
 
 
 # ---- Pricing (USD per 1M tokens) -----------------------------------
-# Mid-2026 list prices. If they drift far enough that the daily-cost
-# math becomes inaccurate, update here — single source of truth.
+# Mid-2026 list prices. SINGLE SOURCE OF TRUTH for token pricing across
+# the whole codebase. Both the global daily kill-switch
+# (``estimate_cost_usd`` below) and the per-user monthly budget
+# (``budget_service.estimate_call_cost_vnd``, which imports these same
+# numbers) derive from these constants, so the USD and VND ledgers can
+# never quote different rates for the same provider. The intent-layer
+# Tier 1 analytics cost (``classifier/llm_based.py``) also calls
+# ``estimate_cost_usd`` rather than redeclaring rates. If a vendor
+# changes their rate card, edit ONLY here.
 DEEPSEEK_PRICE_INPUT_PER_M = 0.14
 DEEPSEEK_PRICE_OUTPUT_PER_M = 0.28
 GROQ_PRICE_INPUT_PER_M = 0.59
 GROQ_PRICE_OUTPUT_PER_M = 0.79
 CLAUDE_SONNET_PRICE_INPUT_PER_M = 3.0
 CLAUDE_SONNET_PRICE_OUTPUT_PER_M = 15.0
+
+# Canonical pricing table keyed by model family. ``estimate_cost_usd``
+# resolves a model string to one of these keys; ``PROVIDER_TO_PRICING_KEY``
+# maps the provider labels used by ``budget_service`` onto the same keys.
+MODEL_PRICING_USD_PER_M: dict[str, tuple[float, float]] = {
+    "deepseek": (DEEPSEEK_PRICE_INPUT_PER_M, DEEPSEEK_PRICE_OUTPUT_PER_M),
+    "groq": (GROQ_PRICE_INPUT_PER_M, GROQ_PRICE_OUTPUT_PER_M),
+    "sonnet": (CLAUDE_SONNET_PRICE_INPUT_PER_M, CLAUDE_SONNET_PRICE_OUTPUT_PER_M),
+}
+
+
+def resolve_pricing_key(model: str) -> str | None:
+    """Map a model string to a ``MODEL_PRICING_USD_PER_M`` key.
+
+    ``deepseek-v4-flash`` / ``deepseek-reasoner`` match by prefix; Groq's
+    Llama family matches the ``llama``/``groq`` substring; Anthropic's
+    versioned IDs (``claude-sonnet-4-6``, ``claude-sonnet-4-5-20250929``)
+    match the ``claude``/``sonnet`` substring — 4.5 and 4.6 share the
+    same $3/$15 list price. Unknown models return ``None``.
+    """
+    m = (model or "").lower()
+    if m.startswith("deepseek"):
+        return "deepseek"
+    if "llama" in m or "groq" in m:
+        return "groq"
+    if "sonnet" in m or "claude" in m:
+        return "sonnet"
+    return None
 
 
 def estimate_cost_usd(
@@ -67,27 +102,14 @@ def estimate_cost_usd(
 ) -> float:
     """Return the dollar cost of a single LLM call.
 
-    ``model`` is matched as a prefix so ``deepseek-v4-flash`` /
-    ``deepseek-reasoner`` all map to the same pricing. Groq's Llama
-    family is matched by the ``llama`` substring; Anthropic's versioned
-    model IDs (``claude-sonnet-4-6``, ``claude-sonnet-4-5-20250929``)
-    match the ``claude`` substring, and Sonnet 4.5 and 4.6 share the
-    same $3/$15 per-1M list price so the same constants apply.
+    Rates come from :data:`MODEL_PRICING_USD_PER_M`. Unknown models
+    return ``0.0`` so a typo can never over-bill the kill-switch.
     """
-    m = (model or "").lower()
-    if m.startswith("deepseek"):
-        return (
-            input_tokens / 1_000_000 * DEEPSEEK_PRICE_INPUT_PER_M
-            + output_tokens / 1_000_000 * DEEPSEEK_PRICE_OUTPUT_PER_M
-        )
-    if "llama" in m or "groq" in m:
-        return (
-            input_tokens / 1_000_000 * GROQ_PRICE_INPUT_PER_M
-            + output_tokens / 1_000_000 * GROQ_PRICE_OUTPUT_PER_M
-        )
-    if "sonnet" in m or "claude" in m:
-        return (
-            input_tokens / 1_000_000 * CLAUDE_SONNET_PRICE_INPUT_PER_M
-            + output_tokens / 1_000_000 * CLAUDE_SONNET_PRICE_OUTPUT_PER_M
-        )
-    return 0.0
+    key = resolve_pricing_key(model)
+    if key is None:
+        return 0.0
+    input_per_m, output_per_m = MODEL_PRICING_USD_PER_M[key]
+    return (
+        input_tokens / 1_000_000 * input_per_m
+        + output_tokens / 1_000_000 * output_per_m
+    )

--- a/backend/intent/classifier/llm_based.py
+++ b/backend/intent/classifier/llm_based.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.agent.limits import estimate_cost_usd
 from backend.config import get_settings
 from backend.intent.intents import (
     CLASSIFIER_LLM,
@@ -42,13 +43,6 @@ from backend.services.llm_service import LLMError, call_llm
 logger = logging.getLogger(__name__)
 settings = get_settings()
 
-
-# Groq pricing (USD per 1M tokens) — used to attribute cost to the
-# ``llm_classifier_call`` analytics event. Pricing as of 2026-05 for
-# llama-3.3-70b-versatile. Update here when Groq changes their rate
-# card; the test for max-cost-per-call will catch silent drift.
-_GROQ_INPUT_USD_PER_1M = 0.59
-_GROQ_OUTPUT_USD_PER_1M = 0.79
 
 # Tier 1 has to respond in <2s wall-clock from the pipeline's perspective.
 # Groq Llama 3.3 70B typically returns in 300-700ms; we cap at 3s to give
@@ -281,12 +275,18 @@ class LLMClassifier:
         # Vietnamese mixed-script text in practice.
         input_tokens = max(1, len(prompt) // 4)
         output_tokens = max(1, len(response) // 4)
+        # Cost comes from the shared pricing table (Groq rates) rather
+        # than redeclaring per-1M constants here — keeps the analytics
+        # attribution in lockstep with the budget/kill-switch ledgers.
         cost = (
-            input_tokens * _GROQ_INPUT_USD_PER_1M / 1_000_000
-            + output_tokens * _GROQ_OUTPUT_USD_PER_1M / 1_000_000
+            0.0
+            if cache_hit
+            else estimate_cost_usd(
+                model=settings.groq_model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
         )
-        if cache_hit:
-            cost = 0.0
         return LLMCallStats(
             input_tokens=input_tokens,
             output_tokens=output_tokens,

--- a/backend/services/cost/budget_service.py
+++ b/backend/services/cost/budget_service.py
@@ -24,6 +24,12 @@ from decimal import Decimal
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from backend.agent.limits import (
+    DEEPSEEK_PRICE_INPUT_PER_M,
+    DEEPSEEK_PRICE_OUTPUT_PER_M,
+    GROQ_PRICE_INPUT_PER_M,
+    GROQ_PRICE_OUTPUT_PER_M,
+)
 from backend.models.cost_budget import (
     DEFAULT_BUDGET_VND,
     LLMCostLog,
@@ -34,21 +40,34 @@ from backend.models.cost_budget import (
 logger = logging.getLogger(__name__)
 
 
-# Pricing — VND per call/unit. Conservative for v1; refined post-launch.
-# DeepSeek is OpenAI-compatible; tokens_in + tokens_out get the same
-# rate to keep math simple (the diff is < 5% of the call cost).
+# Pricing — VND per call/unit. Token rates are sourced from
+# ``backend.agent.limits`` (the single source of truth shared with the
+# USD daily kill-switch) and converted to VND here, so the two ledgers
+# can never quote a different per-token rate. We build Decimal per-token
+# rates from those floats via ``str()`` to stay in exact Decimal math
+# (money is always Decimal, never float).
 USD_VND_RATE = Decimal(os.environ.get("USD_VND_RATE", "25000"))
 
-# DeepSeek V4-Flash: roughly $0.27 per 1M tokens (blended in+out for v1).
-# Cache-hit prices not modeled — LLMCache returns cached responses
-# without hitting the API (zero upstream cost).
-_DEEPSEEK_USD_PER_TOKEN = Decimal("0.27") / Decimal("1_000_000")
+# DeepSeek V4-Flash — split input/output ($0.14 / $0.28 per 1M), matching
+# the USD kill-switch. Cache-hit prices not modeled — LLMCache returns
+# cached responses without hitting the API (zero upstream cost).
+_DEEPSEEK_INPUT_USD_PER_TOKEN = (
+    Decimal(str(DEEPSEEK_PRICE_INPUT_PER_M)) / Decimal("1_000_000")
+)
+_DEEPSEEK_OUTPUT_USD_PER_TOKEN = (
+    Decimal(str(DEEPSEEK_PRICE_OUTPUT_PER_M)) / Decimal("1_000_000")
+)
 # Groq Llama 3.3 70B — $0.59 input / $0.79 output per 1M tokens. Track
 # input + output separately because the split matters for Tier 1
 # (short prompts, very short JSON responses).
-_GROQ_INPUT_USD_PER_TOKEN = Decimal("0.59") / Decimal("1_000_000")
-_GROQ_OUTPUT_USD_PER_TOKEN = Decimal("0.79") / Decimal("1_000_000")
-# Claude Sonnet OCR — ~$0.03 per page using p50 token counts.
+_GROQ_INPUT_USD_PER_TOKEN = (
+    Decimal(str(GROQ_PRICE_INPUT_PER_M)) / Decimal("1_000_000")
+)
+_GROQ_OUTPUT_USD_PER_TOKEN = (
+    Decimal(str(GROQ_PRICE_OUTPUT_PER_M)) / Decimal("1_000_000")
+)
+# Claude Sonnet OCR — ~$0.03 per page using p50 token counts. This is a
+# per-page cost model (not token-based), so it lives only here.
 _CLAUDE_PER_PAGE_USD = Decimal("0.03")
 # Whisper at $0.006 per minute → per-second.
 _WHISPER_PER_SECOND_USD = Decimal("0.006") / Decimal("60")
@@ -90,7 +109,8 @@ def estimate_call_cost_vnd(
     """Best-effort VND cost estimate from raw call params.
 
     Operations:
-      - DeepSeek: (tokens_in + tokens_out) at one rate; OK for budget.
+      - DeepSeek: split input/output rates ($0.14 / $0.28 per 1M).
+      - Groq: split input/output rates ($0.59 / $0.79 per 1M).
       - Claude OCR: per-page rate × page_count.
       - Whisper: per-second × audio_seconds.
 
@@ -99,8 +119,10 @@ def estimate_call_cost_vnd(
     """
     p = provider.lower()
     if p == "deepseek":
-        total_tokens = Decimal(tokens_in + tokens_out)
-        cost_usd = total_tokens * _DEEPSEEK_USD_PER_TOKEN
+        cost_usd = (
+            Decimal(tokens_in) * _DEEPSEEK_INPUT_USD_PER_TOKEN
+            + Decimal(tokens_out) * _DEEPSEEK_OUTPUT_USD_PER_TOKEN
+        )
         return (cost_usd * USD_VND_RATE).quantize(Decimal("0.0001"))
     if p == "groq":
         cost_usd = (

--- a/backend/tests/test_cost_pricing.py
+++ b/backend/tests/test_cost_pricing.py
@@ -47,13 +47,16 @@ def test_estimate_call_cost_vnd_groq_zero_tokens_is_zero():
     assert estimate_call_cost_vnd(provider="groq") == Decimal("0.0000")
 
 
-def test_estimate_call_cost_vnd_deepseek_path_unchanged():
-    # DeepSeek uses a blended single rate; verify it still computes
-    # against tokens_in + tokens_out and the existing rate.
+def test_estimate_call_cost_vnd_deepseek_splits_input_output():
+    # DeepSeek now uses split input/output rates ($0.14 / $0.28 per 1M),
+    # matching the USD kill-switch — no more blended $0.27.
     cost = estimate_call_cost_vnd(
         provider="deepseek", tokens_in=1000, tokens_out=500
     )
-    expected_usd = Decimal(1500) * (Decimal("0.27") / Decimal("1_000_000"))
+    expected_usd = (
+        Decimal(1000) * (Decimal("0.14") / Decimal("1_000_000"))
+        + Decimal(500) * (Decimal("0.28") / Decimal("1_000_000"))
+    )
     expected_vnd = (expected_usd * USD_VND_RATE).quantize(Decimal("0.0001"))
     assert cost == expected_vnd
 
@@ -123,3 +126,50 @@ def test_estimate_cost_usd_sonnet_4_5_legacy_id_still_priced():
 
 def test_estimate_cost_usd_unknown_model_returns_zero():
     assert estimate_cost_usd(model="mystery", input_tokens=999, output_tokens=999) == 0.0
+
+
+# ----- cross-system consistency -------------------------------------
+# These guard the whole point of the unification: the per-user VND
+# ledger (System B) and the USD daily kill-switch (System A) must never
+# quote a different per-token rate for the same provider.
+
+
+@pytest.mark.parametrize(
+    ("provider", "model"),
+    [
+        ("deepseek", "deepseek-v4-flash"),
+        ("groq", "llama-3.3-70b-versatile"),
+    ],
+)
+def test_vnd_ledger_matches_usd_killswitch(provider, model):
+    tokens_in, tokens_out = 1234, 567
+    vnd_direct = estimate_call_cost_vnd(
+        provider=provider, tokens_in=tokens_in, tokens_out=tokens_out
+    )
+    usd = estimate_cost_usd(
+        model=model, input_tokens=tokens_in, output_tokens=tokens_out
+    )
+    vnd_from_usd = Decimal(str(usd)) * USD_VND_RATE
+    # Both derive from the same per-1M constants; any gap is sub-VND
+    # float/Decimal rounding, not a rate divergence.
+    assert abs(vnd_direct - vnd_from_usd) < Decimal("0.01")
+
+
+# ----- live model-string coverage -----------------------------------
+# Every model identifier actually wired into the agent stack must
+# resolve to a non-zero rate, or its spend silently drops to the $0
+# unknown-model branch. Update this list when a tier swaps models.
+
+
+@pytest.mark.parametrize(
+    "model",
+    [
+        "deepseek-v4-flash",
+        "llama-3.3-70b-versatile",
+        "claude-sonnet-4-6",
+        "claude-sonnet-4-5-20250929",
+    ],
+)
+def test_every_live_model_string_is_priced(model):
+    cost = estimate_cost_usd(model=model, input_tokens=1000, output_tokens=1000)
+    assert cost > 0.0


### PR DESCRIPTION
## Summary

The codebase ran two parallel cost systems with **independently declared** token rates:

- **System A** — global daily kill-switch (`limits.estimate_cost_usd`, USD, split input/output), covering Tier 2/3 direct SDK calls.
- **System B** — per-user monthly budget (`budget_service.estimate_call_cost_vnd`, VND, provider-based) via `tracked_call`, covering all `call_llm` tasks (Tier 1 classifier + categorize + feedback + storytelling + report_text).

They could (and did) quote different rates: DeepSeek was priced at a **blended $0.27/1M** in System B but **split $0.14/$0.28** in System A — up to ~45% divergence on input-heavy calls. Groq rates were triplicated across `limits.py`, `budget_service.py`, and the Tier 1 classifier.

This PR makes `backend/agent/limits.py` the single source of truth for token pricing.

- Token rates (USD per 1M, split input/output) live only in `limits.py` via `MODEL_PRICING_USD_PER_M` + `resolve_pricing_key`.
- `budget_service` imports those numbers and builds its Decimal per-token rates from them (money stays `Decimal`, never `float`).
- **DeepSeek switches from blended $0.27 to split $0.14/$0.28**, matching the kill-switch.
- Tier 1 classifier (`llm_based.py`) drops its duplicate Groq constants and calls `estimate_cost_usd` for analytics attribution.
- Claude OCR (per-page) and Whisper (per-second) cost models are non-token and remain local to `budget_service`.

Latency: zero impact — pricing is O(1) in-memory dict arithmetic, and budget recording already runs off the user's critical path (in `tracked_call`'s `finally`).

Ledger unification (merging the two spend ledgers) is intentionally **out of scope** here and deferred to a future phase.

## Test plan

- [x] `pytest backend/tests/test_cost_pricing.py` — 16 passed (incl. new cross-system consistency test `VND ledger == USD kill-switch`, and a coverage test asserting every live model string resolves to a non-zero rate)
- [x] `pytest backend/tests/test_intent/test_llm_classifier.py test_performance.py` — 17 passed (Tier 1 analytics cost unchanged behaviorally)
- [x] Grep confirmed no consumers outside the edited modules depend on the removed private constants

https://claude.ai/code/session_01UP9pqutaFp5SoXGrjxwBCq