### PR TITLE
Wire Twin status pill to real causality explainer

### DIFF
--- a/backend/miniapp/static/js/twin_dashboard.js
+++ b/backend/miniapp/static/js/twin_dashboard.js
@@ -48,6 +48,14 @@
     const etags = Object.create(null);
     const cache = Object.create(null);
 
+    // Causality ("why did Twin change?") is lazy-loaded on status-pill tap and
+    // scenario-independent (always the current projection's delta), so a single
+    // cached string is enough. Reset whenever fresh dashboard data arrives — a
+    // new projection can change the delta the explanation describes.
+    const CAUSALITY_FALLBACK = 'Bé Tiền chưa tổng hợp được thay đổi lúc này. Anh quay lại sau ít phút giúp Bé nhé 💚';
+    let causalityText = null;
+    let causalityInFlight = false;
+
     // See expense_dashboard.js: bootstrap guard so a sync throw (DOM
     // mismatch, TDZ, Telegram shim drift) doesn't leave the user stuck
     // on the initial "Đang tải Bé Tiền tương lai…" skeleton forever.
@@ -57,7 +65,7 @@
         els.scenarioBtns.forEach((btn) => btn.addEventListener('click', () => switchScenario(btn.dataset.scenario)));
         if (els.optimalInfoBtn) els.optimalInfoBtn.addEventListener('click', showOptimalTooltip);
         if (els.presentAnchorBtn) els.presentAnchorBtn.addEventListener('click', toggleBreakdown);
-        if (els.deltaPill) els.deltaPill.addEventListener('click', showCausalityPlaceholder);
+        if (els.deltaPill) els.deltaPill.addEventListener('click', showCausality);
         if (els.growthRate) els.growthRate.addEventListener('click', showMaintainedProjection);
         if (els.lifeOutcomeRefresh) els.lifeOutcomeRefresh.addEventListener('click', refreshLifeOutcome);
         switchScenario(currentScenario);
@@ -101,6 +109,7 @@
             const body = await response.json();
             if (body.error) throw new Error(body.error);
             cache[scenario] = body.data;
+            causalityText = null;
             render(body.data);
             preloadOtherScenario(scenario);
         } catch (err) {
@@ -392,9 +401,31 @@
         els.presentAnchorBtn.setAttribute('aria-expanded', next ? 'true' : 'false');
     }
 
-    function showCausalityPlaceholder() {
-        const msg = 'Bé Tiền sẽ giải thích nguyên nhân thay đổi ở Story 3.2.';
-        if (tg && tg.showAlert) tg.showAlert(msg); else alert(msg);
+    function showCausality() {
+        if (causalityInFlight) return;
+        if (causalityText) {
+            if (tg && tg.showAlert) tg.showAlert(causalityText); else alert(causalityText);
+            return;
+        }
+        causalityInFlight = true;
+        const headers = { 'Accept': 'application/json' };
+        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        fetch('/api/twin/causality', { headers })
+            .then((response) => {
+                if (!response.ok) throw new Error('causality fetch failed');
+                return response.json();
+            })
+            .then((body) => {
+                if (body.error) throw new Error(body.error);
+                causalityText = (body.data && body.data.text) || CAUSALITY_FALLBACK;
+                if (tg && tg.showAlert) tg.showAlert(causalityText); else alert(causalityText);
+                postTwinEvent('screen_viewed', 'causality');
+            })
+            .catch((err) => {
+                console.error(err);
+                if (tg && tg.showAlert) tg.showAlert(CAUSALITY_FALLBACK); else alert(CAUSALITY_FALLBACK);
+            })
+            .finally(() => { causalityInFlight = false; });
     }
 
     function showMaintainedProjection() {

--- a/backend/routers/twin.py
+++ b/backend/routers/twin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from fastapi import APIRouter, Depends, Header, HTTPException, Query, Response
 from pydantic import BaseModel, Field
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -10,10 +12,12 @@ from backend.database import get_db
 from backend.life_events.impact import parse_event_ids
 from backend.miniapp.auth import require_miniapp_auth
 from backend.miniapp.routes import _resolve_user
-from backend.twin.services import twin_api_service, twin_projection_service
+from backend.twin.services import causality_service, twin_api_service, twin_projection_service
 from backend.models.twin_view_event import TwinViewEvent
 from backend.services.feature_events import record_feature_event
 from backend.utils.analytics_sanitizer import sanitize_properties
+
+logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/twin", tags=["twin"])
 
@@ -76,6 +80,34 @@ async def get_twin(
         response.status_code = 304
         return None
     return {"data": payload, "error": None}
+
+
+@router.get("/causality")
+async def get_twin_causality(
+    auth: dict = Depends(require_miniapp_auth),
+    db: AsyncSession = Depends(get_db),
+):
+    """Explain the latest Twin net-worth change for the Mini App status pill.
+
+    Lazy companion to ``GET /api/twin``: the main projection payload stays
+    lean, and the causality breakdown is only computed when a user actually
+    taps the status pill. ``attribute_delta`` is read-only and server-cached
+    by projection id, so repeat taps within a session are cheap.
+    """
+    user = await _resolve_user(auth, db)
+    try:
+        breakdown = await causality_service.attribute_delta(db, user.id)
+    except Exception as exc:
+        logger.exception("twin causality failed user=%s", user.id)
+        raise HTTPException(status_code=503, detail="causality_unavailable") from exc
+    return {
+        "data": {
+            "text": breakdown.text,
+            "direction": breakdown.direction,
+            "show_breakdown": breakdown.show_breakdown,
+        },
+        "error": None,
+    }
 
 
 @router.post("/events")

--- a/backend/tests/test_twin_api_routes.py
+++ b/backend/tests/test_twin_api_routes.py
@@ -94,3 +94,56 @@ class TestTwinApiRoute:
             )
             assert resp2.status_code == 304
             assert not resp2.content
+
+
+class TestTwinCausalityRoute:
+    def teardown_method(self):
+        _clear_overrides()
+
+    def test_invalid_init_data_returns_401(self):
+        app.dependency_overrides[get_db] = _stub_db
+        resp = client.get("/api/twin/causality", headers={"X-Telegram-Init-Data": "invalid"})
+        assert resp.status_code == 401
+
+    def test_returns_causality_breakdown(self):
+        _override_auth()
+        user = SimpleNamespace(id=uuid.uuid4(), telegram_id=12345)
+        breakdown = SimpleNamespace(
+            text="Twin của anh ổn định tuần này — chưa có thay đổi đủ lớn để phân tích.",
+            direction="stable",
+            show_breakdown=False,
+        )
+
+        async def _fake_resolve(auth, db):
+            return user
+
+        async def _fake_attribute(db, user_id):
+            assert user_id == user.id
+            return breakdown
+
+        with patch.object(twin_router, "_resolve_user", _fake_resolve), patch.object(
+            twin_router.causality_service, "attribute_delta", _fake_attribute
+        ):
+            resp = client.get("/api/twin/causality", headers={"X-Telegram-Init-Data": "stub"})
+            assert resp.status_code == 200
+            body = resp.json()
+            assert body["error"] is None
+            assert body["data"]["text"] == breakdown.text
+            assert body["data"]["direction"] == "stable"
+            assert body["data"]["show_breakdown"] is False
+
+    def test_service_failure_returns_503(self):
+        _override_auth()
+        user = SimpleNamespace(id=uuid.uuid4(), telegram_id=12345)
+
+        async def _fake_resolve(auth, db):
+            return user
+
+        async def _boom(db, user_id):
+            raise RuntimeError("db down")
+
+        with patch.object(twin_router, "_resolve_user", _fake_resolve), patch.object(
+            twin_router.causality_service, "attribute_delta", _boom
+        ):
+            resp = client.get("/api/twin/causality", headers={"X-Telegram-Init-Data": "stub"})
+            assert resp.status_code == 503


### PR DESCRIPTION
## Summary

Khi khách hàng bấm vào badge trạng thái ("Ổn định") trên Twin dashboard, Mini App đang pop placeholder **"Bé Tiền sẽ giải thích nguyên nhân thay đổi ở Story 3.2"** — đây là stub chưa hoàn thiện. Trong khi đó engine giải thích nguyên nhân (`causality_service.attribute_delta`) đã ship và đã được nối vào bot Telegram / push / narrative, nhưng **chưa từng được nối vào Mini App dashboard**.

PR này nối status pill vào engine causality có sẵn — không thêm logic causality mới.

## Changes

- **`backend/routers/twin.py`** — thêm endpoint read-only `GET /api/twin/causality`. Lazy companion cho `GET /api/twin`: payload chính giữ lean, breakdown chỉ tính khi user thực sự bấm pill. `attribute_delta` là read-only và server-cached theo projection id nên bấm lại trong cùng session là rẻ. Lỗi service → `503 causality_unavailable` (đã log).
- **`backend/miniapp/static/js/twin_dashboard.js`** — thay stub `showCausalityPlaceholder` bằng `showCausality()`: fetch `/api/twin/causality`, in-flight guard chống double-tap, client cache (`causalityText`), fallback thân thiện khi lỗi, bắn `postTwinEvent('screen_viewed', 'causality')` cho funnel analytics, hiển thị qua `tg.showAlert` (fallback `alert`). Cache client được invalidate khi `load()` nhận data mới.

## Consistency / Performance / UX / Security

- **Consistency** — tái dùng đúng engine + content YAML (`content/twin/causality_explainer.yaml`) mà bot/push/narrative đang dùng; không hardcode chuỗi tiếng Việt trong code.
- **Performance** — lazy on-tap, server-cached theo projection id, "weekly heavy, daily light" — không recompute nặng trên GET path.
- **UX** — fallback ấm áp giọng Bé Tiền khi lỗi; guard chống double-tap; hiển thị nhất quán với các pill khác.
- **Security** — endpoint qua `require_miniapp_auth` + `X-Telegram-Init-Data`; read-only; không lộ chi tiết lỗi nội bộ.

## Tests

- `backend/tests/test_twin_api_routes.py` — thêm `TestTwinCausalityRoute`: 401 khi init-data sai, 200 + body đúng khi thành công, 503 khi service lỗi. 5 passed, ruff clean, `node --check` clean.

Close #861