### PR TITLE
fix(miniapp): carry source param on chat menu button URL to escape poisoned WebView cache

### DIFF
--- a/backend/bot/setup_menu_button.py
+++ b/backend/bot/setup_menu_button.py
@@ -71,14 +71,26 @@ def _is_ngrok_free_interstitial_host(base_url: str) -> bool:
 
 
 def _bumped_mini_app_url(base: str, build_hash: str) -> str:
-    """Return ``{base}/miniapp/wealth?b={build_hash}`` preserving any existing
-    query string or trailing slash on ``base``.
+    """Return ``{base}/miniapp/wealth?b={build_hash}&source=chat_menu_button``
+    preserving any existing query string or trailing slash on ``base``.
 
     Telegram caches WebView HTML by URL, so the build hash MUST live on the
     URL itself (not just inside the document) for the next tap to defeat the
     cache. Using a stable parameter name (``b``) means the cached entry from
     deploy N is invalidated by the new value at deploy N+1 — Telegram treats
     them as different URLs.
+
+    The ``source`` param does double duty. Primarily it aligns this entry
+    point with the ``urls.py`` convention every other launch URL already
+    follows (inline "Mở dashboard" buttons carry ``&source=...``), giving us
+    analytics attribution for menu-button taps. Critically, it also means the
+    menu URL is NOT byte-identical to a bare ``?b=<hash>`` URL: if the WebView
+    ever cached a blank/failed render of the old menu URL, ``?b`` alone cannot
+    bust it on a restart that recomputes the *same* build hash (the hash only
+    changes when CSS/JS/template bytes change, not on every boot). Carrying a
+    distinct ``source`` yields a URL the WebView has never seen, escaping any
+    poisoned cache entry — the same reason inline buttons render fine while a
+    bare menu URL stays blank.
     """
     base = base.rstrip("/")
     parts = urlsplit(f"{base}/miniapp/wealth")
@@ -88,6 +100,7 @@ def _bumped_mini_app_url(base: str, build_hash: str) -> str:
         if kv
     )
     existing["b"] = build_hash
+    existing["source"] = "chat_menu_button"
     new_query = urlencode(existing)
     return urlunsplit(
         (parts.scheme, parts.netloc, parts.path, new_query, parts.fragment)

--- a/backend/tests/test_setup_menu_button.py
+++ b/backend/tests/test_setup_menu_button.py
@@ -52,11 +52,24 @@ def fake_settings(monkeypatch):
 class TestBumpedMiniAppUrl:
     def test_appends_build_hash_query_param(self):
         url = _bumped_mini_app_url("https://example.com", "abc1234")
-        assert url == "https://example.com/miniapp/wealth?b=abc1234"
+        assert url == (
+            "https://example.com/miniapp/wealth?b=abc1234&source=chat_menu_button"
+        )
 
     def test_strips_trailing_slash_on_base(self):
         url = _bumped_mini_app_url("https://example.com/", "abc1234")
-        assert url == "https://example.com/miniapp/wealth?b=abc1234"
+        assert url == (
+            "https://example.com/miniapp/wealth?b=abc1234&source=chat_menu_button"
+        )
+
+    def test_carries_source_param_to_escape_poisoned_webview_cache(self):
+        # The menu URL must NOT be byte-identical to a bare ``?b=<hash>`` URL:
+        # a restart recomputes the SAME build hash (it only changes when
+        # asset bytes change), so ``?b`` alone can't bust a WebView entry that
+        # cached a blank render. The distinct ``source`` makes it a URL the
+        # WebView has never seen — the documented root-cause fix.
+        url = _bumped_mini_app_url("https://example.com", "abc1234")
+        assert "source=chat_menu_button" in url
 
     def test_replaces_stale_b_param_on_redeploy(self):
         # Defensive: even if MINIAPP_BASE_URL were ever set with a leftover
@@ -89,7 +102,7 @@ class TestSetupChatMenuButton:
         # Pin the cache-bust contract: the build hash MUST be on the URL,
         # not the document — that's the whole point of this module.
         assert button["web_app"]["url"] == (
-            "https://example.com/miniapp/wealth?b=abc1234"
+            "https://example.com/miniapp/wealth?b=abc1234&source=chat_menu_button"
         )
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Why — the TRUE root cause of the blank menu-button dashboard

After the HMAC fix (#871) and the diagnostic-message fix (#872), inline "Mở dashboard" buttons render the Wealth dashboard correctly, but tapping the chat **menu button** (💰 Tài sản) still opened a **blank** WebView (Telegram's loading skeleton, not even our spinner).

Live bisection confirmed the cause: the inline button works, the menu button does not. The only difference between the two launch URLs was the query string.

- Inline buttons go through `urls.py` → `…/miniapp/wealth?b=<hash>&source=<…>`
- The menu button (`setup_menu_button.py`) registered `…/miniapp/wealth?b=<hash>` with **no `source`**

Telegram's WebView **caches HTML by URL and ignores `Cache-Control`**. The build hash (`?b=`) only changes when CSS/JS/template **bytes** change — it does **not** change on a plain restart. So once the WebView cached a blank/failed render of the exact menu URL (from a tap before the earlier fixes were live), every backend restart re-registered the **same** URL and re-served the same poisoned cache entry. That's why restarting never fixed it, and why the inline button — carrying a distinct `&source=` the WebView had never cached — rendered fine.

## What

`_bumped_mini_app_url()` now appends `&source=chat_menu_button`, so the menu URL is never byte-identical to a bare `?b=<hash>` URL. This:

1. Yields a URL the WebView has never seen → escapes the poisoned cache entry on the next deploy/restart.
2. Aligns the menu button with the `urls.py` attribution convention every other launch URL already follows (analytics now sees menu-button taps).

The server already accepts a `source` query param on `/miniapp/wealth` (no 422), and editing this module does **not** change the build hash (the file is not part of the static/template ref set), so behaviour elsewhere is unchanged.

## Files

- `backend/bot/setup_menu_button.py` — `_bumped_mini_app_url` adds `source=chat_menu_button`; docstring documents the cache-escape rationale.
- `backend/tests/test_setup_menu_button.py` — URL assertions updated; new `test_carries_source_param_to_escape_poisoned_webview_cache` pins the contract.

## Test plan

- [x] `pytest backend/tests/test_setup_menu_button.py` — 28 passed
- [ ] Deploy + **restart** the backend, then tap the 💰 menu button in Telegram: the dashboard should render fresh. The boot log line should read `…/miniapp/wealth?b=<hash>&source=chat_menu_button`.

> Operator note: this fix only takes effect after a real restart re-registers the menu button with the new URL.

https://claude.ai/code/session_01KeY9BGPHRMoABuezvbaDif