### PR TITLE
fix(ocr): accept bank/e-wallet transfer screenshots in receipt parser

### DIFF
--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -59,15 +59,18 @@ Hãy trả về DUY NHẤT một JSON theo schema sau, không kèm giải thích
   "date": "YYYY-MM-DD" | null,
   "items": [{{"name": <string>, "price": <số>}}],
   "note": <string hoặc null>,
-  "category_suggestion": "food_drink"|"transport"|"shopping"|"health"|"entertainment"|"utilities"|"other",
+  "category_suggestion": "food_drink"|"transport"|"shopping"|"health"|"entertainment"|"utilities"|"other"|null,
   "confidence": "high"|"medium"|"low",
   "error": null | "not_a_receipt"
 }}
 
 Quy tắc:
-- CHỈ đặt "error": "not_a_receipt" khi text hoàn toàn KHÔNG phải chứng từ tài chính (không tìm thấy bất kỳ số tiền giao dịch nào). Ảnh chuyển tiền / giao dịch ngân hàng VẪN HỢP LỆ, dù không có "merchant" kiểu cửa hàng — đừng đặt not_a_receipt chỉ vì thiếu merchant.
+- Luồng này CHỈ ghi nhận khoản CHI (tiền ra). Đặt "error": "not_a_receipt" khi:
+  - text hoàn toàn KHÔNG phải chứng từ tài chính (không tìm thấy số tiền giao dịch nào), HOẶC
+  - là giao dịch TIỀN VÀO / nhận tiền (dấu "+", "Nhận tiền", "Ghi có", "Tiền vào", "Hoàn tiền") — KHÔNG ghi nhận như một khoản chi.
+  Ảnh chuyển tiền ĐI (tiền ra) VẪN HỢP LỆ dù không có "merchant" kiểu cửa hàng — đừng đặt not_a_receipt chỉ vì thiếu merchant.
 - Hoá đơn mua hàng: ``total_amount`` chọn dòng tổng cuối cùng (TỔNG CỘNG / TOTAL / THÀNH TIỀN), KHÔNG cộng dồn các dòng item.
-- Ảnh chuyển tiền / giao dịch: ``total_amount`` lấy từ dòng "Số tiền giao dịch" / "Số tiền"; bỏ dấu "-" và "VND" (ví dụ "-800,000 VND" → 800000). ``merchant_name`` = tên người/đơn vị nhận nếu rõ, nếu không → null. ``category_suggestion`` = "other" khi không rõ mục đích.
+- Ảnh chuyển tiền ĐI / giao dịch tiền ra: ``total_amount`` lấy từ dòng "Số tiền giao dịch" / "Số tiền"; bỏ dấu "-" và "VND" (ví dụ "-800,000 VND" → 800000). ``merchant_name`` = tên người/đơn vị nhận nếu rõ, nếu không → null. ``category_suggestion`` = null khi không rõ mục đích chi (đừng mặc định "other") để hệ thống tự phân loại.
 - Bỏ dấu phân cách hàng nghìn khi parse số. Ví dụ "150.000" → 150000.
 - ``note``: nội dung/diễn giải giao dịch — lấy NGUYÊN VĂN dòng "Lời nhắn", "Nội dung chuyển khoản", "Nội dung giao dịch", "Diễn giải", "Nội dung", "payment reference" hoặc "memo" nếu có. KHÔNG tóm tắt, KHÔNG thêm chữ. Nếu không có → null.
 - ``confidence``: "high" nếu thấy rõ số tiền + (merchant hoặc nội dung giao dịch); "medium" nếu thiếu 1 field; "low" nếu nhiều field phải đoán.

--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -46,8 +46,10 @@ def _get_client() -> httpx.AsyncClient:
     return _client
 
 
-_STRUCTURE_PROMPT = """Bạn là trợ lý phân tích hoá đơn tiếng Việt.
-Dưới đây là text trích xuất từ ảnh hoá đơn (có thể nhiễu OCR).
+_STRUCTURE_PROMPT = """Bạn là trợ lý phân tích chứng từ chi tiêu tiếng Việt.
+Dưới đây là text trích xuất từ ảnh (có thể nhiễu OCR). Ảnh có thể là:
+- Hoá đơn / biên lai mua hàng, HOẶC
+- Ảnh chụp xác nhận giao dịch / chuyển tiền (app ngân hàng, ví điện tử).
 Hãy trả về DUY NHẤT một JSON theo schema sau, không kèm giải thích:
 
 {{
@@ -63,11 +65,12 @@ Hãy trả về DUY NHẤT một JSON theo schema sau, không kèm giải thích
 }}
 
 Quy tắc:
-- Nếu text không giống hoá đơn (không có tổng tiền, không có merchant rõ ràng) → đặt "error": "not_a_receipt" và các field khác để null/0.
-- ``total_amount`` chọn dòng tổng cuối cùng (TỔNG CỘNG / TOTAL / THÀNH TIỀN), KHÔNG cộng dồn các dòng item.
+- CHỈ đặt "error": "not_a_receipt" khi text hoàn toàn KHÔNG phải chứng từ tài chính (không tìm thấy bất kỳ số tiền giao dịch nào). Ảnh chuyển tiền / giao dịch ngân hàng VẪN HỢP LỆ, dù không có "merchant" kiểu cửa hàng — đừng đặt not_a_receipt chỉ vì thiếu merchant.
+- Hoá đơn mua hàng: ``total_amount`` chọn dòng tổng cuối cùng (TỔNG CỘNG / TOTAL / THÀNH TIỀN), KHÔNG cộng dồn các dòng item.
+- Ảnh chuyển tiền / giao dịch: ``total_amount`` lấy từ dòng "Số tiền giao dịch" / "Số tiền"; bỏ dấu "-" và "VND" (ví dụ "-800,000 VND" → 800000). ``merchant_name`` = tên người/đơn vị nhận nếu rõ, nếu không → null. ``category_suggestion`` = "other" khi không rõ mục đích.
 - Bỏ dấu phân cách hàng nghìn khi parse số. Ví dụ "150.000" → 150000.
 - ``note``: nội dung/diễn giải giao dịch — lấy NGUYÊN VĂN dòng "Lời nhắn", "Nội dung chuyển khoản", "Nội dung giao dịch", "Diễn giải", "Nội dung", "payment reference" hoặc "memo" nếu có. KHÔNG tóm tắt, KHÔNG thêm chữ. Nếu không có → null.
-- ``confidence``: "high" nếu thấy rõ total + merchant; "medium" nếu thiếu 1 field; "low" nếu nhiều field phải đoán.
+- ``confidence``: "high" nếu thấy rõ số tiền + (merchant hoặc nội dung giao dịch); "medium" nếu thiếu 1 field; "low" nếu nhiều field phải đoán.
 
 === OCR TEXT ===
 {text}


### PR DESCRIPTION
## Vấn đề

Bé Tiền trả lời "Hmm, mình không thấy đây là hoá đơn 🤔" cho ảnh **xác nhận chuyển tiền** ngân hàng, dù gọi OCR trực tiếp vẫn trích xuất text đầy đủ.

## Nguyên nhân gốc (KHÔNG phải timeout)

Câu trả lời trong screenshot ("Hmm, mình không thấy đây là hoá đơn") đến từ nhánh `result.error == "not_a_receipt"` tại `backend/bot/handlers/photo_receipt.py:577`. Nếu là timeout, message sẽ là *"Mình đọc chưa được hoá đơn này 😔"* (nhánh `ValueError` tại dòng 564) — message khác hẳn.

Vậy OCR provider **đã trả về text thành công**; nhánh structuring bằng DeepSeek (`_STRUCTURE_PROMPT` trong `ocr_service.py`) mới là nơi phân loại sai. Prompt cũ yêu cầu *"không có merchant rõ ràng → not_a_receipt"*, nên ảnh chuyển tiền P2P (có số tiền `-800,000 VND` nhưng không có cửa hàng) bị từ chối.

Timeout hiện tại (đã kiểm tra, không phải nguyên nhân):
- OCR provider: `ocr_api_timeout_seconds = 20.0s`
- LLM structuring: `llm_timeout_seconds = 60.0s`

## Thay đổi

Mở rộng `_STRUCTURE_PROMPT` để chấp nhận ảnh chuyển tiền / giao dịch ngân hàng & ví điện tử:
- Lấy `total_amount` từ dòng "Số tiền giao dịch" / "Số tiền", bỏ dấu `-` và "VND".
- Cho phép `merchant_name = null` (chuyển tiền P2P không có cửa hàng).
- Chỉ đặt `not_a_receipt` khi text hoàn toàn không có số tiền giao dịch nào.

Luồng downstream (`_autosave_and_confirm`) đã hỗ trợ merchant null + ghi note từ "Nội dung giao dịch", nên không cần đổi.

## Test plan

- [x] Prompt vẫn `.format(text=...)` đúng (escaping `{{ }}` giữ nguyên schema JSON).
- [ ] Gửi lại ảnh chuyển tiền Techcombank/MB trong screenshot → Bé Tiền đọc được số tiền 800k và hỏi xác nhận danh mục.

https://claude.ai/code/session_01MPR9TSJtfxQmfZoUqUVLwF