### PR TITLE
fix(ocr): stop receipts failing on truncated structuring JSON

### DIFF
--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -35,6 +35,11 @@ TASK_MAX_TOKENS = {
     # Monthly reports contain multiple sections + bullets and were
     # getting cut mid-sentence at 500 tokens in production.
     "report_text": 900,
+    # Receipt structuring returns a JSON object (amount, merchant, date,
+    # note, items[]). At 500 tokens V4-Flash spent the budget reasoning
+    # before the answer and truncated the JSON mid-object (cut right after
+    # "date"), so json.loads failed and the bot rejected valid receipts.
+    "parse_receipt": 1500,
 }
 
 
@@ -198,6 +203,14 @@ async def call_llm(
                 timeout=effective_timeout,
             )
             result = response.choices[0].message.content.strip()
+            if getattr(response.choices[0], "finish_reason", None) == "length":
+                logger.warning(
+                    "%s response truncated at max_tokens=%d (task=%s) — "
+                    "raise TASK_MAX_TOKENS if downstream parsing fails",
+                    provider,
+                    max_tokens,
+                    task_type,
+                )
             tokens_used = response.usage.total_tokens if response.usage else None
             if response.usage:
                 recorder.tokens_in = response.usage.prompt_tokens or 0

--- a/backend/services/ocr_service.py
+++ b/backend/services/ocr_service.py
@@ -111,6 +111,65 @@ def _strip_code_fence(text: str) -> str:
     return text
 
 
+def _repair_truncated_json(text: str) -> str | None:
+    """Close a JSON object the LLM cut off at the token cap.
+
+    V4-Flash occasionally truncates mid-object (e.g. right after ``"date"``).
+    The prefix is still valid JSON, so we trim back to the last completed
+    field/element boundary and append the brackets needed to close every
+    open structure — preserving the fields we *did* receive instead of
+    discarding the whole receipt. Returns ``None`` if nothing salvageable.
+    """
+    stack: list[str] = []
+    in_string = False
+    escape = False
+    best_cut: tuple[int, str] | None = None  # (cut_index, closing_brackets)
+    for i, ch in enumerate(text):
+        if in_string:
+            if escape:
+                escape = False
+            elif ch == "\\":
+                escape = True
+            elif ch == '"':
+                in_string = False
+            continue
+        if ch == '"':
+            in_string = True
+        elif ch in "{[":
+            stack.append("}" if ch == "{" else "]")
+        elif ch in "}]":
+            if stack:
+                stack.pop()
+            # Boundary just after a completed structure.
+            best_cut = (i + 1, "".join(reversed(stack)))
+        elif ch == ",":
+            # Boundary just before a separator (drops the partial field).
+            best_cut = (i, "".join(reversed(stack)))
+    if best_cut is None:
+        return None
+    cut_index, closers = best_cut
+    return text[:cut_index] + closers
+
+
+def _loads_receipt_json(text: str) -> dict | None:
+    """Parse the structuring response, salvaging a truncated object."""
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    repaired = _repair_truncated_json(text)
+    if repaired is None:
+        return None
+    try:
+        parsed = json.loads(repaired)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(parsed, dict):
+        return None
+    logger.warning("Salvaged truncated structuring JSON (%d fields)", len(parsed))
+    return parsed
+
+
 async def _call_external_ocr(image_bytes: bytes, mime_type: str) -> str:
     """POST image to the external OCR endpoint, return extracted text."""
     headers: dict[str, str] = {"accept": "application/json"}
@@ -194,11 +253,10 @@ async def parse_receipt_image(
         raise ValueError(f"Receipt parser unavailable: {exc}") from exc
 
     response_text = _strip_code_fence(response_text)
-    try:
-        result = json.loads(response_text)
-    except json.JSONDecodeError as exc:
+    result = _loads_receipt_json(response_text)
+    if result is None:
         logger.error("Failed to parse structuring LLM response: %s", response_text[:300])
-        raise ValueError(f"Invalid JSON from receipt parser: {exc}") from exc
+        raise ValueError("Invalid JSON from receipt parser")
 
     logger.info(
         "OCR parsed: merchant=%s amount=%s confidence=%s error=%s",

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -45,6 +45,11 @@ def test_report_text_has_higher_token_budget():
     assert TASK_MAX_TOKENS.get("report_text") == 900
 
 
+def test_parse_receipt_has_higher_token_budget():
+    # 500 truncated the structuring JSON mid-object in production.
+    assert TASK_MAX_TOKENS.get("parse_receipt", 500) > 500
+
+
 @pytest.mark.asyncio
 async def test_call_llm_groq_provider_uses_groq_client():
     client = _fake_client("ok", "llama-3.3-70b-versatile")

--- a/backend/tests/test_ocr_service.py
+++ b/backend/tests/test_ocr_service.py
@@ -1,0 +1,86 @@
+"""Tests for backend.services.ocr_service structuring/salvage path.
+
+The two-stage OCR pipeline was rejecting valid receipts in production:
+the external OCR provider extracted the text fine, but DeepSeek V4-Flash
+truncated its JSON answer at the token cap (cut right after ``"date"``),
+so ``json.loads`` raised and the bot showed "đọc chưa được". These tests
+cover the salvage that recovers the fields we *did* receive, plus the
+end-to-end ``parse_receipt_image`` behaviour with a truncated response.
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from backend.services.ocr_service import (
+    _loads_receipt_json,
+    _repair_truncated_json,
+    parse_receipt_image,
+)
+
+# The exact production failure: response cut off mid-object after "date".
+TRUNCATED_RESPONSE = (
+    '{\n'
+    ' "total_amount": 4600000,\n'
+    ' "currency": "VND",\n'
+    ' "merchant_name": "NGUYEN THI THUY",\n'
+    ' "date": "2026-04-22",\n'
+)
+
+
+def test_repair_closes_object_truncated_after_field():
+    repaired = _repair_truncated_json(TRUNCATED_RESPONSE)
+    parsed = json.loads(repaired)
+    assert parsed["total_amount"] == 4600000
+    assert parsed["merchant_name"] == "NGUYEN THI THUY"
+    assert parsed["date"] == "2026-04-22"
+    # The trailing partial field is dropped, not invented.
+    assert "items" not in parsed
+
+
+def test_repair_truncated_inside_items_array():
+    truncated = (
+        '{"total_amount": 50000, "items": ['
+        '{"name": "Cà phê", "price": 30000}, '
+        '{"name": "Bánh"'
+    )
+    parsed = json.loads(_repair_truncated_json(truncated))
+    assert parsed["total_amount"] == 50000
+    # Completed element survives; the half-written one is dropped.
+    assert parsed["items"] == [{"name": "Cà phê", "price": 30000}]
+
+
+def test_repair_handles_comma_inside_string():
+    # A comma inside a quoted value must not be treated as a field boundary.
+    truncated = '{"note": "Chuyen tien, ho tro", "total_amount": 800000,'
+    parsed = json.loads(_repair_truncated_json(truncated))
+    assert parsed["note"] == "Chuyen tien, ho tro"
+    assert parsed["total_amount"] == 800000
+
+
+def test_loads_receipt_json_prefers_strict_parse():
+    valid = '{"total_amount": 100, "currency": "VND"}'
+    assert _loads_receipt_json(valid) == {"total_amount": 100, "currency": "VND"}
+
+
+def test_loads_receipt_json_returns_none_for_garbage():
+    assert _loads_receipt_json("not json at all") is None
+
+
+@pytest.mark.asyncio
+async def test_parse_receipt_recovers_from_truncated_llm_response():
+    """A truncated structuring response must still yield a usable receipt."""
+    with patch(
+        "backend.services.ocr_service._call_external_ocr",
+        new=AsyncMock(return_value="Chuyen thanh cong\nVND 4,600,000\nNGUYEN THI THUY"),
+    ), patch(
+        "backend.services.ocr_service.call_llm",
+        new=AsyncMock(return_value=TRUNCATED_RESPONSE),
+    ):
+        result = await parse_receipt_image(b"\xff\xd8fakejpeg", "image/jpeg")
+
+    assert result["total_amount"] == 4600000
+    assert result["merchant_name"] == "NGUYEN THI THUY"
+    assert result.get("error") != "not_a_receipt"


### PR DESCRIPTION
## Root cause

Issues #855/#856 fixed the *classification* of outgoing transfers, but Bé Tiền still rejected the two test receipts. The real failure is in the **structuring stage**, not OCR.

The two-stage pipeline is: external OCR provider extracts raw text → DeepSeek V4-Flash structures that text into JSON. V4-Flash is reasoning/batch-oriented and spends completion tokens *reasoning before emitting the answer*. At the default `max_tokens=500` it ran out of budget mid-object and truncated the JSON right after the `"date"` field:

```
{
 "total_amount": 4600000,
 "currency": "VND",
 "merchant_name": "NGUYEN THI THUY",
 "date": "2026-04-22",
```

`json.loads` then raised `JSONDecodeError: Expecting property name enclosed in double quotes`, the structuring step raised `ValueError`, and the handler showed *"Mình đọc chưa được hoá đơn này 😔"* — even though direct OCR read every field. This explains why the merged fixes looked ineffective: they never got the chance to run on a parseable object.

## Fix

1. **Raise the token budget** for `parse_receipt` to 1500 (`TASK_MAX_TOKENS`), so V4-Flash has room to finish the JSON after its reasoning. This prevents truncation on fresh requests.
2. **Salvage truncated JSON** (`_repair_truncated_json` / `_loads_receipt_json` in `ocr_service.py`): walk the response tracking string-state and bracket depth, trim back to the last completed field/element boundary, and close open structures. This recovers the fields we *did* receive instead of discarding the whole receipt — and crucially handles responses **already poisoned in the 30-day LLM cache** (the prompt/cache key is unchanged, so the truncated string would otherwise keep being served).
3. **Log `finish_reason == "length"`** in `llm_service.py` so future truncation surfaces in logs instead of silently failing downstream parsing.

## Tests

- `backend/tests/test_ocr_service.py` (new): reproduces the exact production truncation (cut after `"date"`), plus truncation inside an `items[]` array and a comma inside a quoted value; end-to-end `parse_receipt_image` recovers amount=4600000 / merchant=NGUYEN THI THUY and does not flag `not_a_receipt`.
- `backend/tests/test_llm_service.py`: asserts `parse_receipt` budget > 500.

All 56 relevant tests pass (14 ocr/llm + 42 photo/callbacks/cache).