### PR TITLE
Handle duplicate e-wallet assets with merge confirmation

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -1028,7 +1028,7 @@ async def _handle_cash_existing_confirm(
 
     draft = wizard_service.get_draft(user.wizard_state)
     subtype = str(draft.get("subtype") or "cash")
-    if subtype == "bank_checking":
+    if subtype in {"bank_checking", "e_wallet"}:
         merge_asset_id_raw = str(draft.get("merge_asset_id") or "").strip()
         pending_amount_raw = draft.get("pending_amount")
         if merge_asset_id_raw and pending_amount_raw is not None:
@@ -1136,6 +1136,45 @@ async def _handle_cash_amount_input(
             )
             return
 
+    if draft.get("subtype") == "e_wallet" and label:
+        normalized_label = label.strip().casefold()
+        existing_assets = await asset_service.get_user_assets(
+            db,
+            user.id,
+            asset_type=AssetType.CASH.value,
+        )
+        existing_wallet = next(
+            (
+                a
+                for a in existing_assets
+                if str(getattr(a, "subtype", "")) == "e_wallet"
+                and str((a.name or "")).strip().casefold() == normalized_label
+            ),
+            None,
+        )
+        if existing_wallet is not None:
+            wallet_name = html.escape(str(existing_wallet.name).strip())
+            await wizard_service.update_step(
+                db,
+                user.id,
+                step="cash_existing_confirm",
+                draft_patch={
+                    "merge_asset_id": str(existing_wallet.id),
+                    "merge_wallet_name": str(existing_wallet.name).strip(),
+                    "pending_amount": str(amount),
+                },
+            )
+            await send_message(
+                chat_id=chat_id,
+                text=(
+                    f"💳 Bạn đã có ví điện tử <b>{wallet_name}</b>.\n"
+                    "Bạn có muốn cộng thêm vào không?"
+                ),
+                parse_mode="HTML",
+                reply_markup=cash_existing_confirm_keyboard(),
+            )
+            return
+
     name = label or {
         "bank_savings": "Tài khoản tiết kiệm",
         "bank_checking": "Tài khoản thanh toán",
@@ -1144,7 +1183,7 @@ async def _handle_cash_amount_input(
     }.get(draft.get("subtype", ""), "Tài khoản")
 
     merge_asset_id_raw = str(draft.get("merge_asset_id") or "").strip()
-    if draft.get("subtype") == "bank_checking" and merge_asset_id_raw:
+    if draft.get("subtype") in {"bank_checking", "e_wallet"} and merge_asset_id_raw:
         try:
             merge_asset_id = uuid.UUID(merge_asset_id_raw)
         except ValueError:

--- a/backend/tests/test_asset_entry_handler.py
+++ b/backend/tests/test_asset_entry_handler.py
@@ -293,6 +293,65 @@ async def test_cash_existing_confirm_add_merges_existing_bank_checking():
     assert update_current.await_args.args[3] == Decimal("12000000")
 
 
+@pytest.mark.asyncio
+async def test_cash_amount_input_e_wallet_existing_wallet_shows_confirm():
+    user = _user(
+        {
+            "flow": asset_entry.FLOW_CASH,
+            "step": "amount",
+            "draft": {"asset_type": "cash", "subtype": "e_wallet"},
+        }
+    )
+    db = _db(user)
+    existing = _asset(asset_type="cash", value=2_000_000)
+    existing.subtype = "e_wallet"
+    existing.name = "MoMo"
+    with (
+        patch.object(asset_entry, "get_user_by_telegram_id", AsyncMock(return_value=user)),
+        patch.object(asset_entry.asset_service, "get_user_assets", AsyncMock(return_value=[existing])),
+        patch.object(asset_entry.wizard_service, "update_step", AsyncMock()) as update_step,
+        patch.object(asset_entry.asset_service, "create_asset", AsyncMock()) as create_asset,
+        patch.object(asset_entry, "send_message", AsyncMock()) as send,
+    ):
+        consumed = await asset_entry.handle_asset_text_input(
+            db, {"text": "Momo 1 triệu", "chat": {"id": 100}, "from": {"id": 100}}
+        )
+    assert consumed is True
+    create_asset.assert_not_awaited()
+    assert update_step.await_args.kwargs["step"] == "cash_existing_confirm"
+    assert "đã có ví điện tử <b>MoMo</b>" in send.await_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
+async def test_cash_existing_confirm_add_merges_existing_e_wallet():
+    existing = _asset(asset_type="cash", value=2_000_000)
+    existing.subtype = "e_wallet"
+    existing.name = "MoMo"
+    user = _user(
+        {
+            "flow": asset_entry.FLOW_CASH,
+            "step": "cash_existing_confirm",
+            "draft": {
+                "subtype": "e_wallet",
+                "merge_asset_id": str(existing.id),
+                "pending_amount": "1000000",
+            },
+        }
+    )
+    db = _db(user)
+    with (
+        patch.object(asset_entry.asset_service, "get_asset_by_id", AsyncMock(return_value=existing)),
+        patch.object(asset_entry.asset_service, "update_current_value", AsyncMock(return_value=existing)) as update_current,
+        patch.object(asset_entry.net_worth_calculator, "calculate_stored_current", AsyncMock(return_value=MagicMock(total=Decimal("3000000"), asset_count=1))),
+        patch.object(asset_entry, "update_user_level", AsyncMock(return_value=None)),
+        patch.object(asset_entry.wizard_service, "clear", AsyncMock()),
+        patch.object(asset_entry, "send_message", AsyncMock()),
+    ):
+        await asset_entry._handle_cash_existing_confirm(db, 100, user, "add")
+    update_current.assert_awaited_once()
+    assert update_current.await_args.args[3] == Decimal("3000000")
+
+
 # -----------------------------------------------------------------
 # Stock flow — ticker step
 # -----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Tránh tạo trùng ví điện tử (ví dụ MoMo, VNPay) khi user thêm tài sản loại `e_wallet` và giữ UX giống với trường hợp `bank_checking` hiện có. 
- Giữ consistency hệ thống bằng cách tái sử dụng luồng merge hiện tại để cập nhật `current_value` thay vì tạo bản ghi mới.

### Description
- Khi xử lý input amount cho `subtype == "e_wallet"`, so sánh tên ví không phân biệt hoa/thường và nếu tìm thấy ví tồn tại thì chuyển sang bước confirm (reuse `cash_existing_confirm`), hiển thị: “Bạn đã có ví điện tử [tên ví], bạn có muốn cộng thêm vào không?”.
- Mở rộng nhánh xử lý trong `_handle_cash_existing_confirm` để chấp nhận cả `bank_checking` và `e_wallet` cho luồng merge bằng `merge_asset_id` và `pending_amount`, rồi gọi `asset_service.update_current_value` + `_post_save` như luồng cũ.
- Thêm unit tests mới để kiểm tra phát hiện trùng ví (`test_cash_amount_input_e_wallet_existing_wallet_shows_confirm`) và việc nhấn "Thêm" sẽ merge số tiền vào ví hiện có (`test_cash_existing_confirm_add_merges_existing_e_wallet`).
- Thay đổi chính ở `backend/bot/handlers/asset_entry.py` và tests ở `backend/tests/test_asset_entry_handler.py`.

### Testing
- Chạy: `pytest -q backend/tests/test_asset_entry_handler.py -k "e_wallet or bank_checking_existing_bank_shows_confirm or existing_confirm_add_merges_existing_bank_checking"`.
- Kết quả: `4 passed, 66 deselected` (tests liên quan đến e-wallet và bank_checking đều passed).

Close #NNN

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1424e634f4832f811b1075719f6d7c)