### PR TITLE
fix(expense-dashboard): chuẩn hóa format tiền và auto-format input số tiền

### DIFF
--- a/backend/miniapp/static/js/dashboard_common.js
+++ b/backend/miniapp/static/js/dashboard_common.js
@@ -74,7 +74,7 @@
     }
 
     function formatMoneyFull(amount) {
-        return new Intl.NumberFormat('vi-VN').format(Math.round(amount)) + 'đ';
+        return new Intl.NumberFormat('en-US').format(Math.round(amount)) + 'đ';
     }
 
     function escapeHtml(value) {

--- a/backend/miniapp/static/js/expense_dashboard.js
+++ b/backend/miniapp/static/js/expense_dashboard.js
@@ -683,6 +683,22 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
         els.modalCategory.innerHTML = CATEGORIES.map(
             ([code, label]) => `<option value="${code}">${escapeHtml(label)}</option>`
         ).join('');
+        els.modalAmount.addEventListener('input', onAmountInput);
+    }
+
+    function parseMoneyInput(raw) {
+        const digits = String(raw || '').replace(/[^\d]/g, '');
+        return digits ? Number(digits) : 0;
+    }
+
+    function formatMoneyInput(raw) {
+        const amount = parseMoneyInput(raw);
+        return amount ? amount.toLocaleString('en-US') : '';
+    }
+
+    function onAmountInput() {
+        const formatted = formatMoneyInput(els.modalAmount.value);
+        if (els.modalAmount.value !== formatted) els.modalAmount.value = formatted;
     }
 
     function applyLocalizedKeywords() {
@@ -716,7 +732,7 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
         els.modalTitle.textContent = editingExpenseId ? (txType === 'money_in' ? 'Sửa tiền vào' : 'Sửa chi tiêu') : (txType === 'money_in' ? 'Thêm tiền vào' : 'Thêm chi tiêu');
         els.modalType.value = txType;
         applySourceOptions(txType, sourceValue(item), item?.source_credit_card_id || null);
-        els.modalAmount.value = item ? Math.round(item.amount || 0) : '';
+        els.modalAmount.value = item ? formatMoneyInput(Math.round(item.amount || 0)) : '';
         els.modalCategory.value = item?.category || 'other';
         els.modalDate.value = item?.expense_date || new Date().toISOString().slice(0, 10);
         els.modalNote.value = item?.merchant || item?.note || '';
@@ -760,7 +776,7 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
     }
 
     async function onSave() {
-        const amount = parseFloat(els.modalAmount.value);
+        const amount = parseMoneyInput(els.modalAmount.value);
         if (!amount || amount < 1000) {
             if (tg && tg.showAlert) tg.showAlert('Số tiền phải từ 1.000đ.');
             else window.alert('Số tiền phải từ 1.000đ.');

--- a/backend/miniapp/static/js/twin_dashboard.js
+++ b/backend/miniapp/static/js/twin_dashboard.js
@@ -452,10 +452,10 @@
         if (value >= 1_000_000_000) return `${trim(value / 1_000_000_000)} tỷ`;
         if (value >= 1_000_000) return `${trim(value / 1_000_000)}tr`;
         if (value >= 1_000) return `${trim(value / 1_000)}k`;
-        return `${Math.round(value).toLocaleString('vi-VN')}đ`;
+        return `${Math.round(value).toLocaleString('en-US')}đ`;
     }
 
-    function formatMoneyFull(value) { return `${Math.round(value).toLocaleString('vi-VN')}đ`; }
+    function formatMoneyFull(value) { return `${Math.round(value).toLocaleString('en-US')}đ`; }
     function trim(value) { return value.toFixed(value >= 10 ? 0 : 1).replace('.0', ''); }
 
     const DATE_FORMAT_BY_LANGUAGE = {

--- a/backend/miniapp/templates/expense_dashboard.html
+++ b/backend/miniapp/templates/expense_dashboard.html
@@ -102,7 +102,7 @@
         <div class="modal-content">
             <h3 id="expense-modal-title">Thêm chi tiêu</h3>
             <label for="expense-amount">Số tiền (VNĐ)</label>
-            <input id="expense-amount" type="number" min="1000" step="1000" inputmode="numeric" />
+            <input id="expense-amount" type="text" inputmode="numeric" autocomplete="off" />
             <label for="expense-type">Loại giao dịch</label>
             <select id="expense-type">
                 <option value="expense">Chi tiêu (-)</option>

--- a/backend/tests/test_dashboard_common.py
+++ b/backend/tests/test_dashboard_common.py
@@ -148,9 +148,9 @@ def test_format_money_full_uses_vi_locale_grouping() -> None:
             'rounded': DC.formatMoneyFull(1500.7),
         };
     """)
-    assert cases["1000"] == "1.000đ"
-    assert cases["1234567"] == "1.234.567đ"
-    assert cases["rounded"] == "1.501đ"
+    assert cases["1000"] == "1,000đ"
+    assert cases["1234567"] == "1,234,567đ"
+    assert cases["rounded"] == "1,501đ"
 
 
 def test_escape_html_blocks_xss_vectors() -> None:

--- a/backend/tests/test_expense_miniapp_static.py
+++ b/backend/tests/test_expense_miniapp_static.py
@@ -149,3 +149,16 @@ def test_source_options_distinguish_expense_vs_money_in_and_gate_credit_card():
     assert "source_options" in js
     assert "{ value: 'credit_card', label: 'Thẻ tín dụng' }" in js
     assert "if (selectedValue === 'credit_card' && existingCardId)" in js
+
+
+def test_expense_amount_input_uses_localized_grouping_and_safe_numeric_parse():
+    html = HTML.read_text()
+    js = JS.read_text()
+
+    assert '<input id="expense-amount" type="text" inputmode="numeric" autocomplete="off" />' in html
+    assert "function parseMoneyInput(raw)" in js
+    assert "replace(/[^\\d]/g, '')" in js
+    assert "function formatMoneyInput(raw)" in js
+    assert "toLocaleString('en-US')" in js
+    assert "els.modalAmount.addEventListener('input', onAmountInput);" in js
+    assert "const amount = parseMoneyInput(els.modalAmount.value);" in js

--- a/miniapp/src/views/TwinDashboard.tsx
+++ b/miniapp/src/views/TwinDashboard.tsx
@@ -80,7 +80,7 @@ function Kpi({ label, value }: { label: string; value?: string }) {
 }
 
 function money(raw: string) {
-  return `${Number(raw).toLocaleString('vi-VN')}đ`;
+  return `${Number(raw).toLocaleString('en-US')}đ`;
 }
 
 function labelAsset(name: string) {


### PR DESCRIPTION
### Motivation
- Đồng bộ hoá định dạng hiển thị tiền và nhập số trong Mini App để tránh trình bày không nhất quán giữa các dashboard và form, và đảm bảo parse an toàn trước khi gửi lên backend.

### Description
- Thay input `type=number` thành `type=text` cho trường `#expense-amount` và bật `inputmode="numeric"` để cho phép auto-format khi người dùng nhập tiền (thêm handler `onAmountInput`).
- Thêm hàm `parseMoneyInput`, `formatMoneyInput` và sử dụng `parseMoneyInput` khi submit để đảm bảo chỉ gửi số nguyên hợp lệ lên API; hiển thị dùng grouping khi render modal (ví dụ: `1000000` → `1,000,000`).
- Chuẩn hoá formatter hiển thị toàn cục bằng cách cập nhật `formatMoneyFull` / các chỗ gọi `.toLocaleString` để dùng cùng kiểu grouping và cập nhật các dashboard Twin/Wealth/Expense tương ứng.
- Bổ sung và cập nhật unit test để khoá hành vi mới (`test_expense_amount_input_uses_localized_grouping_and_safe_numeric_parse` và điều chỉnh kỳ vọng formatter chung).

### Testing
- Chạy unit tests: `pytest -q backend/tests/test_dashboard_common.py backend/tests/test_expense_miniapp_static.py` và kết quả là `21 passed`.
- Các test cập nhật kiểm tra HTML input, sự hiện diện của hàm `parseMoneyInput`/`formatMoneyInput`, listener `onAmountInput` và thay đổi kỳ vọng grouping trong `formatMoneyFull`.

Closes #NNN

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16c5bb4894832fb08a9dcc8cdf5c45)