### PR TITLE
feat(intent): catch colloquial VN expense shapes at Tier 1

### DIFF
--- a/backend/tests/test_intent/fixtures/query_examples.yaml
+++ b/backend/tests/test_intent/fixtures/query_examples.yaml
@@ -367,6 +367,75 @@ edge_cases:
     expected_min_confidence: 0.8
     notes: "Salary income credited to a cash account (#656)."
 
+  # Expense-lead verb + description + amount — the colloquial Vietnamese
+  # shape where users name what they bought between the verb and the
+  # number ("chi vé công viên nước 500k"). Previously fell to the LLM
+  # tier and was mis-tagged as action_record_saving.
+  - text: "chi vé công viên nước 500k"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: "Expense lead verb with description before amount."
+
+  - text: "chi 1000k ăn thịt cá sấu"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: "Expense lead verb with amount before description."
+
+  - text: "mất 200k đổ xăng"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: '"mất X" idiom for unplanned expense.'
+
+  - text: "tốn 500k mua quà"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: '"tốn X" idiom — common spoken Vietnamese.'
+
+  - text: "đóng 500k học phí"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: 'Payment-style verb ("đóng") used for tuition.'
+
+  - text: "trả 200k tiền điện"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: 'Bill payment ("trả") routes to quick-transaction.'
+
+  # "hết X" idiom — sentence describes activity then total spent.
+  - text: "ăn thịt cá sấu hết 1000k"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: '"hết X" idiom — activity then total cost.'
+
+  - text: "ăn trưa hết 50k"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: "Lunch logged via hết idiom."
+
+  # Trailing-amount description — fast-log shape with no verb.
+  - text: "ăn thịt cá sấu 1000k"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: "Description then amount, no leading verb."
+
+  - text: "cà phê highlands 50k"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: "Trailing amount with cafe context."
+
+  # Leading-amount fast-log.
+  - text: "50k cà phê"
+    expected_intent: action_quick_transaction
+    expected_min_confidence: 0.85
+    notes: "Amount-then-description quick log."
+
+  # Negative regressions — these MUST still route to their existing
+  # intents, NOT to action_quick_transaction.
+  - text: "tiết kiệm 1tr"
+    expected_intent: action_record_saving
+    expected_min_confidence: 0.85
+    notes: "Saving log must still beat the new expense patterns."
+
   # Inline-edit shapes — these used to fall through the picker even
   # though the user had already named both the asset and the new
   # value. The handler now reads asset_name + new_value and applies

--- a/content/intent_patterns.yaml
+++ b/content/intent_patterns.yaml
@@ -285,6 +285,55 @@ action_quick_transaction:
     - pattern: '^(?:tru|bot|giam|chi|tieu|rut)\s+[\d.,]+.*(?:khoi|tu|o|trong|vao)\s+(?:vi|tai\s*khoan|cash|tien\s*mat|momo|zalopay|viettel|vcb|acb|tcb|mb|tpb|techcom)'
       confidence: 0.9
 
+    # ---- Expense-lead verb + amount anywhere in the clause ----
+    # Catches the colloquial Vietnamese shapes where users name what
+    # they bought BEFORE saying how much:
+    #   "chi vé công viên nước 500k", "chi 1000k ăn thịt cá sấu",
+    #   "mất 200k đổ xăng", "tốn 500k mua quà", "trả 200k tiền điện",
+    #   "đóng 500k học phí", "nộp 1tr tiền nhà", "xài 200k cà phê",
+    #   "thanh toán 1tr ăn tối", "bỏ 300k mua sách".
+    # Negative lookahead skips "chi tiêu/chi phí ..." (the noun phrase
+    # used by the query intents) so report-style asks still route to
+    # query_expenses / query_expenses_by_category.
+    # Money suffix is mandatory (k/tr/triệu/nghìn/ngàn/đ/vnd) — bare
+    # numbers without a unit are too noisy to trust at this confidence.
+    - pattern: '^(?:chi|tieu|xai|tra|mua|mat|ton|bo|dong|nop|thanh\s*toan|rut)\s+(?!(?:tieu|phi)\b)[^?\n]{0,60}?\b\d+(?:[.,]\d+)?\s*(?:k|tr|trieu|nghin|ngan|m|vnd|vnđ|d)\b'
+      confidence: 0.9
+
+    # Subject-led variant: "tôi mất 500k đi nhậu", "mình chi 1tr ăn tối",
+    # "em vừa trả 200k tiền điện", "tao tốn 500k đổ xăng".
+    # The optional adverb cluster (đã/mới/vừa) covers past-tense
+    # phrasing that Vietnamese speakers default to when logging
+    # transactions retroactively.
+    - pattern: '\b(?:toi|minh|em|tao|tui|t)\s+(?:da\s+|moi\s+|vua\s+|cung\s+)?(?:chi|tieu|tra|mua|mat|ton|bo|dong|nop|xai|thanh\s*toan)\s+(?!(?:tieu|phi)\b)[^?\n]{0,60}?\b\d+(?:[.,]\d+)?\s*(?:k|tr|trieu|nghin|ngan|m|vnd|vnđ|d)\b'
+      confidence: 0.88
+
+    # "hết X" idiom — when X is an amount, the sentence is almost
+    # always logging an expense: "ăn trưa hết 50k",
+    # "ăn thịt cá sấu hết 1000k", "mua sách hết 200k",
+    # "đổ xăng hết 100k", "đi grab hết 80k".
+    # Requires a money suffix to avoid matching unrelated "hết" usages
+    # like "hết tiền" or "hết hàng".
+    - pattern: '\bhet\s+\d+(?:[.,]\d+)?\s*(?:k|tr|trieu|nghin|ngan|m|vnd|vnđ)\b'
+      confidence: 0.88
+
+    # Leading bare amount + description — the canonical fast-log shape:
+    #   "50k cà phê", "200k đổ xăng", "1tr ăn nhậu", "30k trà sữa".
+    # Anchored to start with an optional sign so the income fast-path
+    # ("+200k …") still wins via the message-layer pre-check.
+    - pattern: '^\s*[+\-]?\s*\d+(?:[.,]\d+)?\s*(?:k|tr|trieu|nghin|ngan)\s+[^\d?].{1,40}$'
+      confidence: 0.86
+
+    # Trailing-amount description — "ăn thịt cá sấu 1000k",
+    # "cà phê highlands 50k", "vé công viên nước 500k",
+    # "grab về nhà 80k". Requires the line to START with a known
+    # spending-context lead word (ăn/uống/mua/đi/vé/đổ/cà phê/trà
+    # sữa/cơm/phở/bún/grab/taxi/xe/tiền) so questions and reports
+    # ("ăn uống tháng này bao nhiêu") don't accidentally match —
+    # those have time tokens, not money suffixes.
+    - pattern: '^(?:an|uong|mua|di|ve|do|cafe|ca\s*phe|com|pho|bun|tra\s*sua|grab|taxi|xe|tien|nuoc|bia|ruou|do\s*xang|xang)\b[^?\n]{1,60}?\b\d+(?:[.,]\d+)?\s*(?:k|tr|trieu|nghin|ngan)\s*$'
+      confidence: 0.86
+
 action_record_saving:
   description: "User wants to record a saving."
   patterns:


### PR DESCRIPTION
## Summary

Enhance the Tier 1 rule classifier so common Vietnamese expense phrasings no longer fall through to the LLM tier (where they were mis-tagged as `action_record_saving` or `query_expenses_by_category`).

Real misclassifications observed in chat:
- `chi vé công viên nước 500k` → was tagged `action_record_saving` ("ghi tiết kiệm — coming soon")
- `ăn thịt cá sấu 1000k` / `ăn thịt cá sấu hết 1000k` → was tagged `query_expenses_by_category` ("Rân Chơi không có chi tiêu nào tháng này")

Root cause: the existing `^(?:tru|bot|...|chi|tieu|rut)\s+[\d.,]+` pattern required the number immediately after the verb AND an explicit wallet suffix. Most colloquial logs put a description between the verb and the amount and don't name a wallet.

## Changes

`content/intent_patterns.yaml` — 5 new patterns under `action_quick_transaction`:
- expense-lead verb + description + amount (`chi/mất/tốn/trả/đóng/nộp/xài/thanh toán/bỏ ...`)
- subject-led (`tôi mất 500k đi nhậu`, `mình chi 1tr ăn tối`)
- `hết X` idiom (`ăn trưa hết 50k`)
- leading-amount fast-log (`50k cà phê`)
- trailing-amount with spending lead-word (`ăn thịt cá sấu 1000k`)

Guards:
- Negative lookahead `(?!(?:tieu|phi)\b)` preserves `chi tiêu / chi phí` routing to `query_expenses*`.
- Money suffix mandatory (`k|tr|trieu|nghin|ngan|m|vnd|đ`) to keep precision high.
- Leading-amount pattern allows an optional `+`/`-` sign so the income fast-path still wins.

`backend/tests/test_intent/fixtures/query_examples.yaml` — 12 canonical fixtures covering the screenshot cases plus a `tiết kiệm 1tr` regression case to confirm `action_record_saving` still beats the new patterns.

## Test plan

- [x] `pytest backend/tests/test_intent/test_rule_based.py` — 84 passed (includes new fixtures + OOS invariant `test_out_of_scope_never_returns_a_query_intent`)
- [ ] Smoke check in Telegram: send `chi vé công viên nước 500k`, `ăn thịt cá sấu 1000k`, `mất 200k đổ xăng`, `tiết kiệm 1tr`, `chi tiêu tháng này` and confirm each routes to the expected intent.
