### PR TITLE
fix(ocr): preserve transfer note and add category picker before confirm

### DIFF
--- a/backend/bot/formatters/templates.py
+++ b/backend/bot/formatters/templates.py
@@ -75,24 +75,34 @@ def format_receipt_confirmation(
     receipt_date: date | None = None,
     items: list[tuple[str, float | None]] | None = None,
     confidence: str = "high",
-    auto_categorized: bool = True,
+    note: str | None = None,
+    category_uncertain: bool = False,
 ) -> str:
-    """Confirmation message sent after auto-saving an OCR receipt.
+    """Body of the confirmation message for an OCR receipt pending confirm.
 
-    Mirrors `format_transaction_confirmation` aesthetic but adds the
-    receipt-specific date (dd/mm/yyyy) and a compact item list. Pairs
-    with `transaction_actions_keyboard` so the user can re-categorize,
-    edit, or undo within the 5s window.
+    Renders the parsed facts (merchant, amount, date, category, note,
+    item list). The caller owns the trailing call-to-action and the
+    inline keyboard so the prompt always matches the buttons shown.
+
+    ``note`` surfaces the receipt's "Lời nhắn"/transfer memo so it isn't
+    silently dropped. ``category_uncertain`` switches the category line to
+    an invitation to pick when we couldn't confidently auto-categorize.
     """
     cat = get_category(category_code)
 
-    lines: list[str] = ["🧾 Đã ghi hoá đơn!", ""]
+    lines: list[str] = ["🧾 Đã đọc hoá đơn!", ""]
     lines.append(f"{cat.emoji} {merchant}  —  {format_money_full(amount)}")
 
     if receipt_date:
         lines.append(f"📅 {receipt_date.strftime('%d/%m/%Y')}")
 
-    lines.append(f"🏷 Danh mục: {cat.name_vi}")
+    if category_uncertain:
+        lines.append("🏷 Danh mục: bạn chọn giúp mình bên dưới nhé 👇")
+    else:
+        lines.append(f"🏷 Danh mục: {cat.name_vi}")
+
+    if note:
+        lines.append(f"📝 Nội dung: {note}")
 
     if items:
         lines.append("")
@@ -111,12 +121,6 @@ def format_receipt_confirmation(
     if confidence == "low":
         lines.append("")
         lines.append("⚠️ Mình đọc chưa chắc — bạn rà lại số tiền giúp nhé.")
-
-    lines.append("")
-    if auto_categorized:
-        lines.append("Tap 🏷 nếu cần đổi danh mục, hoặc ↶ để hủy.")
-    else:
-        lines.append("Tap ↶ trong 5s nếu bạn muốn hủy nhé.")
 
     return "\n".join(lines)
 

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -270,6 +270,7 @@ async def handle_transaction_callback(
         CallbackPrefix.UNDO_TRANSACTION: _handle_undo_transaction,
         CallbackPrefix.UNDO_TRANSACTION_BATCH: _handle_undo_transaction_batch,
         CallbackPrefix.EDIT_TRANSACTION: _handle_edit_transaction,
+        CallbackPrefix.RECEIPT_CATEGORY: _handle_receipt_category,
     }
 
     handler = handlers.get(prefix)
@@ -389,6 +390,42 @@ async def _handle_delete_transaction(
         reply_markup=confirm_delete_keyboard(str(expense.id)),
     )
     await answer_callback(callback_id)
+
+
+async def _handle_receipt_category(
+    *, db, user, args, callback_id, chat_id, message_id
+):
+    """User picked a category on a pending OCR receipt (before confirming).
+
+    Updates the in-memory pending payload and re-renders the confirmation
+    message in place so the chosen category is ticked and reflected in the
+    body. The expense itself is only written on the later ``confirm`` tap.
+    """
+    if len(args) < 2:
+        await answer_callback(callback_id)
+        return
+
+    token, code = args[0], str(args[1]).strip().lower()
+    rendered = photo_receipt.set_pending_receipt_category(
+        token=token, user=user, category=code
+    )
+    if rendered is None:
+        await answer_callback(
+            callback_id,
+            text="Phiên xác nhận đã hết hạn — bạn chụp lại hoá đơn giúp mình nhé.",
+            show_alert=True,
+        )
+        return
+
+    text, keyboard = rendered
+    await edit_message_text(
+        chat_id=chat_id,
+        message_id=message_id,
+        text=text,
+        parse_mode=None,
+        reply_markup=keyboard,
+    )
+    await answer_callback(callback_id, text="Đã chọn danh mục 👌")
 
 
 async def _handle_confirm_action(*, db, user, args, callback_id, chat_id, message_id):

--- a/backend/bot/handlers/photo_receipt.py
+++ b/backend/bot/handlers/photo_receipt.py
@@ -48,6 +48,8 @@ from backend import analytics
 from backend.bot.formatters.money import format_money_short
 from backend.bot.formatters.templates import format_receipt_confirmation
 from backend.bot.handlers.transaction import _normalize_category
+from backend.bot.keyboards.transaction_keyboard import receipt_confirm_keyboard
+from backend.config.categories import get_all_categories
 from backend.models.user import User
 from backend.schemas.expense import VALID_CATEGORIES, ExpenseCreate
 from backend.services import expense_service
@@ -79,6 +81,45 @@ EVENT_RECEIPT_PHOTO_FAILED = "receipt_photo_failed"
 EVENT_RECEIPT_EXPENSE_AUTOSAVED = "receipt_expense_autosaved"
 _PENDING_RECEIPT_TTL_S = 180
 _pending_receipt_confirms: dict[str, dict[str, Any]] = {}
+
+# Receipt notes are echoed back to the user and persisted verbatim; bound
+# the length so a noisy OCR dump can't blow up the message or the column.
+_MAX_NOTE_LEN = 200
+
+# Display-code namespace the inline category picker offers. A user pick must
+# be one of these before we mutate the pending payload.
+_VALID_DISPLAY_CATEGORY_CODES = frozenset(cat.code for cat in get_all_categories())
+
+
+def _clean_note(value: Any) -> str | None:
+    """Normalize an OCR-extracted note: collapse whitespace, bound length.
+
+    Returns ``None`` for empty/non-string input so callers can fall back to
+    an item-name preview.
+    """
+    if not isinstance(value, str):
+        return None
+    cleaned = " ".join(value.split())
+    if not cleaned:
+        return None
+    if len(cleaned) > _MAX_NOTE_LEN:
+        cleaned = cleaned[:_MAX_NOTE_LEN].rstrip() + "…"
+    return cleaned
+
+
+def _item_name_preview(items: list[Any]) -> str | None:
+    """Short ", "-joined preview of item names, used when no OCR note exists."""
+    names = [
+        str(it.get("name") or "").strip()
+        for it in items
+        if isinstance(it, dict) and (it.get("name") or "").strip()
+    ]
+    if not names:
+        return None
+    preview = ", ".join(names[:3])
+    if len(names) > 3:
+        preview += f" +{len(names) - 3}"
+    return preview
 
 
 def _parse_iso_date(value: Any) -> date | None:
@@ -216,6 +257,55 @@ def _format_receipt(result: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _render_receipt_confirmation(
+    payload: dict[str, Any], token: str
+) -> tuple[str, dict]:
+    """Build the confirmation text + inline keyboard from a pending payload.
+
+    Single source of truth for both the first render (after OCR) and the
+    re-render after a category pick, so the message body and the keyboard's
+    ticked category never drift apart.
+
+    A stored ``needs_review`` category means we couldn't confidently
+    auto-categorize: the body invites the user to pick and the keyboard
+    leaves every category un-ticked instead of pre-selecting "Khác".
+    """
+    stored = str(payload.get("category") or "needs_review")
+    uncertain = stored == "needs_review"
+    display_code = _normalize_category(stored)
+
+    note = payload.get("note")
+    items = [
+        (str(it.get("name") or ""), it.get("price"))
+        for it in (payload.get("items") or [])
+        if isinstance(it, dict)
+    ]
+    merchant = payload.get("merchant") or note or "Hoá đơn"
+    receipt_date = _parse_iso_date(payload.get("expense_date"))
+
+    body = format_receipt_confirmation(
+        merchant=str(merchant),
+        amount=float(payload["amount"]),
+        category_code=display_code,
+        receipt_date=receipt_date,
+        items=items,
+        confidence=str(payload.get("confidence") or "medium"),
+        note=note,
+        category_uncertain=uncertain,
+    )
+
+    if uncertain:
+        cta = "Chọn danh mục bên dưới rồi tap ✅ Đồng ý để lưu nhé 👇"
+    else:
+        cta = "Đúng rồi thì tap ✅ Đồng ý. Muốn đổi danh mục thì chọn bên dưới."
+
+    text = f"{body}\n\n{cta}"
+    keyboard = receipt_confirm_keyboard(
+        token, selected_code=None if uncertain else display_code
+    )
+    return text, keyboard
+
+
 async def _autosave_and_confirm(
     *,
     db: AsyncSession,
@@ -241,7 +331,7 @@ async def _autosave_and_confirm(
     parsed_date = _parse_iso_date(result.get("date")) or date.today()
     confidence = (result.get("confidence") or "medium").lower()
     items = result.get("items") or []
-    category = _resolve_ocr_category(result.get("category_suggestion"))
+    schema_category = _resolve_ocr_category(result.get("category_suggestion"))
 
     if amount <= 0:
         # Can't auto-save without a total. Keep the legacy read-only view
@@ -253,19 +343,16 @@ async def _autosave_and_confirm(
         )
         return
 
-    note_bits: list[str] = []
-    if items:
-        names = [
-            str(it.get("name") or "").strip()
-            for it in items
-            if isinstance(it, dict) and (it.get("name") or "").strip()
-        ]
-        if names:
-            preview = ", ".join(names[:3])
-            if len(names) > 3:
-                preview += f" +{len(names) - 3}"
-            note_bits.append(preview)
-    note = " · ".join(note_bits) or None
+    # Prefer the receipt's own memo ("Lời nhắn"/"Nội dung chuyển khoản")
+    # so transfer details aren't dropped; fall back to an item preview.
+    note = _clean_note(result.get("note")) or _item_name_preview(items)
+
+    # Keep ``needs_review`` so ``create_expense`` runs its LLM categorizer on
+    # the no-pick path; otherwise store the display code we actually show.
+    if schema_category == "needs_review":
+        category = "needs_review"
+    else:
+        category = _normalize_category(schema_category)
 
     token = secrets.token_urlsafe(8)
     _pending_receipt_confirms[token] = {
@@ -281,26 +368,9 @@ async def _autosave_and_confirm(
         "items": items[:20],
         "category_suggestion": result.get("category_suggestion"),
     }
-    text = format_receipt_confirmation(
-        merchant=merchant or note or "Hoá đơn",
-        amount=amount,
-        category_code=_normalize_category(category),
-        receipt_date=parsed_date,
-        items=[
-            (str(it.get("name") or ""), it.get("price"))
-            for it in items
-            if isinstance(it, dict)
-        ],
-        confidence=confidence,
-        auto_categorized=True,
+    text, keyboard = _render_receipt_confirmation(
+        _pending_receipt_confirms[token], token
     )
-    text += "\n\n✅ Đồng ý để mình lưu khoản chi này?"
-    keyboard = {
-        "inline_keyboard": [[
-            {"text": "✅ Đồng ý", "callback_data": f"confirm:receipt:{token}"},
-            {"text": "❌ Huỷ", "callback_data": f"cancel:receipt:{token}"},
-        ]]
-    }
 
     edited = False
     if ack_id:
@@ -323,6 +393,7 @@ async def _autosave_and_confirm(
             reply_markup=keyboard,
         )
 
+
 async def confirm_pending_receipt(*, db: AsyncSession, user: User, token: str) -> bool:
     payload = _pending_receipt_confirms.pop(token, None)
     if not payload or payload.get("user_id") != str(user.id):
@@ -340,10 +411,38 @@ async def confirm_pending_receipt(*, db: AsyncSession, user: User, token: str) -
             source="ocr",
             expense_date=date.fromisoformat(str(payload["expense_date"])),
             note=payload.get("note"),
-            raw_data={"ocr": {"confidence": payload.get("confidence"), "category_suggestion": payload.get("category_suggestion"), "items": payload.get("items") or []}},
+            raw_data={
+                "ocr": {
+                    "confidence": payload.get("confidence"),
+                    "category_suggestion": payload.get("category_suggestion"),
+                    "items": payload.get("items") or [],
+                }
+            },
         ),
     )
     return True
+
+
+def set_pending_receipt_category(
+    *, token: str, user: User, category: str
+) -> tuple[str, dict] | None:
+    """Record the user's category pick on a pending receipt; re-render it.
+
+    Returns the refreshed ``(text, keyboard)`` so the caller can edit the
+    confirmation message in place, or ``None`` when the pick is rejected —
+    unknown token, not the owner, expired, or an invalid display code (a
+    spoofed callback). Picking refreshes the TTL so the user isn't rushed.
+    """
+    payload = _pending_receipt_confirms.get(token)
+    if not payload or payload.get("user_id") != str(user.id):
+        return None
+    if time.monotonic() - float(payload.get("created_at", 0)) > _PENDING_RECEIPT_TTL_S:
+        return None
+    if category not in _VALID_DISPLAY_CATEGORY_CODES:
+        return None
+    payload["category"] = category
+    payload["created_at"] = time.monotonic()
+    return _render_receipt_confirmation(payload, token)
 
 
 async def handle_photo_message(
@@ -520,5 +619,7 @@ __all__ = [
     "EVENT_RECEIPT_PHOTO_FAILED",
     "EVENT_RECEIPT_PHOTO_PARSED",
     "EVENT_RECEIPT_PHOTO_RECEIVED",
+    "confirm_pending_receipt",
     "handle_photo_message",
+    "set_pending_receipt_category",
 ]

--- a/backend/bot/keyboards/common.py
+++ b/backend/bot/keyboards/common.py
@@ -26,6 +26,7 @@ class CallbackPrefix:
     UNDO_TRANSACTION_BATCH = "undo_batch"
     VIEW_REPORT = "view_report"
     SELECT_CATEGORY = "sel_cat"
+    RECEIPT_CATEGORY = "rcat"
     CONFIRM_ACTION = "confirm"
     CANCEL_ACTION = "cancel"
 

--- a/backend/bot/keyboards/transaction_keyboard.py
+++ b/backend/bot/keyboards/transaction_keyboard.py
@@ -101,6 +101,47 @@ def category_picker_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
     return {"inline_keyboard": rows}
 
 
+def receipt_confirm_keyboard(
+    token: str, selected_code: str | None = None
+) -> InlineKeyboardMarkup:
+    """Keyboard xác nhận hoá đơn OCR: lưới danh mục + 2 nút Đồng ý/Huỷ.
+
+    Layout:
+        [🍜 Ăn uống] [🚗 Di chuyển]
+        ... (2 cột danh mục) ...
+        [✅ Đồng ý]  [❌ Huỷ]
+
+    ``selected_code`` (display code) được đánh dấu "✓ " để user thấy lựa
+    chọn hiện tại. Khi chưa chọn (None) không cột nào được tick.
+    """
+    categories = get_all_categories()
+    rows: list[list[dict]] = []
+
+    for i in range(0, len(categories), 2):
+        row = []
+        for cat in categories[i : i + 2]:
+            label = f"{cat.emoji} {cat.name_vi}"
+            if selected_code and cat.code == selected_code:
+                label = f"✓ {label}"
+            row.append(
+                {
+                    "text": label,
+                    "callback_data": build_callback(
+                        CallbackPrefix.RECEIPT_CATEGORY, token, cat.code
+                    ),
+                }
+            )
+        rows.append(row)
+
+    rows.append(
+        [
+            {"text": "✅ Đồng ý", "callback_data": f"confirm:receipt:{token}"},
+            {"text": "❌ Huỷ", "callback_data": f"cancel:receipt:{token}"},
+        ]
+    )
+    return {"inline_keyboard": rows}
+
+
 def confirm_delete_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
     """Xác nhận trước khi xóa giao dịch."""
     tx = str(transaction_id)

--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -56,6 +56,7 @@ Hãy trả về DUY NHẤT một JSON theo schema sau, không kèm giải thích
   "merchant_name": <string hoặc null>,
   "date": "YYYY-MM-DD" | null,
   "items": [{{"name": <string>, "price": <số>}}],
+  "note": <string hoặc null>,
   "category_suggestion": "food_drink"|"transport"|"shopping"|"health"|"entertainment"|"utilities"|"other",
   "confidence": "high"|"medium"|"low",
   "error": null | "not_a_receipt"
@@ -65,6 +66,7 @@ Quy tắc:
 - Nếu text không giống hoá đơn (không có tổng tiền, không có merchant rõ ràng) → đặt "error": "not_a_receipt" và các field khác để null/0.
 - ``total_amount`` chọn dòng tổng cuối cùng (TỔNG CỘNG / TOTAL / THÀNH TIỀN), KHÔNG cộng dồn các dòng item.
 - Bỏ dấu phân cách hàng nghìn khi parse số. Ví dụ "150.000" → 150000.
+- ``note``: nội dung/diễn giải giao dịch — lấy NGUYÊN VĂN dòng "Lời nhắn", "Nội dung chuyển khoản", "Nội dung giao dịch", "Diễn giải", "Nội dung", "payment reference" hoặc "memo" nếu có. KHÔNG tóm tắt, KHÔNG thêm chữ. Nếu không có → null.
 - ``confidence``: "high" nếu thấy rõ total + merchant; "medium" nếu thiếu 1 field; "low" nếu nhiều field phải đoán.
 
 === OCR TEXT ===
@@ -161,6 +163,7 @@ async def parse_receipt_image(
             "merchant_name": None,
             "date": None,
             "items": [],
+            "note": None,
             "category_suggestion": "other",
             "confidence": "low",
             "error": "not_a_receipt",

--- a/backend/tests/test_callbacks_receipt_flow.py
+++ b/backend/tests/test_callbacks_receipt_flow.py
@@ -6,6 +6,78 @@ from backend.bot.handlers import callbacks
 
 
 @pytest.mark.asyncio
+async def test_handle_receipt_category_edits_message_with_rerender():
+    user = MagicMock()
+    rendered = ("new body", {"inline_keyboard": [[{"text": "✓ x"}]]})
+    with patch.object(
+        callbacks.photo_receipt,
+        "set_pending_receipt_category",
+        return_value=rendered,
+    ) as setcat, \
+         patch.object(callbacks, "edit_message_text", AsyncMock()) as edit, \
+         patch.object(callbacks, "answer_callback", AsyncMock()) as answer:
+        await callbacks._handle_receipt_category(
+            db=MagicMock(),
+            user=user,
+            args=["tok123", "transfer"],
+            callback_id="cb1",
+            chat_id=999,
+            message_id=77,
+        )
+    setcat.assert_called_once_with(token="tok123", user=user, category="transfer")
+    edit.assert_awaited_once_with(
+        chat_id=999,
+        message_id=77,
+        text="new body",
+        parse_mode=None,
+        reply_markup=rendered[1],
+    )
+    answer.assert_awaited_once_with("cb1", text="Đã chọn danh mục 👌")
+
+
+@pytest.mark.asyncio
+async def test_handle_receipt_category_expired_alerts_user():
+    with patch.object(
+        callbacks.photo_receipt,
+        "set_pending_receipt_category",
+        return_value=None,
+    ), \
+         patch.object(callbacks, "edit_message_text", AsyncMock()) as edit, \
+         patch.object(callbacks, "answer_callback", AsyncMock()) as answer:
+        await callbacks._handle_receipt_category(
+            db=MagicMock(),
+            user=MagicMock(),
+            args=["tok123", "transfer"],
+            callback_id="cb1",
+            chat_id=999,
+            message_id=77,
+        )
+    edit.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+
+
+@pytest.mark.asyncio
+async def test_handle_receipt_category_ignores_malformed_args():
+    with patch.object(
+        callbacks.photo_receipt, "set_pending_receipt_category"
+    ) as setcat, \
+         patch.object(callbacks, "edit_message_text", AsyncMock()) as edit, \
+         patch.object(callbacks, "answer_callback", AsyncMock()) as answer:
+        await callbacks._handle_receipt_category(
+            db=MagicMock(),
+            user=MagicMock(),
+            args=["tok123"],
+            callback_id="cb1",
+            chat_id=999,
+            message_id=77,
+        )
+    setcat.assert_not_called()
+    edit.assert_not_awaited()
+    answer.assert_awaited_once_with("cb1")
+
+
+@pytest.mark.asyncio
 async def test_handle_cancel_action_receipt_branch_hides_keyboard():
     with patch.object(callbacks, "edit_message_reply_markup", AsyncMock()) as edit, \
          patch.object(callbacks, "answer_callback", AsyncMock()) as answer:

--- a/backend/tests/test_photo_receipt_handler.py
+++ b/backend/tests/test_photo_receipt_handler.py
@@ -113,7 +113,7 @@ async def test_handle_photo_returns_false_when_no_image():
 
 
 @pytest.mark.asyncio
-async def test_handle_photo_happy_path_shows_two_button_confirm():
+async def test_handle_photo_happy_path_shows_category_grid_and_confirm():
 
     user = _user()
     msg = _photo_message(photos=[
@@ -144,6 +144,7 @@ async def test_handle_photo_happy_path_shows_two_button_confirm():
 
     assert ok is True
     ocr.assert_awaited_once()
+    # Nothing is persisted until the user taps Đồng ý.
     create.assert_not_awaited()
     # Confirmation rendered with dd/mm/yyyy date and an inline keyboard.
     edit.assert_awaited()
@@ -153,9 +154,19 @@ async def test_handle_photo_happy_path_shows_two_button_confirm():
     assert "2026-05-13" not in final_text
     keyboard = edit.await_args.kwargs["reply_markup"]
     assert keyboard and keyboard["inline_keyboard"]
-    # OCR flow now has only two actions: Đồng ý / Huỷ.
     flat_buttons = [b for row in keyboard["inline_keyboard"] for b in row]
-    assert [b["text"] for b in flat_buttons] == ["✅ Đồng ý", "❌ Huỷ"]
+    button_texts = [b["text"] for b in flat_buttons]
+    # The picker now prepends a category grid before the confirm/cancel row.
+    assert "✅ Đồng ý" in button_texts
+    assert "❌ Huỷ" in button_texts
+    assert len(button_texts) > 2
+    # A confident OCR category (food_drink → food/Ăn uống) is pre-ticked.
+    assert any(t.startswith("✓ ") for t in button_texts)
+    # The confirm/cancel pair is the final row, kept together.
+    assert [b["text"] for b in keyboard["inline_keyboard"][-1]] == [
+        "✅ Đồng ý",
+        "❌ Huỷ",
+    ]
 
 
 @pytest.mark.asyncio
@@ -315,6 +326,311 @@ async def test_handle_photo_download_failure():
     assert ok is True
     ocr.assert_not_awaited()
     assert "không tải được ảnh" in edit.await_args.kwargs["text"]
+
+
+# ---------------------------------------------------------------------------
+# Task 1 — transaction note ("Lời nhắn" / "Nội dung chuyển khoản") extraction
+# ---------------------------------------------------------------------------
+
+
+def test_clean_note_collapses_whitespace():
+    assert photo_receipt._clean_note("  Link  power\nchuyển   tiền ") == (
+        "Link power chuyển tiền"
+    )
+
+
+def test_clean_note_returns_none_for_empty_or_non_string():
+    assert photo_receipt._clean_note("") is None
+    assert photo_receipt._clean_note("   \n\t ") is None
+    assert photo_receipt._clean_note(None) is None
+    assert photo_receipt._clean_note(12345) is None
+
+
+def test_clean_note_bounds_length():
+    long = "x" * (photo_receipt._MAX_NOTE_LEN + 50)
+    out = photo_receipt._clean_note(long)
+    assert out is not None
+    assert out.endswith("…")
+    # The ellipsis replaces the overflow, so the body stays within the cap.
+    assert len(out) <= photo_receipt._MAX_NOTE_LEN + 1
+
+
+def test_item_name_preview_joins_first_three_with_overflow():
+    items = [
+        {"name": "Cà phê"},
+        {"name": "Bánh mì"},
+        {"name": "Trà"},
+        {"name": "Nước"},
+        {"name": "Kẹo"},
+    ]
+    assert photo_receipt._item_name_preview(items) == "Cà phê, Bánh mì, Trà +2"
+
+
+def test_item_name_preview_none_when_no_named_items():
+    assert photo_receipt._item_name_preview([]) is None
+    assert photo_receipt._item_name_preview([{"price": 1000}]) is None
+    assert photo_receipt._item_name_preview([{"name": "   "}]) is None
+
+
+@pytest.mark.asyncio
+async def test_autosave_prefers_ocr_note_over_item_preview():
+    """A transfer memo must survive into the pending payload and the message."""
+    user = _user()
+    msg = _photo_message(photos=[{"file_id": "good", "width": 1280, "height": 960}])
+    parsed = {
+        "total_amount": 2700000,
+        "currency": "VND",
+        "merchant_name": "NGUYEN THI THUY",
+        "date": "2026-04-22",
+        "items": [{"name": "Chuyển khoản", "price": 2700000}],
+        "category_suggestion": None,
+        "note": "Link power chuyển tiền so do thua dat 841",
+        "confidence": "high",
+        "error": None,
+    }
+    photo_receipt._pending_receipt_confirms.clear()
+    with patch.object(photo_receipt, "send_message",
+                       AsyncMock(return_value={"result": {"message_id": 5}})), \
+         patch.object(photo_receipt, "edit_message_text", AsyncMock()) as edit, \
+         patch.object(photo_receipt, "send_chat_action", AsyncMock()), \
+         patch.object(photo_receipt, "download_file", AsyncMock(return_value=b"img")), \
+         patch.object(photo_receipt.expense_service, "create_expense", AsyncMock()), \
+         patch.object(photo_receipt, "parse_receipt_image",
+                       AsyncMock(return_value=parsed)):
+        ok = await photo_receipt.handle_photo_message(MagicMock(), msg, user)
+
+    assert ok is True
+    # The OCR memo (not the item name) is echoed back to the user...
+    final_text = edit.await_args.kwargs["text"]
+    assert "Link power chuyển tiền so do thua dat 841" in final_text
+    # ...and stored verbatim on the pending payload for the eventual save.
+    (payload,) = photo_receipt._pending_receipt_confirms.values()
+    assert payload["note"] == "Link power chuyển tiền so do thua dat 841"
+    photo_receipt._pending_receipt_confirms.clear()
+
+
+@pytest.mark.asyncio
+async def test_autosave_falls_back_to_item_preview_without_note():
+    user = _user()
+    msg = _photo_message(photos=[{"file_id": "good", "width": 1280, "height": 960}])
+    parsed = {
+        "total_amount": 95000,
+        "currency": "VND",
+        "merchant_name": "Highlands",
+        "date": "2026-05-13",
+        "items": [{"name": "Cà phê"}, {"name": "Bánh"}],
+        "category_suggestion": "food_drink",
+        "note": None,
+        "confidence": "high",
+        "error": None,
+    }
+    photo_receipt._pending_receipt_confirms.clear()
+    with patch.object(photo_receipt, "send_message",
+                       AsyncMock(return_value={"result": {"message_id": 5}})), \
+         patch.object(photo_receipt, "edit_message_text", AsyncMock()), \
+         patch.object(photo_receipt, "send_chat_action", AsyncMock()), \
+         patch.object(photo_receipt, "download_file", AsyncMock(return_value=b"img")), \
+         patch.object(photo_receipt.expense_service, "create_expense", AsyncMock()), \
+         patch.object(photo_receipt, "parse_receipt_image",
+                       AsyncMock(return_value=parsed)):
+        await photo_receipt.handle_photo_message(MagicMock(), msg, user)
+
+    (payload,) = photo_receipt._pending_receipt_confirms.values()
+    assert payload["note"] == "Cà phê, Bánh"
+    photo_receipt._pending_receipt_confirms.clear()
+
+
+# ---------------------------------------------------------------------------
+# Task 2 — inline category picker before confirm
+# ---------------------------------------------------------------------------
+
+
+def test_render_receipt_confirmation_uncertain_invites_pick():
+    payload = {
+        "user_id": "u1",
+        "amount": 2700000.0,
+        "currency": "VND",
+        "merchant": "NGUYEN THI THUY",
+        "category": "needs_review",
+        "expense_date": "2026-04-22",
+        "note": "Link power",
+        "confidence": "high",
+        "items": [],
+    }
+    text, keyboard = photo_receipt._render_receipt_confirmation(payload, "tok")
+    # Invitation copy, not a concrete (possibly wrong) "Khác" label.
+    assert "bạn chọn" in text
+    button_texts = [
+        b["text"] for row in keyboard["inline_keyboard"] for b in row
+    ]
+    # Nothing pre-ticked while the category is still uncertain.
+    assert not any(t.startswith("✓ ") for t in button_texts)
+    assert [b["text"] for b in keyboard["inline_keyboard"][-1]] == [
+        "✅ Đồng ý",
+        "❌ Huỷ",
+    ]
+
+
+def test_render_receipt_confirmation_confident_ticks_category():
+    payload = {
+        "user_id": "u1",
+        "amount": 95000.0,
+        "currency": "VND",
+        "merchant": "Highlands",
+        "category": "food",
+        "expense_date": "2026-05-13",
+        "note": None,
+        "confidence": "high",
+        "items": [],
+    }
+    text, keyboard = photo_receipt._render_receipt_confirmation(payload, "tok")
+    assert "Ăn uống" in text
+    button_texts = [
+        b["text"] for row in keyboard["inline_keyboard"] for b in row
+    ]
+    ticked = [t for t in button_texts if t.startswith("✓ ")]
+    assert len(ticked) == 1
+    assert "Ăn uống" in ticked[0]
+
+
+def test_set_pending_receipt_category_records_valid_pick():
+    user = _user()
+    token = "tok_pick"
+    photo_receipt._pending_receipt_confirms[token] = {
+        "created_at": 100.0,
+        "user_id": str(user.id),
+        "amount": 2700000.0,
+        "currency": "VND",
+        "merchant": "NGUYEN THI THUY",
+        "category": "needs_review",
+        "expense_date": "2026-04-22",
+        "note": "Link power",
+        "confidence": "high",
+        "items": [],
+    }
+    with patch.object(photo_receipt, "time") as t:
+        t.monotonic.return_value = 150.0
+        rendered = photo_receipt.set_pending_receipt_category(
+            token=token, user=user, category="transfer"
+        )
+
+    assert rendered is not None
+    text, keyboard = rendered
+    # Pick is persisted on the payload and the TTL is refreshed.
+    payload = photo_receipt._pending_receipt_confirms[token]
+    assert payload["category"] == "transfer"
+    assert payload["created_at"] == 150.0
+    # The chosen category is now ticked in the re-rendered keyboard.
+    ticked = [
+        b["text"]
+        for row in keyboard["inline_keyboard"]
+        for b in row
+        if b["text"].startswith("✓ ")
+    ]
+    assert len(ticked) == 1
+    assert "Chuyển khoản" in ticked[0]
+    del photo_receipt._pending_receipt_confirms[token]
+
+
+def test_set_pending_receipt_category_rejects_wrong_user():
+    user = _user()
+    other = _user()
+    token = "tok_owner"
+    photo_receipt._pending_receipt_confirms[token] = {
+        "created_at": 100.0,
+        "user_id": str(other.id),
+        "amount": 1000.0,
+        "currency": "VND",
+        "category": "needs_review",
+        "expense_date": "2026-04-22",
+    }
+    with patch.object(photo_receipt, "time") as t:
+        t.monotonic.return_value = 101.0
+        assert photo_receipt.set_pending_receipt_category(
+            token=token, user=user, category="food"
+        ) is None
+    del photo_receipt._pending_receipt_confirms[token]
+
+
+def test_set_pending_receipt_category_rejects_expired():
+    user = _user()
+    token = "tok_old"
+    photo_receipt._pending_receipt_confirms[token] = {
+        "created_at": 10.0,
+        "user_id": str(user.id),
+        "amount": 1000.0,
+        "currency": "VND",
+        "category": "needs_review",
+        "expense_date": "2026-04-22",
+    }
+    with patch.object(photo_receipt, "time") as t:
+        t.monotonic.return_value = 10.0 + photo_receipt._PENDING_RECEIPT_TTL_S + 1
+        assert photo_receipt.set_pending_receipt_category(
+            token=token, user=user, category="food"
+        ) is None
+    del photo_receipt._pending_receipt_confirms[token]
+
+
+def test_set_pending_receipt_category_rejects_invalid_code():
+    """A spoofed callback carrying an unknown code must be ignored."""
+    user = _user()
+    token = "tok_bad_code"
+    photo_receipt._pending_receipt_confirms[token] = {
+        "created_at": 100.0,
+        "user_id": str(user.id),
+        "amount": 1000.0,
+        "currency": "VND",
+        "category": "needs_review",
+        "expense_date": "2026-04-22",
+    }
+    with patch.object(photo_receipt, "time") as t:
+        t.monotonic.return_value = 101.0
+        assert photo_receipt.set_pending_receipt_category(
+            token=token, user=user, category="not_a_real_category"
+        ) is None
+    # Payload is left untouched on rejection.
+    assert photo_receipt._pending_receipt_confirms[token]["category"] == "needs_review"
+    del photo_receipt._pending_receipt_confirms[token]
+
+
+def test_set_pending_receipt_category_unknown_token_returns_none():
+    user = _user()
+    assert photo_receipt.set_pending_receipt_category(
+        token="nope", user=user, category="food"
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_confirm_pending_receipt_persists_picked_category():
+    """A user-picked display category is the one written to the expense."""
+    user = _user()
+    token = "tok_picked"
+    photo_receipt._pending_receipt_confirms[token] = {
+        "created_at": 100.0,
+        "user_id": str(user.id),
+        "amount": 2700000.0,
+        "currency": "VND",
+        "merchant": "NGUYEN THI THUY",
+        "category": "transfer",
+        "expense_date": "2026-04-22",
+        "note": "Link power chuyển tiền",
+        "confidence": "high",
+        "items": [],
+        "category_suggestion": None,
+    }
+    create = AsyncMock()
+    with patch.object(photo_receipt, "time") as t, \
+         patch.object(photo_receipt.expense_service, "create_expense", create):
+        t.monotonic.return_value = 101.0
+        ok = await photo_receipt.confirm_pending_receipt(
+            db=MagicMock(), user=user, token=token
+        )
+
+    assert ok is True
+    create.assert_awaited_once()
+    expense_create = create.await_args.args[2]
+    assert expense_create.category == "transfer"
+    assert expense_create.note == "Link power chuyển tiền"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fixes two gaps in the OCR receipt flow ("Bé Tiền" reading a photographed receipt):

- **Task 1 — Note preserved.** The structuring prompt now extracts a `note` field, so the receipt's "Lời nhắn" / "Nội dung giao dịch" memo (e.g. `Link power chuyển tiền so do thua dat 841`) is saved onto the expense instead of being silently dropped. When no memo is present, it falls back to an item-name preview.
- **Task 2 — Category picker before confirm.** The confirmation message now shows a 2-column category grid so the user can choose the danh mục **before** confirming, alongside the existing ✅ Đồng ý / ❌ Huỷ buttons. The picked category re-renders in place (a ✓ marks the selection).

## Design notes

- `_render_receipt_confirmation` is the single source of truth for the body + keyboard, so the rendered text and the ticked category can never drift.
- Consistency across the two category-code namespaces: a display code is stored when OCR is confident; `needs_review` is preserved on the no-pick path so `create_expense`'s LLM categorizer still fires.
- **Performance:** category picks edit the existing message in place — no extra OCR or LLM round-trips.
- **Security:** note bounded to 200 chars; confirmation sent with `parse_mode=None` (raw text, no HTML injection from OCR-derived content); the pending-confirm token is guarded by ownership (user_id) + 180s TTL + valid display-code check, and a pick refreshes the TTL.

## Tests

- `backend/tests/test_photo_receipt_handler.py` — note cleaning/preview, autosave note precedence, category-picker rendering (uncertain vs confident), `set_pending_receipt_category` guards (wrong user / expired / invalid code / unknown token), and persistence of the picked category.
- `backend/tests/test_callbacks_receipt_flow.py` — callback re-render, expired-session alert, malformed-args handling.
- All 37 tests across the two files pass; touched files are `ruff check` clean.

## Test plan

- [ ] Photograph a bank-transfer receipt → memo appears as "📝 Nội dung" and is saved on the expense.
- [ ] Tap a category in the grid → message re-renders with a ✓ on the chosen danh mục.
- [ ] Tap ✅ Đồng ý → expense saved with the chosen category and note.
- [ ] Let the confirmation expire (>180s) → tapping a category shows the "phiên hết hạn" alert.

Close #854