### PR TITLE
fix: stop advisory LLM replies from truncating mid-sentence

### DIFF
--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -31,10 +31,24 @@ groq_client = AsyncOpenAI(
 
 # Tasks that use Claude (only OCR and complex analysis)
 USE_CLAUDE = {"ocr", "complex_analysis"}
+
+# max_tokens is a CEILING, not a target. Billing and latency track the
+# ACTUAL completion tokens the model emits, so a high cap costs nothing for
+# a short reply — it only stops the model being cut off mid-sentence.
+#
+# Vietnamese is the trap: diacritic-dense text tokenizes 2-4x heavier than
+# English, so a "max 200 từ" advisory reply routinely runs 700-1000 tokens.
+# A 500-token default silently truncated EVERY generative Vietnamese task
+# (advisory, investment_advice, roadmap_advisory, report_text, the twin /
+# life-event narratives, news summaries…) mid-sentence. We rediscovered this
+# twice via whack-a-mole — bumping report_text, then parse_receipt — before
+# fixing the root cause here: a default generous enough to hold any prose
+# reply, so a new generative task_type is safe without touching this file.
+#
+# Only register a task below when it needs MORE than the default (JSON
+# structuring), never less — capping below the default re-introduces the bug.
+DEFAULT_MAX_TOKENS = 1200
 TASK_MAX_TOKENS = {
-    # Monthly reports contain multiple sections + bullets and were
-    # getting cut mid-sentence at 500 tokens in production.
-    "report_text": 900,
     # Receipt structuring returns a JSON object (amount, merchant, date,
     # note, items[]). At 500 tokens V4-Flash spent the budget reasoning
     # before the answer and truncated the JSON mid-object (cut right after
@@ -189,7 +203,7 @@ async def call_llm(
     # via content/cost/budget_messages.yaml.
     from backend.adapters.llm.cost_tracking_adapter import tracked_call
 
-    max_tokens = TASK_MAX_TOKENS.get(task_type, 500)
+    max_tokens = TASK_MAX_TOKENS.get(task_type, DEFAULT_MAX_TOKENS)
 
     async with tracked_call(
         db, user_id, provider=provider, operation=task_type

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from backend.services.llm_service import (
+    DEFAULT_MAX_TOKENS,
     TASK_MAX_TOKENS,
     LLMError,
     call_llm,
@@ -41,13 +42,44 @@ def _fake_client(text: str, model: str):
     return client
 
 
-def test_report_text_has_higher_token_budget():
-    assert TASK_MAX_TOKENS.get("report_text") == 900
+def test_default_max_tokens_is_generous():
+    # The 500-token default truncated Vietnamese prose mid-sentence. A
+    # generous default is the root-cause fix (max_tokens is a ceiling, not a
+    # target) so new generative task_types are safe without registration.
+    assert DEFAULT_MAX_TOKENS >= 1000
+
+
+def test_report_text_falls_back_to_generous_default():
+    # report_text used to need an explicit 900 entry just to beat the old
+    # 500 default; the generous default now covers it (and all prose tasks),
+    # so it no longer needs a dedicated entry.
+    assert TASK_MAX_TOKENS.get("report_text", DEFAULT_MAX_TOKENS) >= 900
 
 
 def test_parse_receipt_has_higher_token_budget():
-    # 500 truncated the structuring JSON mid-object in production.
-    assert TASK_MAX_TOKENS.get("parse_receipt", 500) > 500
+    # 500 truncated the structuring JSON mid-object in production. This one
+    # genuinely needs MORE than the default, so it stays registered.
+    assert TASK_MAX_TOKENS["parse_receipt"] > DEFAULT_MAX_TOKENS
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "task_type", ["advisory", "investment_advice", "roadmap_advisory"]
+)
+async def test_advisory_tasks_get_generous_token_ceiling(task_type):
+    """Regression: the 500-token default cut Bé Tiền's advisory replies
+    mid-sentence (the 'Tư vấn tối ưu' / 'Cơ hội đầu tư' buttons). Every
+    generative advisory task must reach the model with a ceiling well above
+    500 — assert against the real wiring, not just the lookup table."""
+    client = _fake_client("ok", "deepseek-v4-flash")
+    with patch("backend.services.llm_service.deepseek_client", client):
+        await call_llm(
+            "prompt",
+            task_type=task_type,
+            use_cache=False,
+            shared_cache=True,
+        )
+    assert client.chat.completions.create.await_args.kwargs["max_tokens"] >= 1000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Clicking **Tài sản → Tư vấn tối ưu** or **Thị trường → Cơ hội đầu tư** produced Bé Tiền replies that were cut off mid-sentence.

Both buttons route through `menu_handler` as `IntentType.ADVISORY` → `advisory.py` → `call_llm(task_type="advisory")`. In `llm_service.py`, the token budget was resolved as:

```python
max_tokens = TASK_MAX_TOKENS.get(task_type, 500)
```

`"advisory"` was never registered, so it fell to the **500-token default**. Vietnamese diacritic-dense text tokenizes 2-4x heavier than English, so a `max 200 từ` advisory reply routinely runs 700-1000 tokens — and got truncated mid-sentence.

This is the same bug class previously patched one task at a time (`report_text` → 900, `parse_receipt` → 1500). The 500 default was the trap; `advisory`, `investment_advice`, `roadmap_advisory`, the twin/life-event narratives, and news summaries were all silently capped.

## Fix — root cause, not symptom

Raise the **default** rather than registering tasks one by one:

- Introduce `DEFAULT_MAX_TOKENS = 1200`, used as the fallback in `call_llm`.
- `max_tokens` is a **ceiling, not a target** — billing and latency track the *actual* completion tokens emitted, so a generous cap costs nothing for short replies and only prevents truncation. No speed regression.
- Removed the now-redundant `report_text` entry (the default covers it); kept `parse_receipt: 1500` since JSON structuring genuinely needs more than the default.
- A new generative `task_type` is now safe without touching this file.

Stays well under Telegram's 4096-char message limit for `max 200 từ` prompts.

## Tests

- Parametrized regression test asserts `advisory` / `investment_advice` / `roadmap_advisory` reach the client with a `>=1000`-token ceiling — verifying the real wiring, not just the lookup table.
- Added `test_default_max_tokens_is_generous`; updated `report_text` / `parse_receipt` expectations.
- `pytest backend/tests/test_llm_service.py` → 12 passed. `ruff check` clean.

## Test plan

- [ ] Trigger **Tài sản → Tư vấn tối ưu** and confirm the reply ends with a complete sentence + disclaimer.
- [ ] Trigger **Thị trường → Cơ hội đầu tư** and confirm no mid-sentence cut-off.
- [ ] Spot-check a `lộ trình <goal>` roadmap query.

https://claude.ai/code/session_01GHYk5CU6e9ctmiHaQNDycG