### PR TITLE
fix: stop advisory/investment replies truncating — size token ceiling for V4-Flash reasoning

### DIFF
--- a/backend/services/llm_service.py
+++ b/backend/services/llm_service.py
@@ -36,24 +36,40 @@ USE_CLAUDE = {"ocr", "complex_analysis"}
 # ACTUAL completion tokens the model emits, so a high cap costs nothing for
 # a short reply — it only stops the model being cut off mid-sentence.
 #
-# Vietnamese is the trap: diacritic-dense text tokenizes 2-4x heavier than
-# English, so a "max 200 từ" advisory reply routinely runs 700-1000 tokens.
+# Two compounding traps make a tight ceiling dangerous here:
+#
+# 1. Vietnamese density: diacritic-dense text tokenizes 2-4x heavier than
+#    English, so a "max 200 từ" advisory reply routinely runs 700-1000
+#    tokens of VISIBLE answer — and models overshoot a soft word cap.
+# 2. Hidden reasoning tokens: DeepSeek V4-Flash is a hybrid-reasoning model.
+#    Its chain-of-thought is billed INSIDE max_tokens but lands in a separate
+#    `reasoning_content` field we never read — we only surface
+#    `message.content`. So the budget is silently SPLIT between invisible
+#    reasoning and the actual answer. When reasoning runs long, the visible
+#    answer truncates mid-sentence even though the reply LOOKS short. This is
+#    why the cut point is intermittent (it tracks reasoning length, not a
+#    fixed offset) and why bumping the cap to 1200 "fixed it" only sometimes.
+#
 # A 500-token default silently truncated EVERY generative Vietnamese task
 # (advisory, investment_advice, roadmap_advisory, report_text, the twin /
 # life-event narratives, news summaries…) mid-sentence. We rediscovered this
-# twice via whack-a-mole — bumping report_text, then parse_receipt — before
-# fixing the root cause here: a default generous enough to hold any prose
-# reply, so a new generative task_type is safe without touching this file.
+# repeatedly via whack-a-mole — report_text, parse_receipt, then advisory —
+# before sizing the default for reasoning + a FULL Vietnamese answer (~1000
+# reasoning + ~1000 answer). 2000 matches Tier-3's per-turn ceiling, so the
+# stack is consistent, and a new generative task_type is safe without
+# touching this file.
 #
 # Only register a task below when it needs MORE than the default (JSON
 # structuring), never less — capping below the default re-introduces the bug.
-DEFAULT_MAX_TOKENS = 1200
+DEFAULT_MAX_TOKENS = 2000
 TASK_MAX_TOKENS = {
     # Receipt structuring returns a JSON object (amount, merchant, date,
     # note, items[]). At 500 tokens V4-Flash spent the budget reasoning
     # before the answer and truncated the JSON mid-object (cut right after
-    # "date"), so json.loads failed and the bot rejected valid receipts.
-    "parse_receipt": 1500,
+    # "date"), so json.loads failed and the bot rejected valid receipts. An
+    # itemized receipt (20-30 line items) plus the hidden reasoning trace
+    # needs headroom ABOVE the generous default, so it stays registered.
+    "parse_receipt": 2500,
 }
 
 

--- a/backend/tests/test_llm_service.py
+++ b/backend/tests/test_llm_service.py
@@ -43,10 +43,13 @@ def _fake_client(text: str, model: str):
 
 
 def test_default_max_tokens_is_generous():
-    # The 500-token default truncated Vietnamese prose mid-sentence. A
-    # generous default is the root-cause fix (max_tokens is a ceiling, not a
-    # target) so new generative task_types are safe without registration.
-    assert DEFAULT_MAX_TOKENS >= 1000
+    # The 500-token default truncated Vietnamese prose mid-sentence; 1200
+    # still truncated intermittently because V4-Flash's hidden reasoning
+    # trace is billed inside max_tokens and competes with the visible answer.
+    # The default must hold reasoning (~1000) + a full Vietnamese answer
+    # (~1000), so the floor is 2000. Dropping back below this re-opens the
+    # mid-sentence-cut regression on advisory / investment / report tasks.
+    assert DEFAULT_MAX_TOKENS >= 2000
 
 
 def test_report_text_falls_back_to_generous_default():
@@ -79,7 +82,9 @@ async def test_advisory_tasks_get_generous_token_ceiling(task_type):
             use_cache=False,
             shared_cache=True,
         )
-    assert client.chat.completions.create.await_args.kwargs["max_tokens"] >= 1000
+    # Headroom must cover V4-Flash's hidden reasoning trace AND a full
+    # ~200-từ Vietnamese answer — 1200 was not enough (reasoning ate it).
+    assert client.chat.completions.create.await_args.kwargs["max_tokens"] >= 2000
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

When a user taps **Tài sản → Tư vấn tối ưu** or **Thị trường → Cơ hội đầu tư**, Bé Tiền's reply still gets cut off mid-sentence — even after PR #859 raised `DEFAULT_MAX_TOKENS` to 1200.

## Root cause

The advisory path is clean (no body slicing, no clamping, no cache for personalized advice) — it calls `call_llm(task_type="advisory")`, which uses the default token ceiling. The real culprit is the model itself:

**DeepSeek V4-Flash is a hybrid-reasoning model.** Its chain-of-thought is billed **inside** `max_tokens`, but lands in a separate `reasoning_content` field we never read — we only surface `message.content`. So the budget is silently **split** between invisible reasoning and the visible answer. When reasoning runs long, a "max 200 từ" Vietnamese reply (already 700–1000 tokens because diacritics tokenize 2–4× denser) gets starved and truncates.

This explains why:
- the cut point is **intermittent** — it tracks reasoning length, not a fixed offset;
- bumping the cap to 1200 only *sometimes* fixed it.

The existing in-code comment already documented the symptom for receipts ("V4-Flash spent the budget reasoning before the answer and truncated the JSON mid-object") — this generalizes the insight to all generative tasks.

## Fix

- `DEFAULT_MAX_TOKENS` 1200 → **2000** — holds reasoning (~1000) + a full Vietnamese answer (~1000). Matches Tier-3's `_MAX_TOKENS_PER_TURN`, so the stack is consistent. `max_tokens` is a ceiling, not a target, so this costs nothing for short replies.
- `parse_receipt` 1500 → **2500** — keeps it above the new generous default rather than capping receipts below it (capping below default re-opens the bug).
- Tests lock the new 2000 floor so a regression back to 1200 fails loudly.

## Deployment note

The fix only takes effect once the **Bé Tiền Test** bot process is **restarted/redeployed** — a long-running process keeps the old token ceiling in memory. The observed cut length is consistent with the live process still running pre-#859 code, so please redeploy/restart after merge to verify.

## Test plan

- [x] `pytest backend/tests/test_llm_service.py` — 12 passed
- [x] `ruff check` — clean
- [ ] After redeploy: tap **Tư vấn tối ưu** and **Cơ hội đầu tư**, confirm full reply with no mid-sentence cut

https://claude.ai/code/session_01GHYk5CU6e9ctmiHaQNDycG