### PR TITLE
fix(tier2): route "tổng chi tiêu" to get_transactions, not compute_metric

### DIFF
--- a/backend/agent/tier2/prompts.py
+++ b/backend/agent/tier2/prompts.py
@@ -27,10 +27,14 @@ QUY TẮC:
 3. Query về "đang lãi" / "lời" / "tăng" → filter gain_pct.gt = 0.
 4. Query về "đang lỗ" / "lỗ" / "âm" → filter gain_pct.lt = 0.
 5. Query "top N" / "nhiều nhất" / "lớn nhất" → set limit=N với sort phù hợp.
-6. Query aggregate (tổng, trung bình, tỷ lệ) → use compute_metric.
-7. Query so sánh A vs B → use compare_periods.
-8. Query giá thị trường 1 mã → use get_market_data.
-9. Query không match tool nào → trả lời text giải thích bạn không hiểu.
+6. Query "tổng chi tiêu" / "tổng chi" / "chi bao nhiêu" / "tổng giao dịch"
+   (cộng tổng các giao dịch chi tiêu) → use get_transactions. Output đã có
+   sẵn total_amount; KHÔNG dùng compute_metric để cộng tổng chi tiêu.
+7. Query metric phái sinh — chi TRUNG BÌNH, TỶ LỆ tiết kiệm, tỷ lệ chi/thu,
+   % tăng trưởng net worth, tổng lãi/lỗ portfolio → use compute_metric.
+8. Query so sánh A vs B → use compare_periods.
+9. Query giá thị trường 1 mã → use get_market_data.
+10. Query không match tool nào → trả lời text giải thích bạn không hiểu.
 
 NGÀY HÔM NAY: {today.isoformat()}.
 - "tuần này" = 7 ngày trước → hôm nay
@@ -46,6 +50,8 @@ VÍ DỤ:
   get_assets(filter={{value: {{gt: 1000000000}}}}, sort: "value_desc")
 - "Chi cho ăn uống tuần này" →
   get_transactions(filter={{category: "food", date_from: <7 ngày trước>, date_to: <hôm nay>}})
+- "Tổng chi tiêu tháng này" →
+  get_transactions(filter={{date_from: <ngày 1 tháng này>, date_to: <hôm nay>}})
 - "Tổng lãi portfolio" →
   compute_metric(metric_name: "portfolio_total_gain")
 - "Chi tháng này so với tháng trước" →

--- a/backend/tests/test_agent/test_tier2_prompt.py
+++ b/backend/tests/test_agent/test_tier2_prompt.py
@@ -1,0 +1,42 @@
+"""Tier-2 DB-Agent prompt — routing-guidance regression tests.
+
+These lock the disambiguation that prevents "tổng chi tiêu tháng này"
+from being steered to ``compute_metric`` (which has no total-expense
+metric) and then escalating to Tier 3. The total of expense rows is
+already produced by ``get_transactions.total_amount``, so summing
+spending must route there — only derived metrics (average, ratio,
+growth, portfolio PnL) belong to ``compute_metric``.
+"""
+from __future__ import annotations
+
+from datetime import date
+
+from backend.agent.tier2.prompts import build_db_agent_prompt
+
+
+class TestTier2PromptRouting:
+    def test_today_is_baked_in(self):
+        prompt = build_db_agent_prompt(today=date(2026, 5, 26))
+        assert "2026-05-26" in prompt
+
+    def test_total_spending_routes_to_get_transactions(self):
+        prompt = build_db_agent_prompt()
+        # The worked example must steer "tổng chi tiêu tháng này" to the
+        # transactions tool, not the metric tool.
+        assert "Tổng chi tiêu tháng này" in prompt
+        idx = prompt.index("Tổng chi tiêu tháng này")
+        # Scope to this bullet only (up to the next "- " example).
+        example = prompt[idx : prompt.index("\n-", idx)]
+        assert "get_transactions" in example
+        assert "compute_metric" not in example
+
+    def test_rule_forbids_compute_metric_for_total_spending(self):
+        prompt = build_db_agent_prompt()
+        assert "KHÔNG dùng compute_metric để cộng tổng chi tiêu" in prompt
+
+    def test_derived_metrics_still_route_to_compute_metric(self):
+        prompt = build_db_agent_prompt()
+        # The portfolio-PnL example stays on compute_metric.
+        idx = prompt.index("Tổng lãi portfolio")
+        following = prompt[idx : idx + 120]
+        assert "compute_metric" in following


### PR DESCRIPTION
## Bối cảnh

Đây là phần vá tiếp theo cho lỗi "tổng chi tiêu tháng này" trả lời sai (PR #850 đã thêm Tier-1 rule guard + date grounding cho Tier 3). PR này bít nốt **lỗ hổng thiết kế ở Tier 2** mà guard chỉ che được đúng một câu.

## Root cause (Tier 2)

`get_transactions` vốn đã trả về `total_amount` — nghĩa là tổng chi tiêu đã có sẵn. Nhưng prompt DB-agent (`backend/agent/tier2/prompts.py`) gộp chung **"tổng"** với "trung bình/tỷ lệ" rồi đẩy tất cả sang `compute_metric`:

> 6. Query aggregate (tổng, trung bình, tỷ lệ) → use compute_metric.

`compute_metric` **không có** metric tổng-chi-tháng (chỉ có `average_monthly_expense`, `saving_rate`, …). Nên câu "tổng chi tiêu tháng này" không bind được tool hợp lệ ở Tier 2 → escalate lên Tier 3 → Claude bịa ngày sai + gắn disclaimer. Đây là lỗi routing/prompt, **không phải** do năng lực model hay không đọc được DB.

## Thay đổi

- Tách luật #6: "tổng chi tiêu / tổng chi / chi bao nhiêu / tổng giao dịch" → `get_transactions` (đã có `total_amount`), và ghi rõ **KHÔNG** dùng `compute_metric` để cộng tổng chi tiêu.
- Luật #7 mới: chỉ metric phái sinh (trung bình, tỷ lệ, % tăng trưởng, tổng lãi/lỗ portfolio) mới dùng `compute_metric`.
- Thêm ví dụ "Tổng chi tiêu tháng này" → `get_transactions(...)`, đặt cạnh "Tổng lãi portfolio" → `compute_metric(...)` để tương phản rõ.
- Thêm test regression `backend/tests/test_agent/test_tier2_prompt.py` khóa lại hướng dẫn routing này.

## Test plan

- [x] `pytest backend/tests/test_agent/` — 173 passed
- [x] `pytest backend/tests/test_agent/test_tier2_prompt.py` — 4 passed
- [x] `ruff check` các file đã đổi — clean
- [ ] Smoke test Telegram thực tế "tổng chi cho ăn uống quý này" (cần môi trường có DeepSeek key)

https://claude.ai/code/session_01QBkSedqEGe3joG3nWBxP4i