### PR TITLE
fix(report): resolve life_insurance label in asset list & morning briefing

### DIFF
--- a/backend/briefing/morning_briefing.py
+++ b/backend/briefing/morning_briefing.py
@@ -24,6 +24,7 @@ from backend.market_data.client import get_crypto_quote, get_gold_quote
 from backend.models.bank_rate import BankRateSnapshot
 from backend.models.market_snapshot import MarketSnapshot
 from backend.models.user import User
+from backend.wealth.asset_types import get_label
 from backend.wealth.ladder import WealthLevel, detect_level
 from backend.wealth.models.asset import Asset
 from backend.wealth.services import net_worth_calculator
@@ -135,7 +136,10 @@ _ASSET_TYPE_LABELS = {
 
 
 def _asset_type_label(asset_type: str) -> str:
-    return _ASSET_TYPE_LABELS.get(str(asset_type), str(asset_type).replace("_", " ").title())
+    # Briefing keeps a few shortened labels (e.g. "Tiền mặt", "Cổ phiếu/Quỹ");
+    # fall back to the YAML-backed label so types absent from the local map
+    # (life_insurance, etc.) render their Vietnamese name, not the raw key.
+    return _ASSET_TYPE_LABELS.get(str(asset_type), get_label(asset_type))
 
 async def _portfolio_assets(db: AsyncSession, user_id) -> list[Asset]:
     result = await db.execute(select(Asset).where(Asset.user_id == user_id, Asset.is_active.is_(True)))

--- a/backend/intent/handlers/query_assets.py
+++ b/backend/intent/handlers/query_assets.py
@@ -10,6 +10,7 @@ from backend.intent.handlers.base import IntentHandler
 from backend.intent.intents import IntentResult
 from backend.intent.wealth_adapt import LevelStyle, decorate, resolve_style
 from backend.models.user import User
+from backend.wealth.asset_types import get_icon, get_label
 from backend.wealth.services import asset_service
 from backend.wealth.valuation.crypto import (
     HoldingValuation,
@@ -51,7 +52,7 @@ class QueryAssetsHandler(IntentHandler):
         )
 
     def _no_match_for_type(self, asset_type: str, user: User) -> str:
-        label = _ASSET_LABELS.get(asset_type, asset_type)
+        label = get_label(asset_type)
         name = user.display_name or "bạn"
         return (
             f"{name} chưa có {label} nào cả 🤔\n\n"
@@ -84,7 +85,7 @@ class QueryAssetsHandler(IntentHandler):
 
         name = user.display_name or "bạn"
         if filtered_type:
-            label = _ASSET_LABELS.get(filtered_type, filtered_type)
+            label = get_label(filtered_type)
             header = f"💎 {label} của {name}:"
         else:
             header = f"💎 Tài sản hiện tại của {name}:"
@@ -103,8 +104,8 @@ class QueryAssetsHandler(IntentHandler):
             reverse=True,
         )
         for asset_type, items in ordered:
-            icon = _ASSET_ICONS.get(asset_type, "📌")
-            label = _ASSET_LABELS.get(asset_type, asset_type)
+            icon = get_icon(asset_type)
+            label = get_label(asset_type)
             type_total = sum(display_values[a] for a in items)
             # Show allocation % only for Mass Affluent + HNW. Starter and
             # Young Pro see the raw amount only — fewer numbers to scan.
@@ -149,28 +150,6 @@ class QueryAssetsHandler(IntentHandler):
         # the dominant contributor to the 10s+ tail latency on the
         # interactive ``query_assets`` reply (issue #797).
         return await value_crypto_holdings(assets)
-
-
-# Inline tables — kept here rather than re-loading asset_categories.yaml
-# for every reply. If the YAML changes we update both; the reverse risk
-# (yaml drift) is caught by Phase 3A's keyboard test.
-_ASSET_LABELS = {
-    "cash": "Tiền mặt & Tài khoản",
-    "stock": "Chứng khoán",
-    "real_estate": "Bất động sản",
-    "crypto": "Tiền số",
-    "gold": "Vàng",
-    "other": "Khác",
-}
-
-_ASSET_ICONS = {
-    "cash": "💵",
-    "stock": "📈",
-    "real_estate": "🏠",
-    "crypto": "₿",
-    "gold": "🥇",
-    "other": "📦",
-}
 
 
 def _crypto_symbol(asset) -> str:

--- a/backend/tests/test_intent/test_handlers.py
+++ b/backend/tests/test_intent/test_handlers.py
@@ -187,6 +187,32 @@ async def test_query_assets_handler_crypto_uses_market_prices():
 
 
 @pytest.mark.asyncio
+async def test_query_assets_handler_life_insurance_uses_vietnamese_label():
+    from backend.intent.handlers.query_assets import QueryAssetsHandler
+
+    assets = [
+        _fake_asset(
+            name="AIA hợp đồng",
+            asset_type="life_insurance",
+            current_value=Decimal("50000000"),
+        ),
+    ]
+    with patch(
+        "backend.intent.handlers.query_assets.asset_service.get_user_assets",
+        AsyncMock(return_value=assets),
+    ):
+        intent = IntentResult(
+            intent=IntentType.QUERY_ASSETS,
+            confidence=0.95,
+            raw_text="tài sản của tôi",
+        )
+        response = await QueryAssetsHandler().handle(intent, _user(), _fake_db())
+
+    assert "Bảo hiểm nhân thọ" in response
+    assert "life_insurance" not in response
+
+
+@pytest.mark.asyncio
 async def test_query_assets_handler_empty_state():
     from backend.intent.handlers.query_assets import QueryAssetsHandler
 


### PR DESCRIPTION
## Vấn đề

Sau khi merge #851, báo cáo tài sản **vẫn** hiển thị `life_insurance` thô.

Nguyên nhân: #851 chỉ sửa **báo cáo thẻ dạng ảnh** (`chart_generator.py`, `chart_service.py`). Còn các báo cáo **dạng text** vẫn dùng bảng nhãn cục bộ (local label map) bị lệch với YAML và **không có** `life_insurance`:

- `backend/intent/handlers/query_assets.py` — `_ASSET_LABELS.get(asset_type, asset_type)` → rơi về key thô `"life_insurance"` (đây là báo cáo `💎 Tài sản hiện tại của ...`).
- `backend/briefing/morning_briefing.py` — `_asset_type_label` fallback `.replace("_"," ").title()` → ra `"Life Insurance"` trong dòng phân bổ tài sản của briefing sáng.

## Thay đổi

- `query_assets.py`: bỏ 2 dict cục bộ `_ASSET_LABELS`/`_ASSET_ICONS`, dùng `get_label`/`get_icon` (nguồn chân lý từ `content/asset_categories.yaml`). Nhãn của các loại tài sản cũ **không đổi** (đã đối chiếu khớp YAML), `life_insurance` giờ ra **"Bảo hiểm nhân thọ"**.
- `morning_briefing.py`: giữ nhãn rút gọn cho cash/stock, chỉ đổi nhánh fallback sang `get_label` để loại nào không có trong map cục bộ (như `life_insurance`) hiển thị đúng tên tiếng Việt thay vì key thô.
- Thêm test hồi quy `test_query_assets_handler_life_insurance_uses_vietnamese_label`.

## Kiểm thử

- `pytest backend/tests/test_intent/test_handlers.py` — 26 passed
- `pytest backend/tests/test_chart_generator.py backend/tests/test_morning_report.py` — passed
- `ruff check` các file đã sửa — clean

## Test plan

- [ ] Người dùng có hợp đồng BHNT → hỏi "tài sản của tôi" → nhóm hiển thị "🛡️ Bảo hiểm nhân thọ", không còn `life_insurance`.
- [ ] Báo cáo sáng (morning briefing) → dòng phân bổ hiển thị "Bảo hiểm nhân thọ".

https://claude.ai/code/session_01SfAFVPhbKdLda9mfEnnbvQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01SfAFVPhbKdLda9mfEnnbvQ)_