### PR TITLE
fix(report): chuẩn hoá life_insurance sang nhãn tiếng Việt trong báo cáo thẻ

### DIFF
--- a/backend/services/chart_generator.py
+++ b/backend/services/chart_generator.py
@@ -20,6 +20,8 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 
+from backend.wealth.asset_types import get_label
+
 logger = logging.getLogger(__name__)
 
 # ── Palette ─────────────────────────────────────────────────────────────────
@@ -38,7 +40,7 @@ _ASSET_CFG: dict[str, dict] = {
     "stocks":         {"label": "Chứng khoán",    "color": "#F28E2B"},  # V1 legacy
     "mutual_fund":    {"label": "Chứng chỉ quỹ", "color": "#E15759"},  # V1 legacy
     "crypto":         {"label": "Tiền số",         "color": "#76B7B2"},
-    "life_insurance": {"label": "Bảo hiểm",       "color": "#59A14F"},
+    "life_insurance": {"label": "Bảo hiểm nhân thọ", "color": "#59A14F"},
     "gold":           {"label": "Vàng",            "color": "#EDC948"},
     "cash":           {"label": "Tiền mặt",        "color": "#B07AA1"},
     "other":          {"label": "Khác",            "color": "#BAB0AC"},
@@ -64,9 +66,11 @@ def _fmt(amount: float) -> str:
 
 def _cfg_for(asset_type: str, extra_idx: int) -> dict:
     if asset_type in _ASSET_CFG:
-        return _ASSET_CFG[asset_type]
+        cfg = dict(_ASSET_CFG[asset_type])
+        cfg["label"] = get_label(asset_type)
+        return cfg
     return {
-        "label": asset_type.replace("_", " ").title(),
+        "label": get_label(asset_type),
         "color": _EXTRA_COLORS[extra_idx % len(_EXTRA_COLORS)],
     }
 
@@ -109,13 +113,8 @@ def generate_portfolio_chart(
     extra_idx = 0
     cfg_map: dict[str, dict] = {}
     for t in sorted_types:
-        if t in _ASSET_CFG:
-            cfg_map[t] = _ASSET_CFG[t]
-        else:
-            cfg_map[t] = {
-                "label": t.replace("_", " ").title(),
-                "color": _EXTRA_COLORS[extra_idx % len(_EXTRA_COLORS)],
-            }
+        cfg_map[t] = _cfg_for(t, extra_idx)
+        if t not in _ASSET_CFG:
             extra_idx += 1
 
     sizes  = [totals[t] / grand_total * 100 for t in sorted_types]

--- a/backend/services/chart_service.py
+++ b/backend/services/chart_service.py
@@ -14,6 +14,8 @@ matplotlib.use("Agg")  # Non-interactive backend for server-side rendering
 import matplotlib.pyplot as plt
 from matplotlib.patches import FancyBboxPatch
 
+from backend.wealth.asset_types import get_label
+
 logger = logging.getLogger(__name__)
 
 # Asset type display config: label, color, emoji
@@ -22,7 +24,7 @@ ASSET_TYPE_CONFIG: dict[str, dict] = {
     "stocks": {"label": "Chứng khoán", "color": "#F28E2B", "emoji": "📈"},
     "mutual_fund": {"label": "Chứng chỉ quỹ", "color": "#E15759", "emoji": "🏦"},
     "crypto": {"label": "Tiền số", "color": "#76B7B2", "emoji": "₿"},
-    "life_insurance": {"label": "Bảo hiểm", "color": "#59A14F", "emoji": "🛡️"},
+    "life_insurance": {"label": "Bảo hiểm nhân thọ", "color": "#59A14F", "emoji": "🛡️"},
     "gold": {"label": "Vàng", "color": "#EDC948", "emoji": "🥇"},
     "cash": {"label": "Tiền mặt", "color": "#B07AA1", "emoji": "💵"},
 }
@@ -76,11 +78,12 @@ def render_donut_chart(
         if pct <= 0:
             continue
         cfg = ASSET_TYPE_CONFIG.get(asset_type, _DEFAULT_CONFIG)
-        labels.append(cfg["label"])
+        label = get_label(asset_type)
+        labels.append(label)
         sizes.append(pct)
         colors.append(cfg["color"])
         value = allocation_values.get(asset_type, 0)
-        legend_labels.append(f'{cfg["emoji"]} {cfg["label"]}: {_format_vnd(value)} ({pct:.1f}%)')
+        legend_labels.append(f'{cfg["emoji"]} {label}: {_format_vnd(value)} ({pct:.1f}%)')
 
     if not sizes:
         return _render_empty_chart()

--- a/backend/tests/test_chart_generator.py
+++ b/backend/tests/test_chart_generator.py
@@ -4,7 +4,7 @@ import zlib
 
 import pytest
 
-from backend.services.chart_generator import _empty_chart, generate_portfolio_chart
+from backend.services.chart_generator import _cfg_for, _empty_chart, generate_portfolio_chart
 
 
 def _is_png(data: bytes) -> bool:
@@ -25,6 +25,10 @@ def _png_dimensions(data: bytes) -> tuple[int, int]:
 # ---------------------------------------------------------------------------
 
 class TestGeneratePortfolioChart:
+    def test_cfg_for_life_insurance_uses_vietnamese_label(self):
+        cfg = _cfg_for("life_insurance", 0)
+        assert cfg["label"] == "Bảo hiểm nhân thọ"
+
     def test_returns_png_bytes(self):
         assets = [{"asset_type": "stocks", "value": 10_000_000}]
         result = generate_portfolio_chart(assets)


### PR DESCRIPTION
### Motivation
- Chuẩn hoá hiển thị loại tài sản `life_insurance` để dùng nhãn tiếng Việt chính thức và tận dụng hệ thống multi-language thay vì hardcode.

### Description
- Thay renderer để lấy nhãn hiển thị từ resolver chung `get_label` (từ `backend.wealth.asset_types`) trong `backend/services/chart_service.py` để legend/labels dùng tiếng Việt hệ thống.
- Cập nhật `backend/services/chart_generator.py` để `_cfg_for` trả về nhãn qua `get_label` và đảm bảo `life_insurance` hiển thị là "Bảo hiểm nhân thọ".
- Thay đổi cấu hình nhãn mặc định cho `life_insurance` trong các cấu hình báo cáo để nhất quán với tiếng Việt.
- Thêm unit test `test_cfg_for_life_insurance_uses_vietnamese_label` vào `backend/tests/test_chart_generator.py` để khoá hành vi hiển thị; commit/PR includes `Closes #NNN`.

### Testing
- Chạy `pytest -q backend/tests/test_chart_generator.py` và mọi test liên quan đều passed (15 passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15623a25f0832faee65518d2deccea)