### PR TITLE
fix(agent): route "tổng chi tiêu tháng này" to Tier 1 + inject today's date into Tier-3 prompt

### DIFF
--- a/backend/agent/orchestrator.py
+++ b/backend/agent/orchestrator.py
@@ -52,7 +52,10 @@ from backend.agent.tier2.formatters import format_db_agent_response
 from backend.agent.tier3.reasoning_agent import ReasoningAgent, ReasoningTrace
 from backend.agent.tools import build_default_registry
 from backend.agent.tools.base import ToolRegistry
-from backend.intent.classifier.pipeline import IntentPipeline
+from backend.intent.classifier.pipeline import (
+    HIGH_CONFIDENCE_THRESHOLD,
+    IntentPipeline,
+)
 from backend.intent.dispatcher import (
     DispatchOutcome,
     IntentDispatcher,
@@ -239,6 +242,17 @@ class Orchestrator:
                 reason="heuristic_tier3", history=history,
             )
         if tier_hint == TIER_2:
+            # A broad tier-2 keyword ("tổng ", "liệt kê", ...) can hijack
+            # a simple summary query that Tier 1 answers directly from the
+            # DB — e.g. "tổng chi tiêu tháng này" is just query_expenses.
+            # Before paying for the LLM cascade (and risking an LLM
+            # hallucination), consult the free rule classifier: a
+            # high-confidence intent means Tier 1 owns this query.
+            guarded = await self._tier1_rule_guard(
+                query, user, db, reason="heuristic_tier2_rule_guard"
+            )
+            if guarded is not None:
+                return guarded
             return await self._cascade_tier2_then_3(
                 query, user, db, streamer,
                 reason="heuristic_tier2", history=history,
@@ -289,6 +303,50 @@ class Orchestrator:
     # ------------------------------------------------------------------
     # Cascade implementations
     # ------------------------------------------------------------------
+
+    async def _tier1_rule_guard(
+        self,
+        query: str,
+        user: User,
+        db: AsyncSession,
+        *,
+        reason: str,
+    ) -> RouteResult | None:
+        """Rescue a query the tier-2 heuristic claimed but the rule
+        classifier recognises with high confidence.
+
+        Returns a Tier 1 ``RouteResult`` when the *free* rule classifier
+        yields a non-UNCLEAR intent at ``>= HIGH_CONFIDENCE_THRESHOLD``;
+        otherwise ``None`` so the caller proceeds with the tier-2
+        cascade. Uses the rule classifier ONLY (no LLM call) so the
+        guard stays free and instant — we don't want to spend a classify
+        token on a query the heuristic already flagged as Tier 2 unless
+        the rule layer is sure enough to short-circuit.
+        """
+        classifier_start = time.monotonic()
+        rule_result = self.intent_pipeline.rule_classifier.classify(query)
+        classifier_latency_ms = int(
+            (time.monotonic() - classifier_start) * 1000
+        )
+        if (
+            rule_result is None
+            or rule_result.intent == IntentType.UNCLEAR
+            or rule_result.confidence < HIGH_CONFIDENCE_THRESHOLD
+        ):
+            return None
+
+        outcome = await self.intent_dispatcher.dispatch(rule_result, user, db)
+        await self.rate_limiter.record(user.id, tier=TIER_1)
+        return RouteResult(
+            tier=TIER_1,
+            routing_reason=reason,
+            text=outcome.text,
+            intent=outcome.intent,
+            confidence=outcome.confidence,
+            dispatch_outcome=outcome,
+            classifier_latency_ms=classifier_latency_ms,
+            classifier_used=rule_result.classifier_used,
+        )
 
     async def _cascade_tier1_then_up(
         self,

--- a/backend/agent/tier3/prompts.py
+++ b/backend/agent/tier3/prompts.py
@@ -16,6 +16,7 @@ Two design rules baked in:
 """
 from __future__ import annotations
 
+from datetime import date
 from decimal import Decimal
 
 from backend.wealth.ladder import WealthLevel
@@ -71,14 +72,21 @@ def build_reasoning_prompt(
     wealth_level: WealthLevel,
     net_worth: Decimal,
     tool_descriptions: str,
+    today: date | None = None,
 ) -> str:
     """Assemble the full Tier 3 system prompt for one query.
 
     We render synchronously rather than caching — the prompt is
     user-specific (name, level, net worth) so caching across users
     would leak data. Per-user caching could work but isn't worth the
-    code path complexity until we see it in profiling."""
+    code path complexity until we see it in profiling.
+
+    ``today`` is injected so date-relative reasoning ("tháng này",
+    "năm nay") resolves against the real calendar instead of the
+    model's training-cutoff guess. Injectable for tests; defaults to
+    ``date.today()``."""
     level_focus = _LEVEL_FOCUS[wealth_level]
+    today = today or date.today()
 
     return f"""Bạn là Bé Tiền — Trợ lý Tài sản cho người Việt.
 
@@ -97,6 +105,11 @@ QUY TẮC TONE:
 - Xưng "mình", gọi user là "bạn" hoặc "{user_name}".
 - Adapt theo wealth level (xem CONTEXT bên dưới).
 - Warm nhưng không nịnh nọt; không emoji thừa.
+
+NGÀY HÔM NAY: {today.isoformat()}.
+- "tháng này" = tháng {today.month}/{today.year}; "năm nay" = {today.year}.
+- Mọi mốc thời gian tương đối phải tính theo ngày hôm nay ở trên,
+  KHÔNG được đoán tháng/năm khác.
 
 CONTEXT USER:
 - Tên: {user_name}

--- a/backend/tests/test_agent/test_orchestrator.py
+++ b/backend/tests/test_agent/test_orchestrator.py
@@ -236,6 +236,103 @@ class TestCascade:
 
 
 # ---------------------------------------------------------------------------
+# Tier-2 rule guard — keep simple summary queries on Tier 1.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+class TestTier2RuleGuard:
+    """Regression for the production bug where "tổng chi tiêu tháng này"
+    was hijacked by the broad ``"tổng "`` tier-2 heuristic into the LLM
+    cascade, which then hallucinated (wrong month, fake "no transactions"
+    answer, investment-advice disclaimer). The free rule classifier
+    recognises it as ``query_expenses`` with high confidence, so the
+    guard must short-circuit such queries to Tier 1 — without hijacking
+    genuine tier-2 aggregates the rule layer can't classify."""
+
+    async def test_real_classifier_rescues_monthly_expense_total(self):
+        from backend.intent.classifier.pipeline import IntentPipeline
+
+        orch = _orch_with_streamable()
+        # Use the REAL rule classifier so this is a true end-to-end
+        # regression of the reported query, not a mock tautology.
+        orch.intent_pipeline = IntentPipeline()
+        # Precondition: the heuristic really does flag this Tier 2.
+        assert orch._heuristic_classify("tổng chi tiêu tháng này") == TIER_2
+        orch.intent_dispatcher.dispatch = AsyncMock(  # type: ignore[assignment]
+            return_value=MagicMock(
+                text="💸 Chi tiêu tháng này: 5tr",
+                intent=IntentType.QUERY_EXPENSES,
+                confidence=0.9,
+            )
+        )
+
+        result = await orch.route(
+            "tổng chi tiêu tháng này", _user(), MagicMock(), streamer=None
+        )
+
+        assert result.tier == TIER_1
+        assert result.routing_reason == "heuristic_tier2_rule_guard"
+        assert result.intent == IntentType.QUERY_EXPENSES
+        assert result.text == "💸 Chi tiêu tháng này: 5tr"
+        assert result.classifier_latency_ms is not None
+        # The expensive LLM DB-agent must never have been consulted.
+        orch.db_agent.answer.assert_not_called()
+
+    async def test_real_classifier_keeps_genuine_tier2_aggregate(self):
+        from backend.intent.classifier.pipeline import IntentPipeline
+
+        orch = _orch_with_streamable()
+        orch.intent_pipeline = IntentPipeline()
+        orch.db_agent.answer = AsyncMock(  # type: ignore[assignment]
+            return_value=_ok_db_result()
+        )
+        async def fake_format(_a, _b, _c, _d): return "tier2 aggregate text"
+        import backend.agent.orchestrator as orch_mod
+        orig = orch_mod.format_db_agent_response
+        orch_mod.format_db_agent_response = fake_format  # type: ignore[assignment]
+        try:
+            result = await orch.route(
+                "tổng lãi portfolio của tôi", _user(), MagicMock(), streamer=None
+            )
+        finally:
+            orch_mod.format_db_agent_response = orig  # type: ignore[assignment]
+
+        # The rule classifier doesn't recognise this aggregate, so the
+        # guard declines and the tier-2 cascade owns it.
+        assert result.tier == TIER_2
+        orch.db_agent.answer.assert_awaited_once()
+
+    async def test_guard_declines_on_low_confidence(self):
+        orch = _orch_with_streamable()
+        # A weakly-confident rule match must NOT short-circuit Tier 1 —
+        # we don't answer a billing-relevant query off a guess.
+        orch.intent_pipeline.rule_classifier.classify = MagicMock(
+            return_value=IntentResult(
+                intent=IntentType.QUERY_EXPENSES,
+                confidence=0.5,
+                raw_text="tổng chi tiêu tháng này",
+            )
+        )
+        orch.db_agent.answer = AsyncMock(  # type: ignore[assignment]
+            return_value=_ok_db_result()
+        )
+        async def fake_format(_a, _b, _c, _d): return "tier2 text"
+        import backend.agent.orchestrator as orch_mod
+        orig = orch_mod.format_db_agent_response
+        orch_mod.format_db_agent_response = fake_format  # type: ignore[assignment]
+        try:
+            result = await orch.route(
+                "tổng chi tiêu tháng này", _user(), MagicMock(), streamer=None
+            )
+        finally:
+            orch_mod.format_db_agent_response = orig  # type: ignore[assignment]
+
+        assert result.tier == TIER_2
+        orch.intent_dispatcher.dispatch.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
 # Rate limit + cost gates
 # ---------------------------------------------------------------------------
 
@@ -352,8 +449,16 @@ def _ok_db_result():
 
 def _orch_skeleton() -> Orchestrator:
     """Build an orchestrator with no-op agents for heuristic tests."""
+    intent_pipeline = MagicMock()
+    # Tier-2 rule guard reads the sync rule classifier; default UNCLEAR
+    # so the guard declines and heuristic routing is unchanged.
+    intent_pipeline.rule_classifier.classify = MagicMock(
+        return_value=IntentResult(
+            intent=IntentType.UNCLEAR, confidence=0.0, raw_text=""
+        )
+    )
     return Orchestrator(
-        intent_pipeline=MagicMock(),
+        intent_pipeline=intent_pipeline,
         intent_dispatcher=MagicMock(),
         db_agent=MagicMock(),
         reasoning_agent=MagicMock(),
@@ -376,6 +481,14 @@ def _orch_with_streamable(
     paths replace the relevant method explicitly."""
     intent_pipeline = MagicMock()
     intent_pipeline.classify = AsyncMock(
+        return_value=IntentResult(
+            intent=IntentType.UNCLEAR, confidence=0.0, raw_text=""
+        )
+    )
+    # The tier-2 rule guard consults the SYNC rule classifier directly.
+    # Default it to UNCLEAR so the guard declines and the cascade runs;
+    # tests exercising the rescue path override this explicitly.
+    intent_pipeline.rule_classifier.classify = MagicMock(
         return_value=IntentResult(
             intent=IntentType.UNCLEAR, confidence=0.0, raw_text=""
         )

--- a/backend/tests/test_agent/test_reasoning_agent.py
+++ b/backend/tests/test_agent/test_reasoning_agent.py
@@ -307,3 +307,29 @@ class TestCallbackResilience:
         )
         # Agent still completes successfully even if streamer dies.
         assert trace.success is True
+
+
+class TestReasoningPromptDate:
+    """The Tier-3 prompt must inject today's real date so date-relative
+    reasoning ("tháng này", "năm nay") resolves against the calendar
+    instead of the model's training-cutoff guess — the second half of
+    the production bug, where Tier 3 answered with "tháng 7/2025"."""
+
+    def test_prompt_injects_today_for_relative_dates(self):
+        from datetime import date
+
+        from backend.agent.tier3.prompts import build_reasoning_prompt
+        from backend.wealth.ladder import WealthLevel
+
+        today = date(2026, 5, 26)
+        prompt = build_reasoning_prompt(
+            user_name="Hà",
+            wealth_level=WealthLevel.YOUNG_PROFESSIONAL,
+            net_worth=Decimal("100_000_000"),
+            tool_descriptions="(no tools)",
+            today=today,
+        )
+
+        assert "2026-05-26" in prompt
+        assert "tháng 5/2026" in prompt
+        assert "năm nay" in prompt and "2026" in prompt

--- a/backend/tests/test_agent/test_winners_e2e.py
+++ b/backend/tests/test_agent/test_winners_e2e.py
@@ -22,8 +22,26 @@ import pytest
 from backend.agent.orchestrator import TIER_2, Orchestrator
 from backend.agent.rate_limit import DailyCostTracker, RateLimiter
 from backend.agent.tier2.db_agent import DBAgentResult
+from backend.intent.intents import IntentResult, IntentType
 from backend.wealth.models.asset import Asset
 from backend.wealth.services import asset_service
+
+
+def _unclear_pipeline() -> MagicMock:
+    """Intent pipeline whose sync rule classifier reports UNCLEAR.
+
+    The tier-2 rule guard consults ``rule_classifier.classify`` before
+    paying for the cascade; an unconfigured ``MagicMock`` would make the
+    guard's ``confidence < threshold`` comparison raise ``TypeError``.
+    These filter queries genuinely belong to Tier 2, so UNCLEAR makes
+    the guard decline and the tier-2 path runs as the tests expect."""
+    pipeline = MagicMock()
+    pipeline.rule_classifier.classify = MagicMock(
+        return_value=IntentResult(
+            intent=IntentType.UNCLEAR, confidence=0.0, raw_text=""
+        )
+    )
+    return pipeline
 
 
 def _stock(name: str, current: int, initial: int) -> Asset:
@@ -119,7 +137,7 @@ class TestWinnersOnlyE2E:
         db = _mock_db(rows)
 
         orch = Orchestrator(
-            intent_pipeline=MagicMock(),  # not used; tier-2 short-circuits
+            intent_pipeline=_unclear_pipeline(),  # guard declines → tier-2
             intent_dispatcher=MagicMock(),
             db_agent=_stub_db_agent_picks_winners_filter(),
             reasoning_agent=MagicMock(),
@@ -188,7 +206,7 @@ class TestWinnersOnlyE2E:
         agent = MagicMock()
         agent.answer = loser_answer
         orch = Orchestrator(
-            intent_pipeline=MagicMock(),
+            intent_pipeline=_unclear_pipeline(),
             intent_dispatcher=MagicMock(),
             db_agent=agent,
             reasoning_agent=MagicMock(),
@@ -238,7 +256,7 @@ class TestWinnersOnlyE2E:
         agent = MagicMock()
         agent.answer = top3_answer
         orch = Orchestrator(
-            intent_pipeline=MagicMock(),
+            intent_pipeline=_unclear_pipeline(),
             intent_dispatcher=MagicMock(),
             db_agent=agent,
             reasoning_agent=MagicMock(),


### PR DESCRIPTION
## Problem

When a user typed **"tổng chi tiêu tháng này"** (total spending this month), Bé Tiền returned a hallucinated LLM advisory: the **wrong date** ("tháng 7/2025" when today is 2026-05-26), a fabricated "no transactions" answer, and an investment-advice disclaimer footer — instead of a real DB-backed expense summary.

## Root cause

Two compounding issues:

1. **Routing.** The broad `"tổng "` keyword in `router_heuristics.yaml` flags this query as **Tier 2** (DeepSeek DB-agent cascade). But "tổng chi tiêu tháng này" is a plain `query_expenses` summary that **Tier 1** answers directly and for free from the DB. The query was paying for the LLM cascade — and risking hallucination — when a free rule classifier already recognises it at high confidence.
2. **Date grounding.** The Tier-3 reasoning prompt never told Claude today's date, so date-relative phrases ("tháng này", "năm nay") resolved against the model's training-cutoff guess — hence "tháng 7/2025".

## Fix

- **Tier-1 rule guard** (`orchestrator.py`): before paying for the tier-2 cascade, consult the *free, synchronous* rule classifier. A non-UNCLEAR intent at `>= HIGH_CONFIDENCE_THRESHOLD` short-circuits to Tier 1. The guard declines (returns `None`) on low confidence or unrecognised aggregates, so genuine tier-2 filter/aggregate queries ("tổng lãi portfolio", "liệt kê mã đang lỗ", "top 3 mã lãi nhất") are untouched. No LLM call in the guard — it stays instant and free.
- **Date injection** (`tier3/prompts.py`): `build_reasoning_prompt` now accepts an injectable `today` (defaults to `date.today()`) and emits a `NGÀY HÔM NAY` block that pins "tháng này"/"năm nay" to the real calendar.

## Verification

- Empirically confirmed the surgical scope: "tổng chi tiêu tháng này" → `query_expenses @ 0.9` (guard rescues to Tier 1); the genuine tier-2 aggregates above return `None` from the rule classifier (guard declines → stay Tier 2).
- New regression tests: monthly-expense rescue to Tier 1, genuine tier-2 aggregate stays Tier 2, low-confidence guard declines, and Tier-3 prompt date injection.
- `542 passed` across `backend/tests/test_agent/` + `backend/tests/test_intent/`; 58 passed on the 3 directly affected suites.

## Test plan

- [x] `pytest backend/tests/test_agent/ backend/tests/test_intent/`
- [ ] Manual smoke: send "tổng chi tiêu tháng này" in Telegram → expect a real DB expense summary with the correct month, no investment disclaimer.

https://claude.ai/code/session_01QBkSedqEGe3joG3nWBxP4i