### PR TITLE
Prompt to merge existing checking account when adding bank checking (Closes #NNN)

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -1001,7 +1001,6 @@ async def _handle_cash_subtype_pick(
                 reply_markup=cash_existing_confirm_keyboard(),
             )
             return
-
     await wizard_service.update_step(
         db,
         user.id,
@@ -1027,12 +1026,40 @@ async def _handle_cash_existing_confirm(
         await send_message(chat_id=chat_id, text="Lựa chọn không hợp lệ.")
         return
 
+    draft = wizard_service.get_draft(user.wizard_state)
+    subtype = str(draft.get("subtype") or "cash")
+    if subtype == "bank_checking":
+        merge_asset_id_raw = str(draft.get("merge_asset_id") or "").strip()
+        pending_amount_raw = draft.get("pending_amount")
+        if merge_asset_id_raw and pending_amount_raw is not None:
+            try:
+                merge_asset_id = uuid.UUID(merge_asset_id_raw)
+                pending_amount = Decimal(str(pending_amount_raw))
+            except (ValueError, ArithmeticError):
+                merge_asset_id = None
+                pending_amount = Decimal("0")
+            if merge_asset_id is not None and pending_amount > 0:
+                existing_asset = await asset_service.get_asset_by_id(
+                    db, user.id, merge_asset_id
+                )
+                if existing_asset is not None and existing_asset.is_active:
+                    new_total = Decimal(str(existing_asset.current_value or 0)) + pending_amount
+                    asset = await asset_service.update_current_value(
+                        db,
+                        user.id,
+                        existing_asset.id,
+                        new_total,
+                    )
+                    await _post_save(db, chat_id, user, asset)
+                    return
     await wizard_service.update_step(
         db,
         user.id,
         step="amount",
     )
-    label_prompt, example = _CASH_SUBTYPE_PROMPTS["cash"]
+    label_prompt, example = _CASH_SUBTYPE_PROMPTS.get(
+        subtype, _CASH_SUBTYPE_PROMPTS["cash"]
+    )
     await send_message(
         chat_id=chat_id,
         text=f"💬 {label_prompt}\n\n{example}",
@@ -1070,12 +1097,70 @@ async def _handle_cash_amount_input(
         await send_message(chat_id=chat_id, text="Số tiền phải lớn hơn 0 nhé 🙂")
         return
 
+    if draft.get("subtype") == "bank_checking" and label:
+        normalized_label = label.strip().casefold()
+        existing_assets = await asset_service.get_user_assets(
+            db,
+            user.id,
+            asset_type=AssetType.CASH.value,
+        )
+        existing_bank = next(
+            (
+                a
+                for a in existing_assets
+                if str(getattr(a, "subtype", "")) == "bank_checking"
+                and str((a.name or "")).strip().casefold() == normalized_label
+            ),
+            None,
+        )
+        if existing_bank is not None:
+            bank_name = html.escape(str(existing_bank.name).strip())
+            await wizard_service.update_step(
+                db,
+                user.id,
+                step="cash_existing_confirm",
+                draft_patch={
+                    "merge_asset_id": str(existing_bank.id),
+                    "merge_bank_name": str(existing_bank.name).strip(),
+                    "pending_amount": str(amount),
+                },
+            )
+            await send_message(
+                chat_id=chat_id,
+                text=(
+                    f"💳 Bạn đã có tài khoản thanh toán ở <b>{bank_name}</b>.\n"
+                    "Bạn có muốn cộng thêm vào không?"
+                ),
+                parse_mode="HTML",
+                reply_markup=cash_existing_confirm_keyboard(),
+            )
+            return
+
     name = label or {
         "bank_savings": "Tài khoản tiết kiệm",
         "bank_checking": "Tài khoản thanh toán",
         "cash": "Tiền mặt",
         "e_wallet": "Ví điện tử",
     }.get(draft.get("subtype", ""), "Tài khoản")
+
+    merge_asset_id_raw = str(draft.get("merge_asset_id") or "").strip()
+    if draft.get("subtype") == "bank_checking" and merge_asset_id_raw:
+        try:
+            merge_asset_id = uuid.UUID(merge_asset_id_raw)
+        except ValueError:
+            merge_asset_id = None
+        if merge_asset_id is not None:
+            existing_asset = await asset_service.get_asset_by_id(db, user.id, merge_asset_id)
+            if existing_asset is not None and existing_asset.is_active:
+                new_total = Decimal(str(existing_asset.current_value or 0)) + amount
+                asset = await asset_service.update_current_value(
+                    db,
+                    user.id,
+                    existing_asset.id,
+                    new_total,
+                )
+                await _post_save(db, chat_id, user, asset)
+                return
 
     asset = await asset_service.create_asset(
         db,

--- a/backend/tests/test_asset_entry_handler.py
+++ b/backend/tests/test_asset_entry_handler.py
@@ -234,6 +234,65 @@ async def test_cash_existing_confirm_cancel_returns_to_add_asset_menu():
     start.assert_awaited_once_with(db, 100, user)
 
 
+@pytest.mark.asyncio
+async def test_cash_amount_input_bank_checking_existing_bank_shows_confirm():
+    user = _user(
+        {
+            "flow": asset_entry.FLOW_CASH,
+            "step": "amount",
+            "draft": {"asset_type": "cash", "subtype": "bank_checking"},
+        }
+    )
+    db = _db(user)
+    existing = _asset(asset_type="cash", value=8_000_000)
+    existing.subtype = "bank_checking"
+    existing.name = "MB"
+    with (
+        patch.object(asset_entry, "get_user_by_telegram_id", AsyncMock(return_value=user)),
+        patch.object(asset_entry.asset_service, "get_user_assets", AsyncMock(return_value=[existing])),
+        patch.object(asset_entry.wizard_service, "update_step", AsyncMock()) as update_step,
+        patch.object(asset_entry.asset_service, "create_asset", AsyncMock()) as create_asset,
+        patch.object(asset_entry, "send_message", AsyncMock()) as send,
+    ):
+        consumed = await asset_entry.handle_asset_text_input(
+            db, {"text": "MB 2 triệu", "chat": {"id": 100}, "from": {"id": 100}}
+        )
+    assert consumed is True
+    create_asset.assert_not_awaited()
+    assert update_step.await_args.kwargs["step"] == "cash_existing_confirm"
+    assert "đã có tài khoản thanh toán ở <b>MB</b>" in send.await_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_cash_existing_confirm_add_merges_existing_bank_checking():
+    existing = _asset(asset_type="cash", value=10_000_000)
+    existing.subtype = "bank_checking"
+    existing.name = "MB"
+    user = _user(
+        {
+            "flow": asset_entry.FLOW_CASH,
+            "step": "cash_existing_confirm",
+            "draft": {
+                "subtype": "bank_checking",
+                "merge_asset_id": str(existing.id),
+                "pending_amount": "2000000",
+            },
+        }
+    )
+    db = _db(user)
+    with (
+        patch.object(asset_entry.asset_service, "get_asset_by_id", AsyncMock(return_value=existing)),
+        patch.object(asset_entry.asset_service, "update_current_value", AsyncMock(return_value=existing)) as update_current,
+        patch.object(asset_entry.net_worth_calculator, "calculate_stored_current", AsyncMock(return_value=MagicMock(total=Decimal("12000000"), asset_count=1))),
+        patch.object(asset_entry, "update_user_level", AsyncMock(return_value=None)),
+        patch.object(asset_entry.wizard_service, "clear", AsyncMock()),
+        patch.object(asset_entry, "send_message", AsyncMock()),
+    ):
+        await asset_entry._handle_cash_existing_confirm(db, 100, user, "add")
+    update_current.assert_awaited_once()
+    assert update_current.await_args.args[3] == Decimal("12000000")
+
+
 # -----------------------------------------------------------------
 # Stock flow — ticker step
 # -----------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- Tránh tạo bản ghi trùng cho cùng một "Tài khoản thanh toán" cùng ngân hàng khi user nhập `Tên ngân hàng + số tiền` bằng cách phát hiện sau khi parse input và hỏi người dùng có muốn cộng vào tài khoản hiện có không. 
- Cải thiện UX để người dùng không vô tình tạo nhiều hàng duplicate và giữ consistency về snapshots/thuật toán tính net worth. 

### Description

- Khi user nhập bước `bank_checking` (format `Tên ngân hàng + số tiền`), hệ thống bây giờ parse label + amount và kiểm tra (case-insensitive) xem user đã có tài khoản thanh toán cùng tên ngân hàng hay không; nếu có sẽ mở wizard confirm với text: "Bạn đã có tài khoản thanh toán ở <b>[tên ngân hàng]</b>. Bạn có muốn cộng thêm vào không?" và keyboard hiện 2 nút **Thêm / Hủy**.
- Nếu user chọn **Thêm** thì thay vì tạo asset mới, code cập nhật `current_value` của asset hiện có bằng `update_current_value(...)` (giữ snapshot/event publishing đúng như service layer) và tiếp tục luồng thành công qua `_post_save`.
- Nếu user chọn **Hủy** thì fallback về menu "Thêm tài sản mới" bằng `start_asset_wizard(...)` như yêu cầu.
- Thay đổi tập trung trong `backend/bot/handlers/asset_entry.py` và thêm unit tests trong `backend/tests/test_asset_entry_handler.py` để bao phủ hai kịch bản: detect-confirm và merge-on-confirm.

### Testing

- Chạy unit tests cụ thể: `pytest -q backend/tests/test_asset_entry_handler.py -k 'cash_existing_confirm or bank_checking_existing'` và tất cả tests đã chọn đều pass (4 passed, 64 deselected).
- Thêm 2 test mới: xác nhận hiển thị wizard khi nhập bank_checking trùng và xác nhận hành vi **Thêm** sẽ merge (cập nhật `current_value`) thành công.
- Các test cash-flow liên quan trước đó vẫn duy trì hành vi cũ và green.
- Closes #NNN

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1422a9cd30832f92d0a7422bb12632)