### PR TITLE
Add diagnostic logging to Mini App initData verification (#869)

### DIFF
--- a/backend/miniapp/auth.py
+++ b/backend/miniapp/auth.py
@@ -39,6 +39,7 @@ def verify_init_data(
     Returns parsed user info dict on success; None on any failure.
     """
     if not init_data:
+        logger.warning("miniapp auth fail: empty initData")
         return None
 
     token = bot_token if bot_token is not None else get_settings().telegram_bot_token
@@ -52,6 +53,7 @@ def verify_init_data(
     try:
         pairs = parse_qsl(init_data, strict_parsing=True, keep_blank_values=True)
     except ValueError:
+        logger.warning("miniapp auth fail: initData not a valid querystring")
         return None
 
     fields = dict(pairs)
@@ -62,11 +64,11 @@ def verify_init_data(
     # the data-check-string makes the HMAC mismatch and every request 401s.
     fields.pop("signature", None)
     if not received_hash:
+        logger.warning("miniapp auth fail: no hash field in initData")
         return None
 
-    data_check_string = "\n".join(
-        f"{k}={v}" for k, v in sorted(fields.items(), key=lambda kv: kv[0])
-    )
+    sorted_keys = sorted(fields.keys())
+    data_check_string = "\n".join(f"{k}={fields[k]}" for k in sorted_keys)
 
     secret_key = hmac.new(
         key=b"WebAppData",
@@ -81,15 +83,30 @@ def verify_init_data(
     ).hexdigest()
 
     if not hmac.compare_digest(received_hash, expected_hash):
+        # Log only hash prefixes (derived, not the secret token) and the field
+        # KEYS (not values, which carry user PII) so an unexpected field
+        # polluting the check string is visible without leaking data.
+        logger.warning(
+            "miniapp auth fail: HMAC mismatch (recv=%s… expected=%s… keys=%s)",
+            received_hash[:8],
+            expected_hash[:8],
+            sorted_keys,
+        )
         return None
 
     # Freshness check — auth_date is seconds since epoch, UTC.
     try:
         auth_date = int(fields.get("auth_date", "0"))
     except ValueError:
+        logger.warning("miniapp auth fail: auth_date not an integer")
         return None
 
     if auth_date <= 0 or (time.time() - auth_date) > max_age_seconds:
+        logger.warning(
+            "miniapp auth fail: initData stale (auth_date age=%ss, max=%ss)",
+            int(time.time() - auth_date),
+            max_age_seconds,
+        )
         return None
 
     user_payload = fields.get("user")
@@ -124,7 +141,13 @@ async def require_miniapp_auth(
     required header. The client treats 401/403 as "re-auth"; a 422 leaks
     as an opaque "không tải được dữ liệu" with no recovery path.
     """
-    verified = verify_init_data(x_telegram_init_data) if x_telegram_init_data else None
-    if not verified or not verified.get("user_id"):
+    if not x_telegram_init_data:
+        logger.warning("miniapp auth fail: missing X-Telegram-Init-Data header")
+        raise HTTPException(status_code=401, detail="Invalid Telegram auth")
+    verified = verify_init_data(x_telegram_init_data)
+    if not verified:
+        raise HTTPException(status_code=401, detail="Invalid Telegram auth")
+    if not verified.get("user_id"):
+        logger.warning("miniapp auth fail: HMAC valid but initData has no user.id")
         raise HTTPException(status_code=401, detail="Invalid Telegram auth")
     return verified


### PR DESCRIPTION
## Why

The Mini App dashboard keeps returning **401** despite two prior fixes (#865 recover initData from the URL hash, #867 exclude the Ed25519 `signature` field from the HMAC). Both fixes were correct in isolation, but the 401 persisted — and we had **no way to know which check was rejecting the request**.

Root cause of the *debugging* failure: `verify_init_data()` returned `None` on every failure path with **zero logging**, so each fix was a blind guess. This PR does **not** add another speculative fix — it makes the failure observable so the next 401 names its own cause.

## Investigation result (re: #863)

The user suspected #863 introduced the regression. **It did not.** #863 (`878e1f4`) is pure frontend formatting (`formatMoneyFull`, money-input parsing — 7 files, all JS/test) and never touches the auth path. `wealth_dashboard.js` — untouched by #863 — still 401s, which places the bug in the shared auth path (`require_miniapp_auth`), not in anything #863 changed.

## What

Add scoped `logger.warning()` at each rejection point in `backend/miniapp/auth.py`:

- empty initData
- malformed querystring
- missing `hash` field
- **HMAC mismatch** (logs hash prefixes + field KEYS)
- non-integer `auth_date`
- stale initData (logs age vs. max)
- missing `X-Telegram-Init-Data` header
- HMAC valid but no `user.id`

### Secret / PII safety

Logs record only **derived hash prefixes** (first 8 chars of received/expected hash) and field **KEYS** — never field values (which carry user PII) and never the bot token.

## Next step (operator)

Redeploy the backend, re-open the Mini App, and read the new warning line. It will name the exact failing check (HMAC mismatch / stale / no user.id), and we apply the real fix from evidence instead of guessing a third time.

## Test plan

- [x] `pytest backend/tests/test_miniapp_auth.py` — 12 passed (logging is additive, behavior preserved)

https://claude.ai/code/session_01KeY9BGPHRMoABuezvbaDif