### PR TITLE
Support credit card as transaction source: validate selection, show bank in confirmation, and preserve field in miniapp payload

### DIFF
--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -137,12 +137,27 @@ async def _handle_source_selection_callback(
         return True
     source_credit_card_id = None
     source_asset_id = None
+    selected_card_bank_name = None
     if data.startswith("txsrc_wallet:"):
         source_type = "e_wallet"
         wallet_provider = data.split(":", 1)[1]
     elif data.startswith("txsrc_card:"):
         source_type = "credit_card"
-        source_credit_card_id = data.split(":", 1)[1]
+        requested_card_id = data.split(":", 1)[1]
+        cards = await list_credit_cards(db, user.id)
+        selected_card = next(
+            (c for c in cards if str(c.id) == str(requested_card_id)),
+            None,
+        )
+        if selected_card is None:
+            await answer_callback(
+                callback_id,
+                text="Thẻ không hợp lệ hoặc đã bị xoá 🌱",
+                show_alert=True,
+            )
+            return True
+        source_credit_card_id = selected_card.id
+        selected_card_bank_name = selected_card.bank_name
     elif data.startswith("txsrc_asset:"):
         source_asset_id = data.split(":", 1)[1]
     elif data.startswith("txsrc:"):
@@ -173,7 +188,11 @@ async def _handle_source_selection_callback(
         "vnpay": "Ví VNPay",
         "zalopay": "Ví ZaloPay",
         "viettelpay": "Ví ViettelPay",
-        "credit_card": "Thẻ tín dụng",
+        "credit_card": (
+            f"Thẻ tín dụng {selected_card_bank_name}"
+            if selected_card_bank_name
+            else "Thẻ tín dụng"
+        ),
     }.get(wallet_provider or source_type, "không liên kết nguồn")
     confirmation_text = (
         f"Đã ghi nhận {tx_sign}{float(expense.amount):,.0f}đ · {source_label}"

--- a/backend/miniapp/routes.py
+++ b/backend/miniapp/routes.py
@@ -603,8 +603,9 @@ def _clean_expense_payload(payload: dict, *, partial: bool = False) -> dict:
         "source_type",
         "e_wallet_provider",
         "source_asset_id",
+        "source_credit_card_id",
     }
-    source_fields = {"source_type", "e_wallet_provider", "source_asset_id"}
+    source_fields = {"source_type", "e_wallet_provider", "source_asset_id", "source_credit_card_id"}
     clean = {}
     for k, v in payload.items():
         if k not in allowed or v == "":

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -339,6 +339,24 @@ async def test_txsrc_credit_card_shows_all_cards_for_expense_only():
 
 
 @pytest.mark.asyncio
+async def test_txsrc_card_select_confirmation_mentions_bank_name():
+    user = _user(state={
+        "flow": "transaction_source_select",
+        "step": "source_type",
+        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
+    })
+    db = MagicMock()
+    expense = _expense(transaction_type="expense", amount=200000.0)
+    card_id = uuid.uuid4()
+    card = SimpleNamespace(id=card_id, bank_name="MSB")
+    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[card])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)),          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})) as edit_text,          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
+        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+
+    assert handled is True
+    assert "Thẻ tín dụng MSB" in edit_text.await_args.kwargs["text"]
+
+
+@pytest.mark.asyncio
 async def test_txsrc_card_select_creates_expense_with_credit_card_source():
     user = _user(state={
         "flow": "transaction_source_select",
@@ -348,13 +366,32 @@ async def test_txsrc_card_select_creates_expense_with_credit_card_source():
     db = MagicMock()
     expense = _expense(transaction_type="expense", amount=200000.0)
     card_id = uuid.uuid4()
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)) as create,          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})),          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
+    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[SimpleNamespace(id=card_id, bank_name="VCB")])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)) as create,          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})),          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
         handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
 
     assert handled is True
     payload = create.await_args.args[2]
     assert payload.source_type == "credit_card"
     assert str(payload.source_credit_card_id) == str(card_id)
+
+
+@pytest.mark.asyncio
+async def test_txsrc_card_select_rejects_unknown_card_id():
+    user = _user(state={
+        "flow": "transaction_source_select",
+        "step": "source_type",
+        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
+    })
+    db = MagicMock()
+    card_id = uuid.uuid4()
+    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock()) as create,          patch.object(callbacks, "answer_callback", AsyncMock()) as answer:
+        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+
+    assert handled is True
+    create.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert "không hợp lệ" in (answer.await_args.kwargs.get("text") or "").lower()
+
 from backend.bot.keyboards.transaction_keyboard import transaction_source_keyboard
 
 def test_tx_source_keyboard_expense_includes_credit_card():

--- a/backend/tests/test_miniapp_expense_routes.py
+++ b/backend/tests/test_miniapp_expense_routes.py
@@ -169,3 +169,20 @@ class TestExpenseOverviewSourceOptions:
             assert resp.status_code == 401
         finally:
             app.dependency_overrides.pop(get_db, None)
+
+
+def test_clean_expense_payload_keeps_credit_card_source_fields():
+    card_id = str(uuid.uuid4())
+    payload = {
+        "amount": 120000,
+        "transaction_type": "expense",
+        "source_type": "credit_card",
+        "source_credit_card_id": card_id,
+        "source": "ignored-by-cleaner",
+    }
+
+    cleaned = miniapp_routes._clean_expense_payload(payload)
+
+    assert cleaned["source_type"] == "credit_card"
+    assert cleaned["source_credit_card_id"] == card_id
+    assert cleaned["source"] == "manual"


### PR DESCRIPTION
### Motivation

- Allow selecting a credit card as a transaction source in the bot flow while validating the chosen card and surfacing the card's bank name in the confirmation message.
- Preserve the `source_credit_card_id` field in miniapp expense payloads so API calls can submit credit-card-based sources.

### Description

- In `backend/bot/handlers/callbacks.py` validate the requested card by calling `list_credit_cards`, return an alert via `answer_callback` for unknown/removed card IDs, and set `source_credit_card_id` from the matched card.
- Add `selected_card_bank_name` and include it in the confirmation `source_label` so confirmations show `Thẻ tín dụng <BANK>` when available.
- In `backend/miniapp/routes.py` add `source_credit_card_id` to the `_clean_expense_payload` `allowed` set and to `source_fields` so it is preserved (and allowed to be `None` on partial updates).
- Add and update unit tests in `backend/tests/test_callbacks_source_selection.py` and `backend/tests/test_miniapp_expense_routes.py` to cover validation, confirmation text, payload cleaning, and creation behavior.

### Testing

- Ran the updated unit tests in `test_callbacks_source_selection.py` including `test_txsrc_card_select_confirmation_mentions_bank_name`, `test_txsrc_card_select_creates_expense_with_credit_card_source`, and `test_txsrc_card_select_rejects_unknown_card_id`, which passed.
- Ran `test_miniapp_expense_routes.py` including `test_clean_expense_payload_keeps_credit_card_source_fields`, which passed.
- Full automated test suite executed successfully (all tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17b593dcdc832f9e38de041cfa32e5)