### PR TITLE
fix(miniapp): distinguish a missing Telegram session from a rejected one

### DIFF
--- a/backend/miniapp/static/js/dashboard.js
+++ b/backend/miniapp/static/js/dashboard.js
@@ -139,6 +139,7 @@
 
     function buildErrorMessage(err) {
         if (err && err.name === 'AbortError') return 'Kết nối quá chậm — thử lại nhé.';
+        if (err && err.message === 'NO_INIT_DATA') return 'Hãy mở lại trang này từ trong Telegram nhé.';
         if (err && err.message === 'API 401') return 'Phiên đăng nhập Telegram không hợp lệ.';
         if (err && err.message === 'API 404') return 'Chưa có dữ liệu — hãy ghi giao dịch đầu tiên.';
         return 'Không tải được dữ liệu, thử lại nhé.';

--- a/backend/miniapp/static/js/dashboard_common.js
+++ b/backend/miniapp/static/js/dashboard_common.js
@@ -104,7 +104,15 @@
         const headers = { 'Content-Type': 'application/json' };
         try {
             const initData = await resolveInitData();
-            if (initData) headers['X-Telegram-Init-Data'] = initData;
+            // No initData (tg.initData empty AND no URL-hash/query fallback)
+            // means the page carries no Telegram session — opened in a plain
+            // browser, or a launch that delivered nothing. The server would
+            // 401, but that 401 is indistinguishable from a *rejected* session
+            // (wrong bot token). Throw a distinct error so the UI can say
+            // "open from inside Telegram" instead of conflating both as one
+            // opaque "phiên không hợp lệ".
+            if (!initData) throw new Error('NO_INIT_DATA');
+            headers['X-Telegram-Init-Data'] = initData;
             const response = await fetch('/miniapp/api' + endpoint, {
                 ...options,
                 headers: { ...headers, ...(options.headers || {}) },

--- a/backend/miniapp/static/js/expense_dashboard.js
+++ b/backend/miniapp/static/js/expense_dashboard.js
@@ -851,6 +851,7 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
 
     function buildErrorMessage(err) {
         if (err && err.name === 'AbortError') return 'Kết nối quá chậm — thử lại nhé.';
+        if (err && err.message === 'NO_INIT_DATA') return 'Hãy mở lại trang này từ trong Telegram nhé.';
         if (err && err.message === 'API 401') return 'Phiên đăng nhập Telegram không hợp lệ.';
         if (err && err.message === 'API 422') return 'Tham số không hợp lệ.';
         return 'Không tải được dữ liệu, thử lại nhé.';

--- a/backend/miniapp/static/js/wealth_dashboard.js
+++ b/backend/miniapp/static/js/wealth_dashboard.js
@@ -633,6 +633,7 @@
 
     function buildErrorMessage(err) {
         if (err && err.name === 'AbortError') return 'Kết nối quá chậm — thử lại nhé.';
+        if (err && err.message === 'NO_INIT_DATA') return 'Hãy mở lại trang Tài sản từ trong Telegram nhé.';
         if (err && err.message === 'API 401') return 'Phiên đăng nhập Telegram không hợp lệ.';
         if (err && err.message === 'API 422') return 'Tham số không hợp lệ.';
         return 'Không tải được dữ liệu, thử lại nhé.';

--- a/backend/tests/test_dashboard_common.py
+++ b/backend/tests/test_dashboard_common.py
@@ -310,6 +310,29 @@ def test_fetch_api_surfaces_payload_error() -> None:
     assert threw == {"threw": True, "message": "no funds"}
 
 
+def test_fetch_api_throws_no_init_data_when_session_absent() -> None:
+    """Root-cause guard (menu-button 401): when no initData can be resolved
+    anywhere (tg.initData empty, no URL hash, no query), fetchAPI must throw a
+    distinct NO_INIT_DATA error WITHOUT firing the doomed request — so the UI
+    can tell "opened outside Telegram / launch delivered nothing" apart from a
+    server-*rejected* session (wrong bot token), instead of conflating both as
+    an opaque 'API 401'.
+    """
+    result = _evaluate("""
+        let calls = 0;
+        ctx.Telegram.WebApp.initData = '';
+        ctx.location = { hash: '', search: '' };
+        ctx.fetch = () => { calls += 1; return Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve({ data: {} }) }); };
+        try {
+            await DC.fetchAPI('/wealth/overview');
+            return { threw: false, calls };
+        } catch (err) {
+            return { threw: true, message: String(err.message), calls };
+        }
+    """)
+    assert result == {"threw": True, "message": "NO_INIT_DATA", "calls": 0}
+
+
 def test_fetch_api_throws_on_http_failure() -> None:
     """Non-2xx must surface as an Error with 'API <status>' so per-
     dashboard buildErrorMessage can map 401/422/404 to localized copy.


### PR DESCRIPTION
## Why

After the HMAC fix (#871) all three dashboards load when launched from inline buttons. But tapping the chat **menu button** (💰 Tài sản) — or opening the dashboard URL in a plain browser — still shows the same opaque error:

> Phiên đăng nhập Telegram không hợp lệ.

That message is misleading. There are **two completely different** failure modes that both ended up here:

1. **No Telegram session was delivered at all** — `tg.initData` is empty *and* there's no `tgWebAppData`/`initData` in the URL hash or query string. This happens when the page is opened outside Telegram (e.g. pasting the raw `trycloudflare.com` link into a browser), or when a launch surface delivered nothing.
2. **A session was delivered but the server rejected it** — initData present, but the bot-token HMAC doesn't match (stale/wrong token).

Before this change the client sent a request with no `X-Telegram-Init-Data` header in case (1), the server 401'd, and the UI showed the case-(2) message — so the real cause ("you're outside Telegram") was undiagnosable from the screen.

## What

`DashboardCommon.fetchAPI()` now throws a distinct `NO_INIT_DATA` error **before** issuing the request when no session is resolvable, instead of firing a header-less request that always 401s. Each dashboard's `buildErrorMessage` maps that to an actionable Vietnamese message:

- **No session** → "Hãy mở lại trang … từ trong Telegram nhé." (open it from inside Telegram)
- **Rejected session** (`API 401`) → "Phiên đăng nhập Telegram không hợp lệ." (unchanged)

This makes the menu-button / plain-browser case self-explanatory and keeps the genuine token-rejection message for the case it actually describes.

## Files

- `backend/miniapp/static/js/dashboard_common.js` — `fetchAPI` throws `NO_INIT_DATA` when no initData resolvable (no header-less request).
- `backend/miniapp/static/js/wealth_dashboard.js`, `expense_dashboard.js`, `dashboard.js` — `buildErrorMessage` maps `NO_INIT_DATA` to the "open from inside Telegram" message.
- `backend/tests/test_dashboard_common.py` — Node vm test asserting `fetchAPI` throws `NO_INIT_DATA` and makes **zero** fetch calls when the session is absent.

## Test plan

- [x] `pytest backend/tests/test_dashboard_common.py` — 13 passed
- [x] `pytest backend/tests/test_expense_miniapp_static.py` — 11 passed
- [ ] In Telegram, tap the 💰 menu button: dashboard should load. If it still errors, the new message names whether it's a missing session (launch/registration) or a rejected one (token).

https://claude.ai/code/session_01KeY9BGPHRMoABuezvbaDif