### PR TITLE
Add `credit_limit` to credit cards, bot flows, migration and undo/delete support

### DIFF
--- a/alembic/versions/20260527_credit_card_limit_and_debt.py
+++ b/alembic/versions/20260527_credit_card_limit_and_debt.py
@@ -1,0 +1,29 @@
+"""add credit_limit to credit_cards
+
+Revision ID: 20260527creditlimit
+Revises: 20260521creditcards
+Create Date: 2026-05-27
+"""
+from alembic import op
+import sqlalchemy as sa
+
+revision = "20260527creditlimit"
+down_revision = "20260521creditcards"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("credit_cards", sa.Column("credit_limit", sa.Numeric(15, 2), nullable=True))
+    op.execute("UPDATE credit_cards SET credit_limit = debt_balance WHERE credit_limit IS NULL")
+    op.alter_column("credit_cards", "credit_limit", nullable=False)
+    op.create_check_constraint(
+        "ck_credit_cards_credit_limit_non_negative",
+        "credit_cards",
+        "credit_limit >= 0",
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint("ck_credit_cards_credit_limit_non_negative", "credit_cards", type_="check")
+    op.drop_column("credit_cards", "credit_limit")

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -259,6 +259,19 @@ async def handle_transaction_callback(
         await start_credit_card_create(db, chat_id, user)
         await answer_callback(callback_query["id"])
         return True
+    if data.startswith("expense:credit:undo:"):
+        from backend.bot.handlers.credit_card_entry import undo_credit_card_create
+
+        from_user = callback_query.get("from") or {}
+        telegram_id = from_user.get("id")
+        message = callback_query.get("message") or {}
+        chat_id = message.get("chat", {}).get("id")
+        user = await get_user_by_telegram_id(db, telegram_id) if telegram_id else None
+        if not user or chat_id is None:
+            return True
+        await undo_credit_card_create(db, chat_id, user, data.split(":")[-1])
+        await answer_callback(callback_query["id"])
+        return True
 
     prefix, args = parse_callback(data)
 

--- a/backend/bot/handlers/credit_card_entry.py
+++ b/backend/bot/handlers/credit_card_entry.py
@@ -7,19 +7,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.bot.formatters.money import format_money_full
 from backend.schemas.credit_card import CreditCardCreate
 from backend.services import wizard_service
-from backend.services.credit_card_service import create_credit_card, list_credit_cards
+from backend.services.credit_card_service import create_credit_card, delete_credit_card, list_credit_cards
 from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.telegram_service import send_message
 
 FLOW_CREDIT_CARD_ADD = "credit_card_add"
 
 
-def _credit_card_footer_keyboard() -> dict:
+def _credit_card_footer_keyboard(card_id: str) -> dict:
     return {
         "inline_keyboard": [
-            [{"text": "+ Thêm tài sản khác", "callback_data": "expense:credit:add"}],
-            [{"text": "Xong", "callback_data": "menu:expenses"}],
-            [{"text": "Huỷ tài sản vừa nhập", "callback_data": "expense:credit:undo_last"}],
+            [
+                {"text": "➕ Thêm thẻ tín dụng", "callback_data": "expense:credit:add"},
+                {"text": "✅ Xong", "callback_data": "menu:expenses"},
+            ],
+            [{"text": "↩️ Huỷ thẻ vừa nhập", "callback_data": f"expense:credit:undo:{card_id}"}],
         ]
     }
 
@@ -33,7 +35,8 @@ async def show_credit_cards_list(db: AsyncSession, chat_id: int, user) -> None:
         for idx, card in enumerate(cards, start=1):
             lines.append(
                 f"\n{idx}. *{card.bank_name}*"
-                f"\n- Hạn mức: {format_money_full(float(Decimal(str(card.debt_balance or 0))))}"
+                f"\n- Hạn mức: {format_money_full(float(Decimal(str(card.credit_limit or 0))))}"
+                f"\n- Tổng dư nợ hiện có: {format_money_full(float(Decimal(str(card.debt_balance or 0))))}"
                 f"\n- Ngày thanh toán: {card.closing_date}"
             )
         text = "\n".join(lines)
@@ -44,7 +47,7 @@ async def show_credit_cards_list(db: AsyncSession, chat_id: int, user) -> None:
         parse_mode="Markdown",
         reply_markup={
             "inline_keyboard": [
-                [{"text": "+ Thêm thẻ tín dụng", "callback_data": "expense:credit:add"}],
+                [{"text": "➕ Thêm thẻ tín dụng", "callback_data": "expense:credit:add"}],
                 [{"text": "Quay về", "callback_data": "menu:expenses"}],
             ]
         },
@@ -97,7 +100,18 @@ async def handle_credit_card_text_input(db: AsyncSession, message: dict) -> bool
         if limit is None or limit <= 0:
             await send_message(chat_id=chat_id, text="Bạn nhập hạn mức hợp lệ nhé. Ví dụ: <code>100tr</code>", parse_mode="HTML")
             return True
-        await wizard_service.update_step(db, user.id, step="closing_date", draft_patch={"credit_limit": float(limit)})
+        await wizard_service.update_step(db, user.id, step="debt_balance", draft_patch={"credit_limit": float(limit)})
+        await send_message(chat_id=chat_id, text="💳 <b>Tổng số dư nợ hiện có?</b> (Ví dụ: 15tr, 40 triệu...)", parse_mode="HTML")
+        return True
+
+    if step == "debt_balance":
+        from backend.wealth.amount_parser import parse_amount
+
+        debt_balance = parse_amount(text)
+        if debt_balance is None or debt_balance < 0:
+            await send_message(chat_id=chat_id, text="Bạn nhập tổng dư nợ hợp lệ nhé. Ví dụ: <code>15tr</code>", parse_mode="HTML")
+            return True
+        await wizard_service.update_step(db, user.id, step="closing_date", draft_patch={"debt_balance": float(debt_balance)})
         await send_message(chat_id=chat_id, text="📅 <b>Ngày thanh toán hàng tháng?</b> (từ 1 đến 31)", parse_mode="HTML")
         return True
 
@@ -112,8 +126,9 @@ async def handle_credit_card_text_input(db: AsyncSession, message: dict) -> bool
                 user.id,
                 CreditCardCreate(
                     bank_name=bank_name,
+                    credit_limit=float(draft.get("credit_limit") or 0),
                     closing_date=int(text),
-                    debt_balance=float(draft.get("credit_limit") or 0),
+                    debt_balance=float(draft.get("debt_balance") or 0),
                 ),
             )
         except ValueError:
@@ -125,12 +140,32 @@ async def handle_credit_card_text_input(db: AsyncSession, message: dict) -> bool
             text=(
                 "✅ Đã thêm thẻ tín dụng thành công:\n"
                 f"- Ngân hàng: <b>{card.bank_name}</b>\n"
-                f"- Hạn mức: <b>{format_money_full(float(Decimal(str(card.debt_balance or 0))))}</b>\n"
+                f"- Hạn mức: <b>{format_money_full(float(Decimal(str(card.credit_limit or 0))))}</b>\n"
+                f"- Tổng dư nợ hiện có: <b>{format_money_full(float(Decimal(str(card.debt_balance or 0))))}</b>\n"
                 f"- Ngày thanh toán: <b>{card.closing_date}</b>"
             ),
             parse_mode="HTML",
-            reply_markup=_credit_card_footer_keyboard(),
+            reply_markup=_credit_card_footer_keyboard(str(card.id)),
         )
         return True
 
     return False
+
+
+async def undo_credit_card_create(db: AsyncSession, chat_id: int, user, card_id: str) -> None:
+    from uuid import UUID
+
+    try:
+        parsed_id = UUID(card_id)
+    except ValueError:
+        await send_message(chat_id=chat_id, text="Không tìm thấy thẻ để huỷ.")
+        return
+    card = await delete_credit_card(db, user.id, parsed_id)
+    if card is None:
+        await send_message(chat_id=chat_id, text="Thẻ này đã được xử lý rồi 🤔")
+        return
+    await send_message(
+        chat_id=chat_id,
+        text=f"↩️ Đã huỷ <b>{card.bank_name}</b>. Danh sách thẻ tín dụng đã được cập nhật.",
+        parse_mode="HTML",
+    )

--- a/backend/models/credit_card.py
+++ b/backend/models/credit_card.py
@@ -19,6 +19,7 @@ class CreditCard(Base):
     )
     user_id: Mapped[uuid.UUID] = mapped_column(UUID(as_uuid=True), nullable=False, index=True)
     bank_name: Mapped[str] = mapped_column(String(120), nullable=False)
+    credit_limit: Mapped[Decimal] = mapped_column(Numeric(15, 2), nullable=False, default=Decimal("0"))
     closing_date: Mapped[int] = mapped_column(Integer, nullable=False)
     debt_balance: Mapped[Decimal] = mapped_column(Numeric(15, 2), nullable=False, default=Decimal("0"))
     created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True), default=datetime.utcnow)

--- a/backend/schemas/credit_card.py
+++ b/backend/schemas/credit_card.py
@@ -6,12 +6,14 @@ from pydantic import BaseModel, Field
 
 class CreditCardCreate(BaseModel):
     bank_name: str = Field(..., min_length=2, max_length=120)
+    credit_limit: float = Field(..., ge=0)
     closing_date: int = Field(..., ge=1, le=31)
     debt_balance: float = Field(default=0, ge=0)
 
 
 class CreditCardUpdate(BaseModel):
     bank_name: str | None = Field(default=None, min_length=2, max_length=120)
+    credit_limit: float | None = Field(default=None, ge=0)
     closing_date: int | None = Field(default=None, ge=1, le=31)
     debt_balance: float | None = Field(default=None, ge=0)
 
@@ -20,6 +22,7 @@ class CreditCardResponse(BaseModel):
     id: uuid.UUID
     user_id: uuid.UUID
     bank_name: str
+    credit_limit: float
     closing_date: int
     debt_balance: float
     created_at: datetime

--- a/backend/services/credit_card_service.py
+++ b/backend/services/credit_card_service.py
@@ -26,6 +26,7 @@ async def create_credit_card(
     card = CreditCard(
         user_id=user_id,
         bank_name=normalized_name,
+        credit_limit=Decimal(str(data.credit_limit)),
         closing_date=data.closing_date,
         debt_balance=Decimal(str(data.debt_balance)),
     )
@@ -57,3 +58,14 @@ async def get_credit_card(
             )
         )
     ).scalar_one_or_none()
+
+
+async def delete_credit_card(
+    db: AsyncSession, user_id: uuid.UUID, card_id: uuid.UUID
+) -> CreditCard | None:
+    card = await get_credit_card(db, user_id, card_id)
+    if card is None:
+        return None
+    await db.delete(card)
+    await db.flush()
+    return card

--- a/tests/test_credit_card_service.py
+++ b/tests/test_credit_card_service.py
@@ -41,17 +41,26 @@ class FakeDB:
     async def refresh(self, _obj):
         self.refreshed = True
 
+    async def delete(self, _obj):
+        return None
+
 
 @pytest.mark.asyncio
 async def test_create_credit_card_success():
     db = FakeDB([None])
     user_id = uuid.uuid4()
-    data = CreditCardCreate(bank_name="  Techcombank ", closing_date=25, debt_balance=1500000)
+    data = CreditCardCreate(
+        bank_name="  Techcombank ",
+        credit_limit=10000000,
+        closing_date=25,
+        debt_balance=1500000,
+    )
 
     got = await credit_card_service.create_credit_card(db, user_id, data)
 
     assert got.user_id == user_id
     assert got.bank_name == "Techcombank"
+    assert float(got.credit_limit) == 10000000
     assert float(got.debt_balance) == 1500000
     assert db.flushed is True
     assert db.refreshed is True
@@ -61,7 +70,7 @@ async def test_create_credit_card_success():
 async def test_create_credit_card_duplicate_bank_name_raises():
     db = FakeDB([SimpleNamespace(id=uuid.uuid4())])
     user_id = uuid.uuid4()
-    data = CreditCardCreate(bank_name="techcombank", closing_date=25, debt_balance=0)
+    data = CreditCardCreate(bank_name="techcombank", credit_limit=0, closing_date=25, debt_balance=0)
 
     with pytest.raises(ValueError, match="Tên ngân hàng đã tồn tại"):
         await credit_card_service.create_credit_card(db, user_id, data)


### PR DESCRIPTION
### Motivation

- Track credit card limits separately from current debt so the app can show both the `credit_limit` and `debt_balance` to users.
- Persist the new `credit_limit` column in the database with a safe migration that populates existing rows and enforces non-negativity.
- Allow users to undo a recently added card via bot UI by deleting the created record.

### Description

- Add an Alembic migration `20260527_credit_card_limit_and_debt.py` that adds the `credit_limit` column to `credit_cards`, backfills it from `debt_balance`, marks it non-nullable, and adds a check constraint `ck_credit_cards_credit_limit_non_negative`.
- Add `credit_limit` to the ORM model `CreditCard` as `Numeric(15, 2)` with default `Decimal("0")` and to Pydantic schemas `CreditCardCreate`, `CreditCardUpdate`, and `CreditCardResponse`.
- Persist `credit_limit` in `create_credit_card` and add `delete_credit_card` service to remove a card and return it.
- Update bot handlers in `credit_card_entry.py` to collect both `credit_limit` and `debt_balance` during the wizard, display both values in messages, add `undo_credit_card_create` to delete a created card, and pass the created card id into the footer keyboard.
- Register the new callback prefix `expense:credit:undo:` in `callbacks.py` to route undo actions to the new handler.
- Update unit tests in `tests/test_credit_card_service.py` to include `credit_limit` in test data and provide a `delete` stub on the fake DB.

### Testing

- Ran the modified unit tests in `tests/test_credit_card_service.py` with `pytest`, which exercised `create_credit_card`, duplicate-name checks, `list_credit_cards`, and `get_credit_card`, and they passed locally.
- No integration or migration-run tests are included here; the Alembic migration was added and should be applied in staging before deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c0ae094c832f8e36a5f712dbc8cb)