### PR TITLE
fix(miniapp): exclude Telegram `signature` field from initData HMAC (#867)

### DIFF
--- a/backend/miniapp/auth.py
+++ b/backend/miniapp/auth.py
@@ -46,8 +46,9 @@ def verify_init_data(
         logger.warning("verify_init_data called without telegram_bot_token")
         return None
 
-    # parse_qsl preserves the original-encoded values, which is what we need
-    # for the HMAC — Telegram signs the URL-encoded string, not the decoded one.
+    # parse_qsl URL-decodes each value, which is exactly what the HMAC
+    # check needs — Telegram builds its data-check-string from the decoded
+    # field values, then URL-encodes the whole querystring for transport.
     try:
         pairs = parse_qsl(init_data, strict_parsing=True, keep_blank_values=True)
     except ValueError:
@@ -55,6 +56,11 @@ def verify_init_data(
 
     fields = dict(pairs)
     received_hash = fields.pop("hash", None)
+    # The Ed25519 `signature` field (used for third-party validation) is NOT
+    # part of the bot-token HMAC check string — Telegram excludes both `hash`
+    # and `signature`. Recent clients always send `signature`; leaving it in
+    # the data-check-string makes the HMAC mismatch and every request 401s.
+    fields.pop("signature", None)
     if not received_hash:
         return None
 

--- a/backend/tests/test_miniapp_auth.py
+++ b/backend/tests/test_miniapp_auth.py
@@ -119,3 +119,15 @@ class TestVerifyInitData:
         fields["auth_date"] = "not-a-number"
         init_data = _sign(fields)
         assert verify_init_data(init_data, bot_token=BOT_TOKEN) is None
+
+    def test_signature_field_excluded_from_hmac(self):
+        """Recent Telegram clients append an Ed25519 `signature` field that is
+        NOT part of the bot-token HMAC check string. Signing without it (as
+        Telegram does) and then attaching `signature` must still verify.
+        """
+        fields = _base_fields()
+        init_data = _sign(fields)  # signed without `signature`, like Telegram
+        with_signature = init_data + "&signature=" + "Ed25519_base64url_blob"
+        result = verify_init_data(with_signature, bot_token=BOT_TOKEN)
+        assert result is not None
+        assert result["user_id"] == 12345


### PR DESCRIPTION
## Problem (#867)

After the #865 fix, the wealth dashboard still returned **401** on a real Telegram account (dev / mac mini via Cloudflare tunnel). The `X-Telegram-Init-Data` header was now being sent, but validation kept failing: `GET /miniapp/api/wealth/overview` → 401, while static assets and `/miniapp/api/version` were 200.

## Root cause

`verify_init_data` built the data-check-string from **every** received field except `hash`. But recent Telegram clients always append an **Ed25519 `signature`** field used for *third-party* validation. Per the [official spec](https://core.telegram.org/bots/webapps#validating-data-received-via-the-mini-app), the bot-token HMAC check string must exclude **both `hash` AND `signature`**. Leaving `signature` in corrupted the data-check-string, so the HMAC never matched and every authenticated request 401'd.

This was never caught because no existing test included a `signature` field — exactly the field real clients send.

## Fix

- Pop `signature` (alongside `hash`) before building the data-check-string in `backend/miniapp/auth.py`.
- Add a regression test that signs initData *without* `signature` (as Telegram does), then attaches a `signature=` param, and asserts `verify_init_data` still succeeds.
- Correct a misleading comment that claimed `parse_qsl` preserves encoded values — it URL-decodes, which is exactly what the HMAC needs.

## Test plan

- [x] `pytest backend/tests/test_miniapp_auth.py` → 12 passed (11 existing + 1 new regression)
- [ ] Re-test the wealth dashboard end-to-end on dev with a real Telegram account → expect 200 on `/miniapp/api/wealth/overview`

Closes #867

https://claude.ai/code/session_01HTutWC9SSovWAPRBrauMjo