### PR TITLE
Support credit-card and asset-backed transaction sources in bot and miniapp

### DIFF
--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -36,13 +36,18 @@ from backend.bot.keyboards.common import CallbackPrefix, parse_callback
 from backend.bot.keyboards.transaction_keyboard import (
     category_picker_keyboard,
     confirm_delete_keyboard,
+    credit_card_source_keyboard,
     e_wallet_provider_keyboard,
+    source_asset_keyboard,
     transaction_actions_keyboard,
+    transaction_source_keyboard,
 )
 from backend.config.categories import get_all_categories
 from backend.models.expense import Expense
 from backend.schemas.expense import ExpenseCreate
 from backend.services import expense_service
+from backend.services.credit_card_service import list_credit_cards
+from backend.services.portfolio_service import list_assets
 from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.telegram_service import (
     answer_callback,
@@ -84,6 +89,24 @@ async def _handle_source_selection_callback(
 
     source_type = None
     wallet_provider = None
+    if data == "txsrc:ewallet_pick":
+        assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
+        ewallet_assets = [a for a in assets if (a.subtype or "").lower() in ("momo", "vnpay", "zalopay", "viettelpay", "e_wallet")]
+        if not ewallet_assets:
+            await answer_callback(callback_id, text="Bạn chưa có ví điện tử nào 🌱", show_alert=True)
+            return True
+        await edit_message_reply_markup(chat_id=chat_id, message_id=message_id, reply_markup=source_asset_keyboard(ewallet_assets, "ewallet"))
+        await answer_callback(callback_id)
+        return True
+    if data == "txsrc:bank_pick":
+        assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
+        bank_assets = [a for a in assets if (a.subtype or "").lower() in ("bank_checking", "bank_account")]
+        if not bank_assets:
+            await answer_callback(callback_id, text="Bạn chưa có tài khoản thanh toán nào 🌱", show_alert=True)
+            return True
+        await edit_message_reply_markup(chat_id=chat_id, message_id=message_id, reply_markup=source_asset_keyboard(bank_assets, "bank"))
+        await answer_callback(callback_id)
+        return True
     if data == "txsrc:e_wallet":
         await edit_message_reply_markup(
             chat_id=chat_id,
@@ -92,9 +115,36 @@ async def _handle_source_selection_callback(
         )
         await answer_callback(callback_id)
         return True
+    if data == "txsrc:back":
+        await edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=transaction_source_keyboard(draft.get("transaction_type", "expense")),
+        )
+        await answer_callback(callback_id)
+        return True
+    if data == "txsrc:credit_card":
+        cards = await list_credit_cards(db, user.id)
+        if not cards:
+            await answer_callback(callback_id, text="Bạn chưa có thẻ tín dụng nào 🌱", show_alert=True)
+            return True
+        await edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=credit_card_source_keyboard(cards),
+        )
+        await answer_callback(callback_id)
+        return True
+    source_credit_card_id = None
+    source_asset_id = None
     if data.startswith("txsrc_wallet:"):
         source_type = "e_wallet"
         wallet_provider = data.split(":", 1)[1]
+    elif data.startswith("txsrc_card:"):
+        source_type = "credit_card"
+        source_credit_card_id = data.split(":", 1)[1]
+    elif data.startswith("txsrc_asset:"):
+        source_asset_id = data.split(":", 1)[1]
     elif data.startswith("txsrc:"):
         chosen = data.split(":", 1)[1]
         if chosen != "skip":
@@ -108,6 +158,8 @@ async def _handle_source_selection_callback(
         source="manual",
         source_type=source_type,
         e_wallet_provider=wallet_provider,
+        source_credit_card_id=source_credit_card_id,
+        source_asset_id=source_asset_id,
     )
     expense = await expense_service.create_expense(db, user.id, expense_data)
     from backend.services import wizard_service
@@ -121,6 +173,7 @@ async def _handle_source_selection_callback(
         "vnpay": "Ví VNPay",
         "zalopay": "Ví ZaloPay",
         "viettelpay": "Ví ViettelPay",
+        "credit_card": "Thẻ tín dụng",
     }.get(wallet_provider or source_type, "không liên kết nguồn")
     confirmation_text = (
         f"Đã ghi nhận {tx_sign}{float(expense.amount):,.0f}đ · {source_label}"

--- a/backend/bot/keyboards/transaction_keyboard.py
+++ b/backend/bot/keyboards/transaction_keyboard.py
@@ -128,16 +128,31 @@ def transaction_source_keyboard(transaction_type: str) -> InlineKeyboardMarkup:
     skip_label = (
         "Bỏ qua nguồn" if transaction_type == "expense" else "Ghi nhận không liên kết"
     )
-    return {
-        "inline_keyboard": [
-            [
-                {"text": "💵 Tiền mặt", "callback_data": f"{prefix}:cash"},
-                {"text": "🏦 Tài khoản", "callback_data": f"{prefix}:bank_account"},
-            ],
-            [{"text": "👛 Ví điện tử", "callback_data": f"{prefix}:e_wallet"}],
-            [{"text": f"↪️ {skip_label}", "callback_data": f"{prefix}:skip"}],
-        ]
-    }
+    rows = [
+        [
+            {"text": "💵 Tiền mặt", "callback_data": f"{prefix}:cash"},
+            {"text": "🏦 Tài khoản", "callback_data": f"{prefix}:bank_pick"},
+        ],
+        [{"text": "👛 Ví điện tử", "callback_data": f"{prefix}:ewallet_pick"}],
+    ]
+    if transaction_type == "expense":
+        rows.append([{"text": "💳 Thẻ tín dụng", "callback_data": f"{prefix}:credit_card"}])
+    rows.append([{"text": f"↪️ {skip_label}", "callback_data": f"{prefix}:skip"}])
+    return {"inline_keyboard": rows}
+
+
+def credit_card_source_keyboard(cards: list) -> InlineKeyboardMarkup:
+    rows: list[list[dict]] = []
+    for card in cards:
+        rows.append([
+            {
+                "text": f"💳 {card.bank_name}",
+                "callback_data": f"txsrc_card:{card.id}",
+            }
+        ])
+    rows.append([{"text": "↩️ Quay lại chọn nguồn", "callback_data": "txsrc:back"}])
+    rows.append([{"text": "↪️ Bỏ qua nguồn", "callback_data": "txsrc:skip"}])
+    return {"inline_keyboard": rows}
 
 
 def e_wallet_provider_keyboard() -> InlineKeyboardMarkup:
@@ -154,3 +169,13 @@ def e_wallet_provider_keyboard() -> InlineKeyboardMarkup:
             [{"text": "↪️ Bỏ qua nguồn", "callback_data": "txsrc:skip"}],
         ]
     }
+
+
+def source_asset_keyboard(assets: list, kind: str) -> InlineKeyboardMarkup:
+    rows: list[list[dict]] = []
+    for a in assets:
+        icon = "🏦" if kind == "bank" else "👛"
+        rows.append([{"text": f"{icon} {a.name}", "callback_data": f"txsrc_asset:{a.id}"}])
+    rows.append([{"text": "↩️ Quay lại chọn nguồn", "callback_data": "txsrc:back"}])
+    rows.append([{"text": "↪️ Bỏ qua nguồn", "callback_data": "txsrc:skip"}])
+    return {"inline_keyboard": rows}

--- a/backend/miniapp/routes.py
+++ b/backend/miniapp/routes.py
@@ -779,6 +779,7 @@ async def get_expense_dashboard_overview(
                 "expenses": [_serialize_expense_item(e) for e in expenses],
                 "money_in": [_serialize_expense_item(e) for e in money_in],
                 "money_in_total": sum(float(e.amount or 0) for e in money_in),
+                "source_options": await _build_source_options(db, user.id),
             }
         except Exception as exc:  # noqa: BLE001
             # Log the underlying DB / ORM error before flattening to a
@@ -810,6 +811,34 @@ async def get_expense_dashboard_overview(
     return {"data": payload, "error": None}
 
 
+
+
+async def _build_source_options(db: AsyncSession, user_id):
+    assets = await list_assets(db, user_id, asset_type="cash", limit=500, offset=0)
+    cards = await list_credit_cards(db, user_id)
+
+    def _asset_label(a):
+        subtype = (a.subtype or "").lower()
+        if subtype in ("bank_checking", "bank_account"):
+            return f"Tài khoản thanh toán · {a.name}"
+        if subtype in ("momo", "vnpay", "zalopay", "viettelpay", "e_wallet"):
+            return f"Ví điện tử · {a.name}"
+        if subtype == "cash":
+            return f"Tiền mặt · {a.name}"
+        return None
+
+    expense = [{"value": "", "label": "Không liên kết nguồn"}]
+    money_in = [{"value": "", "label": "Không liên kết nguồn"}]
+    for a in assets:
+        label = _asset_label(a)
+        if not label:
+            continue
+        opt = {"value": f"asset:{a.id}", "label": label}
+        expense.append(opt)
+        money_in.append(opt)
+    for c in cards:
+        expense.append({"value": f"credit_card:{c.id}", "label": f"Thẻ tín dụng · {c.bank_name}"})
+    return {"expense": expense, "money_in": money_in}
 def _previous_month_key(month_key: str) -> str:
     """Return YYYY-MM for the calendar month immediately before ``month_key``."""
     year, month = month_key.split("-")

--- a/backend/miniapp/static/js/expense_dashboard.js
+++ b/backend/miniapp/static/js/expense_dashboard.js
@@ -106,7 +106,29 @@
     let currentCategoryFilter = '';
     const pageStartedAt = performance.now();
     let loadBeaconSent = false;
-    const SOURCE = new URLSearchParams(window.location.search).get('source');
+    
+    const FALLBACK_SOURCE_OPTIONS = {
+        expense: [
+            { value: '', label: 'Không liên kết nguồn' },
+            { value: 'cash', label: 'Tiền mặt' },
+            { value: 'bank_account', label: 'Tài khoản thanh toán' },
+            { value: 'e_wallet:momo', label: 'Ví Momo' },
+            { value: 'e_wallet:vnpay', label: 'Ví VNPay' },
+            { value: 'e_wallet:zalopay', label: 'Ví ZaloPay' },
+            { value: 'e_wallet:viettelpay', label: 'Ví ViettelPay' },
+            { value: 'credit_card', label: 'Thẻ tín dụng' },
+        ],
+        money_in: [
+            { value: '', label: 'Không liên kết nguồn' },
+            { value: 'cash', label: 'Tiền mặt' },
+            { value: 'bank_account', label: 'Tài khoản thanh toán' },
+            { value: 'e_wallet:momo', label: 'Ví Momo' },
+            { value: 'e_wallet:vnpay', label: 'Ví VNPay' },
+            { value: 'e_wallet:zalopay', label: 'Ví ZaloPay' },
+            { value: 'e_wallet:viettelpay', label: 'Ví ViettelPay' },
+        ],
+    };
+const SOURCE = new URLSearchParams(window.location.search).get('source');
     let refreshInFlight = false;
     let lastRefreshAt = 0;
     let activeRequestId = 0;
@@ -128,6 +150,7 @@
         if (els.moneyInList) els.moneyInList.addEventListener('click', onExpenseRowClick);
         els.modalCancel.addEventListener('click', closeModal);
         els.modalSave.addEventListener('click', onSave);
+        els.modalType.addEventListener('change', () => applySourceOptions(els.modalType.value, '', null));
         els.modalDelete.addEventListener('click', onDelete);
         els.modal.addEventListener('click', (e) => {
             if (e.target === els.modal) closeModal();
@@ -672,17 +695,32 @@
         els.categoryFilter.innerHTML = '<option value="">Tất cả</option>';
     }
 
+
+    function applySourceOptions(txType, selectedValue = '', existingCardId = null) {
+        const key = txType === 'money_in' ? 'money_in' : 'expense';
+        const sourceOptions = (lastOverview && lastOverview.source_options && lastOverview.source_options[key]) || FALLBACK_SOURCE_OPTIONS[key];
+        const opts = [...sourceOptions];
+        if (selectedValue === 'credit_card' && existingCardId) {
+            opts.push({ value: `credit_card:${existingCardId}`, label: 'Thẻ tín dụng (đã chọn)' });
+        }
+        els.modalSource.innerHTML = opts
+            .map((it) => `<option value="${escapeHtml(it.value)}">${escapeHtml(it.label)}</option>`)
+            .join('');
+        els.modalSource.value = selectedValue || '';
+        if (els.modalSource.value !== (selectedValue || '')) els.modalSource.value = '';
+    }
+
     function openModal(item, forcedType) {
         editingExpenseId = item?.id || null;
         const txType = item?.transaction_type || forcedType || 'expense';
         els.modalTitle.textContent = editingExpenseId ? (txType === 'money_in' ? 'Sửa tiền vào' : 'Sửa chi tiêu') : (txType === 'money_in' ? 'Thêm tiền vào' : 'Thêm chi tiêu');
         els.modalType.value = txType;
+        applySourceOptions(txType, sourceValue(item), item?.source_credit_card_id || null);
         els.modalAmount.value = item ? Math.round(item.amount || 0) : '';
         els.modalCategory.value = item?.category || 'other';
         els.modalDate.value = item?.expense_date || new Date().toISOString().slice(0, 10);
         els.modalNote.value = item?.merchant || item?.note || '';
         els.modalPayment.value = item?.payment_method || '';
-        els.modalSource.value = sourceValue(item);
         els.modalDelete.hidden = !editingExpenseId;
         els.modalSave.disabled = false;
         els.modalDelete.disabled = false;
@@ -698,16 +736,27 @@
 
     function sourceValue(item) {
         if (!item || !item.source_type) return '';
+        if (item.source_credit_card_id) return `credit_card:${item.source_credit_card_id}`;
+        if (item.source_asset_id) return `asset:${item.source_asset_id}`;
         if (item.source_type === 'e_wallet') return `e_wallet:${item.e_wallet_provider || 'momo'}`;
         return item.source_type;
     }
 
-    function parseSourceValue(value) {
-        if (!value) return { source_type: null, e_wallet_provider: null };
+    function parseSourceValue(value, editingItem = null) {
+        if (!value) return { source_type: null, e_wallet_provider: null, source_credit_card_id: null, source_asset_id: null };
         if (value.startsWith('e_wallet:')) {
-            return { source_type: 'e_wallet', e_wallet_provider: value.split(':')[1] || 'momo' };
+            return { source_type: 'e_wallet', e_wallet_provider: value.split(':')[1] || 'momo', source_credit_card_id: null, source_asset_id: null };
         }
-        return { source_type: value, e_wallet_provider: null };
+        if (value.startsWith('credit_card:')) return { source_type: 'credit_card', e_wallet_provider: null, source_credit_card_id: value.split(':')[1] || null, source_asset_id: null };
+        if (value.startsWith('asset:')) return { source_type: null, e_wallet_provider: null, source_credit_card_id: null, source_asset_id: value.split(':')[1] || null };
+        if (value === 'credit_card') return { source_type: 'credit_card', e_wallet_provider: null, source_credit_card_id: editingItem?.source_credit_card_id || null, source_asset_id: null };
+        return { source_type: value, e_wallet_provider: null, source_credit_card_id: null, source_asset_id: null };
+    }
+
+
+    function findById(id) {
+        const all = [...(lastOverview.expenses || []), ...(lastOverview.money_in || [])];
+        return all.find((it) => it.id === id) || null;
     }
 
     async function onSave() {
@@ -726,7 +775,7 @@
             note: note || null,
             merchant: note || null,
             payment_method: els.modalPayment.value.trim() || null,
-            ...parseSourceValue(els.modalSource.value),
+            ...parseSourceValue(els.modalSource.value, editingExpenseId ? findById(editingExpenseId) : null),
         };
         els.modalSave.disabled = true;
         let saved;

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -315,3 +315,52 @@ async def test_stale_wizard_state_does_not_call_create_expense():
     create.assert_not_awaited()
     answer.assert_awaited_once()
     assert "hết hạn" in answer.await_args.kwargs["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_credit_card_shows_all_cards_for_expense_only():
+    user = _user(state={
+        "flow": "transaction_source_select",
+        "step": "source_type",
+        "draft": {"amount": 200000.0, "transaction_type": "expense"},
+    })
+    db = MagicMock()
+    cards = [
+        SimpleNamespace(id=uuid.uuid4(), bank_name="VCB"),
+        SimpleNamespace(id=uuid.uuid4(), bank_name="ACB"),
+    ]
+    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=cards)),          patch.object(callbacks, "edit_message_reply_markup", AsyncMock()) as edit_markup,          patch.object(callbacks, "answer_callback", AsyncMock()):
+        handled = await callbacks._handle_source_selection_callback(db, _callback("txsrc:credit_card"))
+
+    assert handled is True
+    kb = edit_markup.await_args.kwargs["reply_markup"]["inline_keyboard"]
+    labels = [row[0]["text"] for row in kb[:2]]
+    assert labels == ["💳 VCB", "💳 ACB"]
+
+
+@pytest.mark.asyncio
+async def test_txsrc_card_select_creates_expense_with_credit_card_source():
+    user = _user(state={
+        "flow": "transaction_source_select",
+        "step": "source_type",
+        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
+    })
+    db = MagicMock()
+    expense = _expense(transaction_type="expense", amount=200000.0)
+    card_id = uuid.uuid4()
+    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)) as create,          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})),          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
+        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+
+    assert handled is True
+    payload = create.await_args.args[2]
+    assert payload.source_type == "credit_card"
+    assert str(payload.source_credit_card_id) == str(card_id)
+from backend.bot.keyboards.transaction_keyboard import transaction_source_keyboard
+
+def test_tx_source_keyboard_expense_includes_credit_card():
+    kb = transaction_source_keyboard("expense")["inline_keyboard"]
+    assert any(btn["callback_data"] == "txsrc:credit_card" for row in kb for btn in row)
+
+def test_tx_source_keyboard_money_in_excludes_credit_card():
+    kb = transaction_source_keyboard("money_in")["inline_keyboard"]
+    assert all(btn["callback_data"] != "txsrc:credit_card" for row in kb for btn in row)

--- a/backend/tests/test_expense_miniapp_static.py
+++ b/backend/tests/test_expense_miniapp_static.py
@@ -140,3 +140,12 @@ def test_expense_init_wrapped_in_try_catch_with_error_state_fallback():
         "user-facing Vietnamese fallback message missing or off-tone "
         "(must match Bé Tiền warm-companion voice)"
     )
+
+def test_source_options_distinguish_expense_vs_money_in_and_gate_credit_card():
+    js = JS.read_text()
+
+    assert "const FALLBACK_SOURCE_OPTIONS" in js
+    assert "expense:" in js and "money_in:" in js
+    assert "source_options" in js
+    assert "{ value: 'credit_card', label: 'Thẻ tín dụng' }" in js
+    assert "if (selectedValue === 'credit_card' && existingCardId)" in js


### PR DESCRIPTION
### Motivation
- Enable users to select credit cards and specific assets (bank accounts / e-wallets) as the source when creating or editing transactions so sources are recorded more precisely. 
- Surface available sources in the Mini App UI so modal source pickers show per-user assets and cards instead of only generic types. 

### Description
- Extend the Telegram source-picker flow in `backend/bot/handlers/callbacks.py` to handle credit card and asset selections, call `list_credit_cards` and `list_assets`, and include `source_credit_card_id` / `source_asset_id` in the `ExpenseCreate` payload.  
- Add keyboard helpers in `backend/bot/keyboards/transaction_keyboard.py`: `credit_card_source_keyboard`, `source_asset_keyboard`, and update `transaction_source_keyboard` to expose card and asset pick flows.  
- Add a Mini App API helper `_build_source_options` in `backend/miniapp/routes.py` to include per-user `assets` and `cards` in the dashboard payload.  
- Update Mini App static JS `backend/miniapp/static/js/expense_dashboard.js` to consume `source_options`, provide `FALLBACK_SOURCE_OPTIONS`, add `applySourceOptions`, extend `parseSourceValue` and `sourceValue` to round-trip `credit_card` and `asset` values, and wire the modal type change to refresh source options.  
- Add unit tests for the bot callback and static JS behavior in `backend/tests/test_callbacks_source_selection.py` and `backend/tests/test_expense_miniapp_static.py`, and add keyboard tests for `transaction_source_keyboard`.  

### Testing
- Ran `pytest` targeting `backend/tests/test_callbacks_source_selection.py` and the new assertions around card selection which passed.  
- Ran `pytest` targeting `backend/tests/test_expense_miniapp_static.py` which verified presence of `FALLBACK_SOURCE_OPTIONS` and related JS changes and passed.  
- Existing transaction keyboard tests were exercised and the new keyboard assertions for inclusion/exclusion of credit-card buttons passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1516fb4094832f8381881a19a55139)