### PR TITLE
fix: merge existing cash amount instead of creating duplicate cash asset

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -985,11 +985,23 @@ async def _handle_cash_subtype_pick(
             for a in existing_cash_assets
         )
         if has_cash_asset:
+            existing_cash = next(
+                (
+                    a
+                    for a in existing_cash_assets
+                    if (a.subtype == "cash")
+                    or (str((a.name or "")).strip().casefold() == "tiền mặt")
+                ),
+                None,
+            )
             await wizard_service.update_step(
                 db,
                 user.id,
                 step="cash_existing_confirm",
-                draft_patch={"subtype": subtype},
+                draft_patch={
+                    "subtype": subtype,
+                    "merge_asset_id": str(existing_cash.id) if existing_cash else None,
+                },
             )
             await send_message(
                 chat_id=chat_id,
@@ -1144,7 +1156,7 @@ async def _handle_cash_amount_input(
     }.get(draft.get("subtype", ""), "Tài khoản")
 
     merge_asset_id_raw = str(draft.get("merge_asset_id") or "").strip()
-    if draft.get("subtype") == "bank_checking" and merge_asset_id_raw:
+    if draft.get("subtype") in {"bank_checking", "cash"} and merge_asset_id_raw:
         try:
             merge_asset_id = uuid.UUID(merge_asset_id_raw)
         except ValueError:

--- a/backend/tests/test_asset_entry_handler.py
+++ b/backend/tests/test_asset_entry_handler.py
@@ -293,6 +293,42 @@ async def test_cash_existing_confirm_add_merges_existing_bank_checking():
     assert update_current.await_args.args[3] == Decimal("12000000")
 
 
+@pytest.mark.asyncio
+async def test_cash_amount_input_merges_existing_cash_after_confirm_add():
+    existing = _asset(asset_type="cash", value=10_000_000)
+    existing.subtype = "cash"
+    existing.name = "Tiền mặt"
+    user = _user(
+        {
+            "flow": asset_entry.FLOW_CASH,
+            "step": "amount",
+            "draft": {
+                "asset_type": "cash",
+                "subtype": "cash",
+                "merge_asset_id": str(existing.id),
+            },
+        }
+    )
+    db = _db(user)
+    with (
+        patch.object(asset_entry, "get_user_by_telegram_id", AsyncMock(return_value=user)),
+        patch.object(asset_entry.asset_service, "get_asset_by_id", AsyncMock(return_value=existing)),
+        patch.object(asset_entry.asset_service, "update_current_value", AsyncMock(return_value=existing)) as update_current,
+        patch.object(asset_entry.asset_service, "create_asset", AsyncMock()) as create_asset,
+        patch.object(asset_entry.net_worth_calculator, "calculate_stored_current", AsyncMock(return_value=MagicMock(total=Decimal("12000000"), asset_count=1))),
+        patch.object(asset_entry, "update_user_level", AsyncMock(return_value=None)),
+        patch.object(asset_entry.wizard_service, "clear", AsyncMock()),
+        patch.object(asset_entry, "send_message", AsyncMock()),
+    ):
+        consumed = await asset_entry.handle_asset_text_input(
+            db, {"text": "2 triệu", "chat": {"id": 100}, "from": {"id": 100}}
+        )
+    assert consumed is True
+    update_current.assert_awaited_once()
+    assert update_current.await_args.args[3] == Decimal("12000000")
+    create_asset.assert_not_awaited()
+
+
 # -----------------------------------------------------------------
 # Stock flow — ticker step
 # -----------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Khi user đã có tài sản `Tiền mặt` và chọn “Thêm”, logic cũ tạo record mới thay vì cộng số tiền vào record hiện có, gây trùng lặp và hiển thị không đúng.

### Description
- Khi subtype là `cash` giờ lấy `existing_cash` và lưu `merge_asset_id` vào wizard draft để giữ context khi user bấm “Thêm”.
- Ở bước nhập amount, nếu `draft` chứa `merge_asset_id` và `subtype` là `cash` hoặc `bank_checking` thì gọi `asset_service.update_current_value` để cập nhật `current_value = cũ + mới` thay vì tạo asset mới với `create_asset`.
- Đã thêm unit test `test_cash_amount_input_merges_existing_cash_after_confirm_add` để kiểm tra behavior merge và đảm bảo `create_asset` không được gọi.
- Files changed: `backend/bot/handlers/asset_entry.py` and `backend/tests/test_asset_entry_handler.py`.

### Testing
- Ran targeted tests with `pytest -q backend/tests/test_asset_entry_handler.py -k "cash_existing_confirm_add_merges_existing_bank_checking or cash_amount_input_merges_existing_cash_after_confirm_add or cash_subtype_pick_existing_cash_shows_confirm_wizard or cash_existing_confirm_add_moves_to_amount_step"` and all selected tests passed.
- Result: `4 passed, 65 deselected`.
- Close #NNN

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1425f5a0b8832fa5d2fe4c8242d503)