### PR TITLE
Update onboarding_v2 trust card and post-demo CTA copy

### DIFF
--- a/backend/services/onboarding/next_action_service.py
+++ b/backend/services/onboarding/next_action_service.py
@@ -43,11 +43,13 @@ class NextActionCTA:
     callback_data: str
     action_type: str
     prefix: str
-    soft_prompt: str
+    soft_prompt: str = ""
 
     @property
     def message_text(self) -> str:
-        return f"{self.prefix}\n\n{self.text}\n\n💬 {self.soft_prompt}"
+        if self.soft_prompt.strip():
+            return f"{self.prefix}\n\n{self.text}\n\n💬 {self.soft_prompt}"
+        return f"{self.prefix}\n\n{self.text}"
 
     @property
     def reply_markup(self) -> dict[str, Any]:
@@ -125,7 +127,7 @@ async def compute(db: AsyncSession, user_id: uuid.UUID) -> NextActionCTA:
         callback_data=button["callback"],
         action_type=button["action_type"],
         prefix=copy["prefix"],
-        soft_prompt=copy["soft_prompt"],
+        soft_prompt=copy.get("soft_prompt", ""),
     )
 
 

--- a/content/onboarding/next_action.yaml
+++ b/content/onboarding/next_action.yaml
@@ -2,7 +2,6 @@
 # 3 asset states × 3 onboarding goals. Keep copy short and action-led.
 
 prefix: "💡 Bước tiếp theo dành cho bạn:"
-soft_prompt: "...hoặc hỏi Bé Tiền bất cứ điều gì về Twin"
 
 buttons:
   add_asset:

--- a/content/onboarding/trust_card.yaml
+++ b/content/onboarding/trust_card.yaml
@@ -1,6 +1,6 @@
 header: "(1/3) Bé Tiền tôn trọng tài chính của bạn"
 body: |
-  Trước khi vẽ Twin tài chính, Bé Tiền hứa với bạn 3 điều:
+  Trước khi vẽ Twin (bản đồ tài chính), Bé Tiền hứa với bạn 3 điều:
 bullets:
   - "🔒 Chỉ bạn thấy chi tiết tài sản — không ai khác nhìn được."
   - "✍️ Bạn có thể xoá hoặc sửa tài sản bất cứ lúc nào."

--- a/tests/test_phase_4_2/test_epic2.py
+++ b/tests/test_phase_4_2/test_epic2.py
@@ -49,7 +49,7 @@ async def test_next_action_matrix_has_9_unique_ctas(
     assert cta.button_key == button_key
     assert cta.text
     assert cta.message_text.startswith("💡 Bước tiếp theo dành cho bạn:")
-    assert "hỏi Bé Tiền" in cta.message_text
+    assert "hỏi Bé Tiền" not in cta.message_text
 
 
 def test_next_action_yaml_contains_unique_copy_for_each_cell():

--- a/tests/test_phase_4_2/test_onboarding_copy_regressions.py
+++ b/tests/test_phase_4_2/test_onboarding_copy_regressions.py
@@ -86,6 +86,8 @@ def test_trust_card_header_carries_one_of_three_label():
 
 def test_trust_card_body_introduces_three_promises():
     copy = _load_yaml("trust_card.yaml")
+    body = copy.get("body") or ""
+    assert "Twin (bản đồ tài chính)" in body
     bullets = copy.get("bullets") or []
     assert len(bullets) == 3, "trust card must list exactly 3 promises"
     # All three should be short, action-oriented, and end on '.'


### PR DESCRIPTION
### Motivation
- Clarify the trust-card copy to explicitly call the Twin a “bản đồ tài chính” for better user understanding. 
- Remove the trailing soft prompt after the demo CTA so the post-demo card does not show the query-suggestion line.

### Description
- Update `content/onboarding/trust_card.yaml` body from `Trước khi vẽ Twin tài chính...` to `Trước khi vẽ Twin (bản đồ tài chính)...`.
- Remove `soft_prompt` line from `content/onboarding/next_action.yaml` so the CTA YAML no longer forces a trailing suggestion.
- Make `backend/services/onboarding/next_action_service.py` tolerant of a missing `soft_prompt` by defaulting it to an empty string and changing `message_text` to omit the `💬` line when `soft_prompt` is blank.
- Update tests: `tests/test_phase_4_2/test_epic2.py` now asserts the CTA message does NOT contain the old soft-prompt text, and `tests/test_phase_4_2/test_onboarding_copy_regressions.py` now asserts the trust-card body contains `Twin (bản đồ tài chính)`.

### Testing
- Running `pytest -q tests/test_phase_4_2/test_epic2.py tests/test_phase_4_2/test_onboarding_copy_regressions.py` without `PYTHONPATH` failed during collection due to import path errors. 
- Running `PYTHONPATH=. pytest -q tests/test_phase_4_2/test_epic2.py tests/test_phase_4_2/test_onboarding_copy_regressions.py` succeeded with `26 passed`.
- PR/commit metadata includes the required closing token: `Close #NNN`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a155f2c71d0832f8150e49039a6e230)