### PR TITLE
fix(miniapp): recover initData from URL hash + return clean 401 (#865)

### DIFF
--- a/backend/miniapp/auth.py
+++ b/backend/miniapp/auth.py
@@ -105,14 +105,20 @@ def verify_init_data(
 
 
 async def require_miniapp_auth(
-    x_telegram_init_data: str = Header(
-        ...,
+    x_telegram_init_data: str | None = Header(
+        None,
         alias="X-Telegram-Init-Data",
         description="Telegram Mini App initData (querystring)",
     ),
 ) -> dict:
-    """FastAPI dependency — return verified user info or raise 401."""
-    verified = verify_init_data(x_telegram_init_data)
+    """FastAPI dependency — return verified user info or raise 401.
+
+    The header is declared Optional so a *missing* header yields a clean
+    401 (auth required) instead of FastAPI's default 422 for a missing
+    required header. The client treats 401/403 as "re-auth"; a 422 leaks
+    as an opaque "không tải được dữ liệu" with no recovery path.
+    """
+    verified = verify_init_data(x_telegram_init_data) if x_telegram_init_data else None
     if not verified or not verified.get("user_id"):
         raise HTTPException(status_code=401, detail="Invalid Telegram auth")
     return verified

--- a/backend/miniapp/static/js/cashflow_dashboard.js
+++ b/backend/miniapp/static/js/cashflow_dashboard.js
@@ -16,9 +16,23 @@
 
 const tg = window.Telegram?.WebApp;
 const API_BASE = "";     // same origin as the HTML
+
+// Telegram injects launch params into the URL HASH fragment
+// (#tgWebAppData=…); when telegram-web-app.js hasn't populated
+// tg.initData yet, the hash is the authoritative fallback so the
+// request still carries auth instead of triggering a 401. This bundle
+// is standalone (no dashboard_common.js), so the helper is inlined.
+function resolveInitData() {
+    if (tg?.initData) return tg.initData;
+    const fromHash = new URLSearchParams((window.location.hash || "").replace(/^#/, ""));
+    const fromSearch = new URLSearchParams(window.location.search || "");
+    return fromHash.get("tgWebAppData") || fromHash.get("initData")
+        || fromSearch.get("tgWebAppData") || fromSearch.get("initData") || "";
+}
+
 const HEADERS = () => ({
     "Content-Type": "application/json",
-    "X-Telegram-Init-Data": tg?.initData ?? "",
+    "X-Telegram-Init-Data": resolveInitData(),
 });
 
 // ── Bootstrap ──────────────────────────────────────────────────────────────

--- a/backend/miniapp/static/js/dashboard.js
+++ b/backend/miniapp/static/js/dashboard.js
@@ -5,7 +5,7 @@
     // Shared helpers from /miniapp/static/js/dashboard_common.js — loaded
     // first via the template. Destructure at IIFE top so bindings exit
     // TDZ before any caller (per the smoke-harness contract).
-    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, formatDate } = window.DashboardCommon;
+    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, formatDate, authHeaders } = window.DashboardCommon;
 
     const tg = window.Telegram && window.Telegram.WebApp;
     if (tg) {
@@ -112,12 +112,11 @@
         }
     }
 
-    function reportLoaded() {
+    async function reportLoaded() {
         if (loadBeaconSent) return;
         loadBeaconSent = true;
         const loadTimeMs = Math.round(performance.now() - pageStartedAt);
-        const headers = { 'Content-Type': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        const headers = await authHeaders();
         fetch('/miniapp/api/events/loaded', {
             method: 'POST',
             headers,

--- a/backend/miniapp/static/js/dashboard_common.js
+++ b/backend/miniapp/static/js/dashboard_common.js
@@ -21,8 +21,18 @@
         return (typeof window !== 'undefined' && window.Telegram && window.Telegram.WebApp) || null;
     }
 
+    // Telegram injects launch params into the URL HASH fragment
+    // (#tgWebAppData=…&tgWebAppVersion=…), NOT the query string. When
+    // telegram-web-app.js hasn't populated `tg.initData` yet (slow CDN,
+    // cache miss), the hash is the authoritative fallback. We also check
+    // `search` for the rare desktop/manual-link case where a host appends
+    // `?tgWebAppData=` or `?initData=` directly.
     function resolveInitDataFromUrl() {
         if (typeof window === 'undefined') return '';
+        const hash = (window.location.hash || '').replace(/^#/, '');
+        const hashParams = new URLSearchParams(hash);
+        const fromHash = hashParams.get('tgWebAppData') || hashParams.get('initData');
+        if (fromHash) return fromHash;
         const qs = new URLSearchParams(window.location.search || '');
         return qs.get('tgWebAppData') || qs.get('initData') || '';
     }
@@ -109,6 +119,17 @@
         }
     }
 
+    // Build headers for a POST mutation with the resolved initData
+    // attached. Mirrors fetchAPI's auth handling so a mutation can't omit
+    // the header that the page-load GET sent — critical when the page
+    // recovered initData from the URL hash (empty tg.initData).
+    async function authHeaders(extra = {}) {
+        const headers = { 'Content-Type': 'application/json', ...extra };
+        const initData = await resolveInitData();
+        if (initData) headers['X-Telegram-Init-Data'] = initData;
+        return headers;
+    }
+
     const DATE_FORMAT_BY_LANGUAGE = {
         vi: { locale: 'vi-VN', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
         en: { locale: 'en-GB', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },
@@ -136,6 +157,8 @@
         formatMoneyFull,
         escapeHtml,
         fetchAPI,
+        resolveInitData,
+        authHeaders,
         formatDate,
         resolveDateFormat,
     };

--- a/backend/miniapp/static/js/expense_dashboard.js
+++ b/backend/miniapp/static/js/expense_dashboard.js
@@ -13,7 +13,7 @@
     // the IIFE so the bindings are out of TDZ before any init-phase
     // caller (cf. the UI_KEYWORDS regression that motivated the smoke
     // harness).
-    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, formatDate } = window.DashboardCommon;
+    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, formatDate, authHeaders } = window.DashboardCommon;
 
     const tg = window.Telegram && window.Telegram.WebApp;
     if (tg) {
@@ -856,12 +856,11 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
         return 'Không tải được dữ liệu, thử lại nhé.';
     }
 
-    function reportLoaded() {
+    async function reportLoaded() {
         if (loadBeaconSent) return;
         loadBeaconSent = true;
         const loadTimeMs = Math.round(performance.now() - pageStartedAt);
-        const headers = { 'Content-Type': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        const headers = await authHeaders();
         fetch('/miniapp/api/events/loaded', {
             method: 'POST',
             headers,

--- a/backend/miniapp/static/js/twin_dashboard.js
+++ b/backend/miniapp/static/js/twin_dashboard.js
@@ -9,6 +9,19 @@
         applyTheme(tg.themeParams || {});
     }
 
+    // Telegram injects launch params into the URL HASH fragment
+    // (#tgWebAppData=…); when telegram-web-app.js hasn't populated
+    // tg.initData yet, the hash is the authoritative fallback so requests
+    // still carry auth instead of triggering a 401. This bundle is
+    // standalone (no dashboard_common.js), so the helper is inlined.
+    function resolveInitData() {
+        if (tg && tg.initData) return tg.initData;
+        const fromHash = new URLSearchParams((window.location.hash || '').replace(/^#/, ''));
+        const fromSearch = new URLSearchParams(window.location.search || '');
+        return fromHash.get('tgWebAppData') || fromHash.get('initData')
+            || fromSearch.get('tgWebAppData') || fromSearch.get('initData') || '';
+    }
+
     const els = {
         loading: document.getElementById('loading'),
         error: document.getElementById('error'),
@@ -122,7 +135,8 @@
 
     function buildHeaders(scenario) {
         const headers = { 'Accept': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        const initData = resolveInitData();
+        if (initData) headers['X-Telegram-Init-Data'] = initData;
         if (etags[scenario]) headers['If-None-Match'] = etags[scenario];
         return headers;
     }
@@ -159,7 +173,8 @@
 
     function postTwinEvent(eventType, screenId) {
         const headers = { 'Accept': 'application/json', 'Content-Type': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        const initData = resolveInitData();
+        if (initData) headers['X-Telegram-Init-Data'] = initData;
         fetch('/api/twin/events', {
             method: 'POST',
             headers,
@@ -409,7 +424,8 @@
         }
         causalityInFlight = true;
         const headers = { 'Accept': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        const initData = resolveInitData();
+        if (initData) headers['X-Telegram-Init-Data'] = initData;
         fetch('/api/twin/causality', { headers })
             .then((response) => {
                 if (!response.ok) throw new Error('causality fetch failed');
@@ -462,10 +478,11 @@
     }
 
     function reportLoaded() {
-        if (!tg || !tg.initData) return;
+        const initData = resolveInitData();
+        if (!initData) return;
         fetch('/miniapp/api/events/loaded', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json', 'X-Telegram-Init-Data': tg.initData },
+            headers: { 'Content-Type': 'application/json', 'X-Telegram-Init-Data': initData },
             body: JSON.stringify({ page: 'twin', scenario: currentScenario }),
         }).catch(() => {});
     }

--- a/backend/miniapp/static/js/wealth_dashboard.js
+++ b/backend/miniapp/static/js/wealth_dashboard.js
@@ -11,7 +11,7 @@
     // Shared helpers from /miniapp/static/js/dashboard_common.js — loaded
     // first via the template. Destructure at IIFE top so bindings exit
     // TDZ before any caller (per the smoke-harness contract).
-    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI } = window.DashboardCommon;
+    const { applyTheme, formatMoneyShort, formatMoneyFull, escapeHtml, fetchAPI, authHeaders } = window.DashboardCommon;
 
     const tg = window.Telegram && window.Telegram.WebApp;
     if (tg) {
@@ -525,8 +525,7 @@
         if (!assetId && !assetIds.length) return;
         editBtn.disabled = true;
         try {
-            const headers = { 'Content-Type': 'application/json' };
-            if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+            const headers = await authHeaders();
             const response = await fetch('/miniapp/api/wealth/start-asset-edit', {
                 method: 'POST',
                 headers,
@@ -562,8 +561,7 @@
         if (deleteBtn) deleteBtn.disabled = true;
 
         try {
-            const headers = { 'Content-Type': 'application/json' };
-            if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+            const headers = await authHeaders();
             const idsToDelete = assetIds.length ? assetIds : [assetId];
             const response = await fetch('/miniapp/api/wealth/delete-asset', {
                 method: 'POST',
@@ -587,8 +585,7 @@
         if (els.addFirstAssetBtn) els.addFirstAssetBtn.disabled = true;
 
         try {
-            const headers = { 'Content-Type': 'application/json' };
-            if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+            const headers = await authHeaders();
             // Wait for the bot to post the type-picker before closing
             // the WebApp — otherwise the user lands on an empty chat
             // and assumes the button did nothing.
@@ -608,8 +605,7 @@
     async function backToMainMenu() {
         if (els.backMenuBtn) els.backMenuBtn.disabled = true;
         try {
-            const headers = { 'Content-Type': 'application/json' };
-            if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+            const headers = await authHeaders();
             // Bound the request so a stalled mobile connection can't trap
             // the user on the dashboard — we close regardless below.
             const controller = new AbortController();
@@ -642,12 +638,11 @@
         return 'Không tải được dữ liệu, thử lại nhé.';
     }
 
-    function reportLoaded() {
+    async function reportLoaded() {
         if (loadBeaconSent) return;
         loadBeaconSent = true;
         const loadTimeMs = Math.round(performance.now() - pageStartedAt);
-        const headers = { 'Content-Type': 'application/json' };
-        if (tg && tg.initData) headers['X-Telegram-Init-Data'] = tg.initData;
+        const headers = await authHeaders();
         fetch('/miniapp/api/events/loaded', {
             method: 'POST',
             headers,

--- a/backend/tests/test_dashboard_common.py
+++ b/backend/tests/test_dashboard_common.py
@@ -108,6 +108,8 @@ def test_dashboard_common_exposes_expected_helpers() -> None:
         "formatMoneyFull",
         "escapeHtml",
         "fetchAPI",
+        "resolveInitData",
+        "authHeaders",
         "formatDate",
         "resolveDateFormat",
     ])
@@ -256,6 +258,36 @@ def test_fetch_api_uses_query_initdata_without_double_decode_breakage() -> None:
     """)
     assert captured["data"] == {"ok": 1}
     assert captured["seenHeader"] == "query%signed=abc"
+
+
+def test_resolve_init_data_reads_hash_fragment() -> None:
+    """Root-cause regression guard (issue #865): Telegram puts launch
+    params in the URL *hash* (#tgWebAppData=…), not the query string. When
+    tg.initData hasn't hydrated, resolveInitData must recover auth from the
+    hash so the page-load GET still authenticates instead of 401-ing.
+    """
+    captured = _evaluate("""
+        ctx.Telegram.WebApp.initData = '';
+        ctx.location = { hash: '#tgWebAppData=hash%25signed%3Dxyz&tgWebAppVersion=7.0', search: '' };
+        const resolved = await DC.resolveInitData(0);
+        return { resolved };
+    """)
+    assert captured["resolved"] == "hash%signed=xyz"
+
+
+def test_auth_headers_attach_resolved_init_data() -> None:
+    """Mutation guard: POST/PATCH headers must carry the same resolved
+    initData the page-load GET sent. Without this, a page that recovered
+    auth from the hash would load but silently 401 on every mutation.
+    """
+    captured = _evaluate("""
+        ctx.Telegram.WebApp.initData = '';
+        ctx.location = { hash: '#tgWebAppData=from-hash', search: '' };
+        const headers = await DC.authHeaders();
+        return headers;
+    """)
+    assert captured["X-Telegram-Init-Data"] == "from-hash"
+    assert captured["Content-Type"] == "application/json"
 
 
 def test_fetch_api_surfaces_payload_error() -> None:

--- a/backend/tests/test_miniapp_wealth_routes.py
+++ b/backend/tests/test_miniapp_wealth_routes.py
@@ -106,9 +106,13 @@ class TestWealthOverviewAuth:
         _clear_overrides()
 
     def test_missing_init_data_returns_401(self):
-        # No header → FastAPI raises 422 (Header(...) is required).
+        # No header → clean 401. The dependency declares the header Optional
+        # so a missing header is treated as "auth required" (401) rather than
+        # FastAPI's default "unprocessable entity" (422). The client maps
+        # 401/403 to a re-auth path; a 422 would surface as an opaque,
+        # unrecoverable "không tải được dữ liệu".
         resp = client.get("/miniapp/api/wealth/overview")
-        assert resp.status_code in {401, 422}
+        assert resp.status_code == 401
 
     def test_invalid_init_data_returns_401(self):
         resp = client.get(


### PR DESCRIPTION
## Summary

Fixes #865 — the Telegram Mini App wealth dashboard "won't open" (404 JS + 422 API).

**Root cause:** Telegram injects launch params into the URL **hash** fragment (`#tgWebAppData=…`), not the query string. On a cold load, `telegram-web-app.js` may not have populated `tg.initData` yet when the first request fires, so the dashboard sent **no** `X-Telegram-Init-Data` header. The backend declared that header as required (`Header(...)`) and raised a **422**, which the client surfaced as an opaque "không tải được dữ liệu" with no recovery path — the dashboard appeared to never open.

## Changes

**Frontend — restore the hash fallback everywhere (system consistency):**
- `dashboard_common.js`: `resolveInitDataFromUrl` now reads the **hash** fragment first (then `search`); added an `authHeaders()` helper so mutations carry the same resolved initData the page-load GET used. Both newly exported on `window.DashboardCommon`.
- `wealth_dashboard.js`, `expense_dashboard.js`, `dashboard.js`: route every mutation + the `loaded` beacon through `authHeaders()` (`reportLoaded` made async).
- `cashflow_dashboard.js`, `twin_dashboard.js` (standalone bundles, no DashboardCommon): inlined a hash-aware `resolveInitData()` so they recover auth the same way. Twin keeps its `If-None-Match` ETag scheme intact.

**Backend — clean 401 instead of 422:**
- `auth.py`: `require_miniapp_auth` declares the header `Optional` and raises a clean **401** on missing/invalid auth, so the client's re-auth path engages instead of an unrecoverable 422.

## Test plan
- [x] `test_dashboard_common.py` — added hash-fragment resolution regression guard (#865) + `authHeaders` mutation-auth test; updated the public-surface lock for the two new exports.
- [x] `test_miniapp_wealth_routes.py` — tightened missing-header assertion to expect `401`.
- [x] Existing `test_miniapp_auth.py` (11) and the dashboard_common suite pass. The only remaining failures in the touched suites are pre-existing/environmental (build-marker footer + a twin preload string-match unrelated to this change) and fail identically on clean `HEAD`.

Closes #865