### PR TITLE
fix(miniapp): accept both signature-in/out HMAC variants to end the 401 (#869)

### DIFF
--- a/backend/miniapp/auth.py
+++ b/backend/miniapp/auth.py
@@ -5,7 +5,9 @@ Docs: https://core.telegram.org/bots/webapps#validating-data-received-via-the-mi
 Flow:
     1. Mini App JS sends `tg.initData` as header `X-Telegram-Init-Data`.
     2. Parse querystring, pop `hash`, build data-check-string by joining the
-       remaining key=value pairs sorted alphabetically with `\n`.
+       remaining key=value pairs sorted alphabetically with `\n`. Because
+       clients disagree on whether the Ed25519 `signature` field belongs in
+       this string, we try both (excluded / included) and accept either.
     3. secret_key = HMAC-SHA256(key="WebAppData", msg=bot_token)
     4. expected_hash = HMAC-SHA256(key=secret_key, msg=data_check_string)
     5. Constant-time compare with received hash.
@@ -58,39 +60,60 @@ def verify_init_data(
 
     fields = dict(pairs)
     received_hash = fields.pop("hash", None)
-    # The Ed25519 `signature` field (used for third-party validation) is NOT
-    # part of the bot-token HMAC check string — Telegram excludes both `hash`
-    # and `signature`. Recent clients always send `signature`; leaving it in
-    # the data-check-string makes the HMAC mismatch and every request 401s.
-    fields.pop("signature", None)
     if not received_hash:
         logger.warning("miniapp auth fail: no hash field in initData")
         return None
 
-    sorted_keys = sorted(fields.keys())
-    data_check_string = "\n".join(f"{k}={fields[k]}" for k in sorted_keys)
-
+    # The Ed25519 `signature` field (third-party validation) is sent by recent
+    # clients. There is genuine ambiguity across Telegram clients/libraries over
+    # whether `signature` belongs in the bot-token HMAC check string. Rather
+    # than guess, accept whichever variant the client actually signed — both
+    # require the real bot token to forge, so accepting either is exactly as
+    # secure as accepting one. We log which variant won so the truth is visible.
     secret_key = hmac.new(
         key=b"WebAppData",
         msg=token.encode("utf-8"),
         digestmod=hashlib.sha256,
     ).digest()
 
-    expected_hash = hmac.new(
-        key=secret_key,
-        msg=data_check_string.encode("utf-8"),
-        digestmod=hashlib.sha256,
-    ).hexdigest()
+    def _expected(keys: list[str]) -> str:
+        data_check_string = "\n".join(f"{k}={fields[k]}" for k in keys)
+        return hmac.new(
+            key=secret_key,
+            msg=data_check_string.encode("utf-8"),
+            digestmod=hashlib.sha256,
+        ).hexdigest()
 
-    if not hmac.compare_digest(received_hash, expected_hash):
-        # Log only hash prefixes (derived, not the secret token) and the field
-        # KEYS (not values, which carry user PII) so an unexpected field
-        # polluting the check string is visible without leaking data.
+    signature_present = "signature" in fields
+    keys_excl = sorted(k for k in fields if k != "signature")
+    keys_incl = sorted(fields.keys())
+
+    expected_excl = _expected(keys_excl)
+    expected_incl = _expected(keys_incl) if signature_present else expected_excl
+
+    if hmac.compare_digest(received_hash, expected_excl):
+        pass  # canonical: signature excluded
+    elif signature_present and hmac.compare_digest(received_hash, expected_incl):
         logger.warning(
-            "miniapp auth fail: HMAC mismatch (recv=%s… expected=%s… keys=%s)",
+            "miniapp auth: initData verified only with `signature` INCLUDED in "
+            "the HMAC check string — this client signs differently than #867 "
+            "assumed."
+        )
+    else:
+        # Neither variant matched → the bot token we hash with is not the token
+        # that signed this initData (stale process or wrong bot). Log the PUBLIC
+        # bot_id (digits before ':', not the secret) so the operator can confirm
+        # bot identity, plus hash prefixes and field KEYS (never values/PII).
+        logger.warning(
+            "miniapp auth fail: HMAC mismatch on BOTH variants — token problem. "
+            "bot_id=%s had_signature=%s recv=%s… expected_excl=%s… "
+            "expected_incl=%s… keys=%s",
+            token.split(":", 1)[0],
+            signature_present,
             received_hash[:8],
-            expected_hash[:8],
-            sorted_keys,
+            expected_excl[:8],
+            expected_incl[:8] if signature_present else "n/a",
+            keys_excl,
         )
         return None
 

--- a/backend/tests/test_miniapp_auth.py
+++ b/backend/tests/test_miniapp_auth.py
@@ -15,7 +15,11 @@ BOT_TOKEN = "1234567:TEST-BOT-TOKEN"
 
 
 def _sign(fields: dict[str, str], token: str = BOT_TOKEN) -> str:
-    """Helper — produce a valid Telegram initData query string."""
+    """Helper — produce a valid Telegram initData query string.
+
+    Signs over exactly the `fields` passed in, so callers control whether a
+    `signature` field is part of the HMAC check string.
+    """
     data_check_string = "\n".join(
         f"{k}={v}" for k, v in sorted(fields.items(), key=lambda kv: kv[0])
     )
@@ -121,13 +125,32 @@ class TestVerifyInitData:
         assert verify_init_data(init_data, bot_token=BOT_TOKEN) is None
 
     def test_signature_field_excluded_from_hmac(self):
-        """Recent Telegram clients append an Ed25519 `signature` field that is
-        NOT part of the bot-token HMAC check string. Signing without it (as
-        Telegram does) and then attaching `signature` must still verify.
+        """Client signs WITHOUT `signature` in the check string, then attaches
+        it (the variant #867 assumed). Must still verify.
         """
         fields = _base_fields()
-        init_data = _sign(fields)  # signed without `signature`, like Telegram
+        init_data = _sign(fields)  # signed without `signature`
         with_signature = init_data + "&signature=" + "Ed25519_base64url_blob"
         result = verify_init_data(with_signature, bot_token=BOT_TOKEN)
         assert result is not None
         assert result["user_id"] == 12345
+
+    def test_signature_field_included_in_hmac(self):
+        """Other clients sign WITH `signature` inside the check string. The
+        verifier must accept this variant too — both prove bot-token possession.
+        """
+        fields = _base_fields()
+        fields["signature"] = "Ed25519_base64url_blob"
+        init_data = _sign(fields)  # signed WITH `signature` in the string
+        result = verify_init_data(init_data, bot_token=BOT_TOKEN)
+        assert result is not None
+        assert result["user_id"] == 12345
+
+    def test_wrong_token_rejected_even_with_signature(self):
+        """Dual-variant acceptance must not weaken auth: a wrong token still
+        fails both variants.
+        """
+        fields = _base_fields()
+        fields["signature"] = "Ed25519_base64url_blob"
+        init_data = _sign(fields, token="real-token")
+        assert verify_init_data(init_data, bot_token="different-token") is None


### PR DESCRIPTION
## Why

The Mini App dashboard 401 survived **two** fixes (#865 recover initData from the URL hash, #867 exclude the Ed25519 `signature` field from the HMAC). The diagnostic logging from #870 finally told us why:

```
miniapp auth fail: HMAC mismatch (recv=384ffcf5… expected=b582b050… keys=['auth_date', 'query_id', 'user'])
```

**Clean keys, correctly-built check string, yet the HMAC still mismatches.** That isolates the cause to one of two things — and both #865/#867 were *guesses* about which:

1. Whether the `signature` field belongs in the bot-token HMAC check string (#867 assumed *excluded*; clients and libraries genuinely disagree — `telegram-mini-apps` excludes it, older refs include it).
2. Whether the bot token we hash with is the token that signed the initData (stale process holding an old token via `@lru_cache get_settings`, or a different bot).

## What

Stop guessing the `signature` question. `verify_init_data()` now computes the HMAC **both ways** — `signature` excluded *and* included — and accepts whichever variant the client actually signed.

- **Security unchanged:** both variants require the real bot token to forge, so accepting either is exactly as secure as accepting one. Added `test_wrong_token_rejected_even_with_signature` to prove a wrong token still fails both.
- **Self-healing:** if #867's exclusion was wrong for this client, the dashboard works immediately on deploy.

For the *token* theory, the mismatch log now prints the **public `bot_id`** (digits before `:`, never the secret) plus which variant was tried:

```
miniapp auth fail: HMAC mismatch on BOTH variants — token problem.
bot_id=<id> had_signature=<bool> recv=…  expected_excl=…  expected_incl=…  keys=[…]
```

So if neither variant matches, the operator compares `bot_id` against the bot serving the Mini App and confirms a stale/wrong token.

### Secret / PII safety

Logs record only derived hash prefixes (8 chars), field **KEYS** (never values), and the **public** bot_id — never field values (user PII) and never the secret part of the token.

## Operator note

`get_settings()` is `@lru_cache`d, so the token is read once at process start. After any `.env` token change, force a real restart (`launchctl kickstart -k gui/$(id -u)/com.financeassistant.backend`) — `KeepAlive=true` can otherwise leave the old process (and its cached token) alive.

## Test plan

- [x] `pytest backend/tests/test_miniapp_auth.py` — 14 passed (added include-signature + wrong-token-with-signature cases)
- [ ] Redeploy, re-open Mini App: either it loads (variant mismatch was the cause) or the new `bot_id` line confirms a token mismatch.

https://claude.ai/code/session_01KeY9BGPHRMoABuezvbaDif