### PR TITLE
feat(expense): apply default source to expense confirmations

### DIFF
--- a/backend/bot/formatters/templates.py
+++ b/backend/bot/formatters/templates.py
@@ -4,10 +4,29 @@ Nguyên tắc: Một function = một loại tin nhắn.
 """
 
 from datetime import date, datetime
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
 
 from backend.bot.formatters.money import format_money_full, format_money_short
 from backend.bot.formatters.progress_bar import make_category_bar, make_progress_bar
 from backend.config.categories import get_category
+
+_TRANSACTION_COPY_PATH = (
+    Path(__file__).resolve().parents[3] / "content" / "transaction_copy.yaml"
+)
+
+
+@lru_cache(maxsize=1)
+def _transaction_copy() -> dict[str, Any]:
+    with open(_TRANSACTION_COPY_PATH, encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _confirmation_copy(key: str, default: str = "") -> str:
+    return _transaction_copy().get("confirmation", {}).get(key, default)
 
 
 def format_transaction_confirmation(
@@ -18,6 +37,8 @@ def format_transaction_confirmation(
     time: datetime | None = None,
     daily_spent: float | None = None,
     daily_budget: float | None = None,
+    source_label: str | None = None,
+    show_edit_hint: bool = False,
 ) -> str:
     """Tin nhắn xác nhận sau khi ghi giao dịch thành công.
 
@@ -34,7 +55,8 @@ def format_transaction_confirmation(
     """
     cat = get_category(category_code)
 
-    lines: list[str] = ["✅ Ghi xong!", ""]
+    title = _confirmation_copy("title_done", "✅ Đã ghi xong!")
+    lines: list[str] = [title, ""]
     lines.append(f"{cat.emoji} {merchant}  —  {format_money_full(amount)}")
 
     context_parts: list[str] = []
@@ -44,6 +66,12 @@ def format_transaction_confirmation(
         context_parts.append(time.strftime("%H:%M"))
     if context_parts:
         lines.append("  •  ".join(context_parts))
+
+    if source_label:
+        source_template = _confirmation_copy(
+            "source_prefix", "💳 Chi từ: {source}"
+        )
+        lines.append(source_template.format(source=source_label))
 
     if daily_spent is not None and daily_budget is not None and daily_budget > 0:
         lines.append("")
@@ -64,6 +92,12 @@ def format_transaction_confirmation(
             lines.append(
                 f"Vượt ngân sách {format_money_short(-remaining)} — cần chú ý 😅"
             )
+
+    if show_edit_hint:
+        hint = _confirmation_copy("edit_hint")
+        if hint:
+            lines.append("")
+            lines.append(hint.strip())
 
     return "\n".join(lines)
 
@@ -128,10 +162,15 @@ def format_receipt_confirmation(
 def format_transaction_batch_confirmation(
     items: list[tuple[str, float, str]],
     time: datetime | None = None,
+    source_label: str | None = None,
+    show_edit_hint: bool = False,
 ) -> str:
     """Tin nhắn xác nhận sau khi ghi nhiều giao dịch cùng lúc."""
     total = sum(amount for _, amount, _ in items)
-    lines: list[str] = [f"✅ Ghi xong {len(items)} khoản!", ""]
+    title_template = _confirmation_copy(
+        "batch_title", "✅ Đã ghi xong {count} khoản!"
+    )
+    lines: list[str] = [title_template.format(count=len(items)), ""]
 
     for merchant, amount, category_code in items:
         cat = get_category(category_code)
@@ -141,6 +180,19 @@ def format_transaction_batch_confirmation(
     lines.append(f"Tổng: {format_money_full(total)}")
     if time:
         lines.append(time.strftime("%H:%M"))
+
+    if source_label:
+        source_template = _confirmation_copy(
+            "source_prefix", "💳 Chi từ: {source}"
+        )
+        lines.append(source_template.format(source=source_label))
+
+    if show_edit_hint:
+        hint = _confirmation_copy("edit_hint")
+        if hint:
+            lines.append("")
+            lines.append(hint.strip())
+
     return "\n".join(lines)
 
 

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -38,6 +38,7 @@ from backend.intent.intents import IntentType
 from backend.schemas.expense import ExpenseCreate
 from backend.services import expense_service, report_service, wizard_service
 from backend.services.dashboard_service import get_user_by_telegram_id
+from backend.services.expense_source_resolver import apply_default_source
 from backend.services.llm_service import call_llm
 from backend.services.telegram_service import send_message
 from backend.wealth.amount_parser import parse_amount
@@ -281,6 +282,7 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
             source_type=source_type,
             source_credit_card_id=source_card_id,
         )
+        expense_data = await apply_default_source(db, user.id, expense_data)
         expense = await expense_service.create_expense(db, user.id, expense_data)
         await send_transaction_confirmation(db, expense)
         return True

--- a/backend/bot/handlers/transaction.py
+++ b/backend/bot/handlers/transaction.py
@@ -20,6 +20,9 @@ from backend.bot.keyboards.transaction_keyboard import (
 from backend.bot.utils.emoji_animation import message_kwargs_for_animation
 from backend.models.expense import Expense
 from backend.services.dashboard_service import get_user_by_id
+from backend.services.expense_source_resolver import (
+    resolve_source_label_for_expense,
+)
 from backend.services.telegram_service import send_message
 
 # Legacy category codes (from earlier phases) → new shared codes.
@@ -50,6 +53,10 @@ async def send_transaction_confirmation(
     if not user or not user.telegram_id:
         return
 
+    is_expense = expense.transaction_type == "expense"
+    source_label = (
+        await resolve_source_label_for_expense(db, expense) if is_expense else None
+    )
     text = format_transaction_confirmation(
         merchant=expense.merchant or expense.note or "Giao dịch",
         amount=float(expense.amount),
@@ -57,13 +64,20 @@ async def send_transaction_confirmation(
         time=expense.created_at,
         daily_spent=daily_spent,
         daily_budget=daily_budget,
+        source_label=source_label,
+        show_edit_hint=is_expense,
     )
-    keyboard = transaction_actions_keyboard(str(expense.id))
+    # Expense confirmations are terminal (edit-hint instead of inline
+    # actions); money-in keeps the legacy action keyboard so the user can
+    # still tweak category / undo.
+    reply_markup = (
+        None if is_expense else transaction_actions_keyboard(str(expense.id))
+    )
     await send_message(
         chat_id=user.telegram_id,
         text=text,
         parse_mode=None,
-        reply_markup=keyboard,
+        reply_markup=reply_markup,
         **message_kwargs_for_animation(text, "transaction"),
     )
 
@@ -98,6 +112,19 @@ async def send_transaction_batch_confirmation(
     if not user or not user.telegram_id:
         return
 
+    all_expense = all(e.transaction_type == "expense" for e in expenses)
+    # Pick the most common source label across the batch — if every item
+    # was charged to the same source, show it; otherwise omit (mixed batches
+    # are rare and we'd rather under-show than mislead).
+    source_label: str | None = None
+    if all_expense:
+        labels = [
+            await resolve_source_label_for_expense(db, e) for e in expenses
+        ]
+        unique = {label for label in labels if label}
+        if len(unique) == 1 and len(labels) == len(expenses):
+            source_label = next(iter(unique))
+
     text = format_transaction_batch_confirmation(
         items=[
             (
@@ -108,12 +135,17 @@ async def send_transaction_batch_confirmation(
             for expense in expenses
         ],
         time=max((expense.created_at for expense in expenses), default=None),
+        source_label=source_label,
+        show_edit_hint=all_expense,
+    )
+    reply_markup = (
+        None if all_expense else transaction_batch_actions_keyboard(batch_id)
     )
     await send_message(
         chat_id=user.telegram_id,
         text=text,
         parse_mode=None,
-        reply_markup=transaction_batch_actions_keyboard(batch_id),
+        reply_markup=reply_markup,
         **message_kwargs_for_animation(text, "transaction"),
     )
 

--- a/backend/intent/handlers/action_quick_transaction.py
+++ b/backend/intent/handlers/action_quick_transaction.py
@@ -36,6 +36,7 @@ from backend.intent.intents import IntentResult
 from backend.models.user import User
 from backend.schemas.expense import ExpenseCreate
 from backend.services import expense_service
+from backend.services.expense_source_resolver import apply_default_source
 from backend.services.llm_service import call_llm
 
 logger = logging.getLogger(__name__)
@@ -112,7 +113,7 @@ _CATEGORY_KEYWORDS: tuple[tuple[str, tuple[str, ...]], ...] = (
 class ParsedExpenseItem:
     amount: float
     merchant: str
-    category_hint: str = "needs_review"
+    category_hint: str = "other"
 
 
 _FALLBACK_REPLY = (
@@ -277,6 +278,7 @@ class ActionQuickTransactionHandler(IntentHandler):
                 source="manual",
                 expense_date=date.today(),
             )
+            expense_data = await apply_default_source(db, user.id, expense_data)
             expense = await expense_service.create_expense(db, user.id, expense_data)
             await send_transaction_confirmation(db, expense)
         else:
@@ -296,6 +298,9 @@ class ActionQuickTransactionHandler(IntentHandler):
                         "batch_index": index,
                         "raw_text": text,
                     },
+                )
+                expense_data = await apply_default_source(
+                    db, user.id, expense_data
                 )
                 expenses.append(
                     await expense_service.create_expense(db, user.id, expense_data)
@@ -490,7 +495,9 @@ def _guess_category(text: str | None) -> str:
     for category, keywords in _CATEGORY_KEYWORDS:
         if any(keyword in normalized for keyword in keywords):
             return category
-    return "needs_review"
+    # Confirmation flow is terminal — show "Khác" rather than blocking on
+    # a clarifier the user can no longer reach.
+    return "other"
 
 
 def _coerce_parsed_items(
@@ -518,7 +525,7 @@ def _coerce_parsed_items(
             ParsedExpenseItem(
                 amount=amount,
                 merchant=merchant,
-                category_hint=category_hint or "needs_review",
+                category_hint=category_hint or "other",
             )
         )
     return parsed_items

--- a/backend/services/expense_source_resolver.py
+++ b/backend/services/expense_source_resolver.py
@@ -1,0 +1,144 @@
+"""Apply the user's ``default_expense_source`` profile setting to expense payloads.
+
+The profile picker stores a source key encoded as one of:
+    ``cash``
+    ``bank_account:<asset_uuid>``
+    ``credit_card:<credit_card_uuid>``
+    ``e_wallet:<asset_uuid>``
+
+This module turns that key into the ``ExpenseCreate`` fields the
+expense service understands, and renders a human-friendly Vietnamese
+label for the confirmation card. Both quick-transaction and the manual
+fast-path go through here so behaviour stays consistent.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.credit_card import CreditCard
+from backend.models.expense import Expense
+from backend.profile.models.user_profile import UserProfile
+from backend.schemas.expense import ExpenseCreate
+from backend.wealth.models.asset import Asset
+
+logger = logging.getLogger(__name__)
+
+_CONTENT_PATH = (
+    Path(__file__).resolve().parents[2] / "content" / "transaction_copy.yaml"
+)
+
+
+@lru_cache(maxsize=1)
+def _copy() -> dict[str, Any]:
+    with open(_CONTENT_PATH, encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _source_label_template(source_type: str | None) -> str:
+    labels = _copy().get("source_labels", {})
+    if source_type and source_type in labels:
+        return labels[source_type]
+    return labels.get("unknown", "Nguồn khác")
+
+
+def _parse_source_key(
+    key: str | None,
+) -> tuple[str | None, uuid.UUID | None, uuid.UUID | None]:
+    """Decode the profile key into (source_type, asset_id, credit_card_id)."""
+    if not key:
+        return None, None, None
+    if key == "cash":
+        return "cash", None, None
+    if ":" not in key:
+        return None, None, None
+    kind, _, raw_id = key.partition(":")
+    try:
+        parsed_id = uuid.UUID(raw_id)
+    except ValueError:
+        return None, None, None
+    if kind == "bank_account":
+        return "bank_account", parsed_id, None
+    if kind == "e_wallet":
+        # The asset's extra metadata carries the provider — the
+        # service-layer resolver re-reads it via ``_asset_source_metadata``.
+        return "e_wallet", parsed_id, None
+    if kind == "credit_card":
+        return "credit_card", None, parsed_id
+    return None, None, None
+
+
+async def apply_default_source(
+    db: AsyncSession, user_id: uuid.UUID, data: ExpenseCreate
+) -> ExpenseCreate:
+    """Return a copy of ``data`` with the user's default source applied.
+
+    No-op when:
+      - the transaction is money-in (incoming flow keeps current UX);
+      - the user has no default configured;
+      - the caller has already specified a source (explicit > default).
+    """
+    if data.transaction_type != "expense":
+        return data
+    if (
+        data.source_type
+        or data.source_asset_id
+        or data.source_credit_card_id
+    ):
+        return data
+
+    profile = await db.get(UserProfile, user_id)
+    key = profile.default_expense_source if profile else None
+    source_type, asset_id, card_id = _parse_source_key(key)
+    if not source_type:
+        return data
+
+    return data.model_copy(
+        update={
+            "source_type": source_type,
+            "source_asset_id": asset_id,
+            "source_credit_card_id": card_id,
+        }
+    )
+
+
+async def resolve_source_label_for_expense(
+    db: AsyncSession, expense: Expense
+) -> str | None:
+    """Build the Vietnamese label shown on the confirmation card.
+
+    Returns ``None`` for money-in or when no source could be resolved.
+    The card line is decorative — silently dropping it is preferable
+    to surfacing a stale or wrong-looking label.
+    """
+    if expense.transaction_type != "expense":
+        return None
+    source_type = expense.source_type
+    if not source_type:
+        return None
+
+    base = _source_label_template(source_type)
+
+    if source_type == "credit_card" and expense.source_credit_card_id:
+        card = await db.get(CreditCard, expense.source_credit_card_id)
+        if card and card.user_id == expense.user_id:
+            bank = (card.bank_name or "").strip()
+            if bank:
+                return f"{base} [{bank}]"
+        return base
+
+    if expense.source_asset_id:
+        asset = await db.get(Asset, expense.source_asset_id)
+        if asset and asset.user_id == expense.user_id:
+            name = (asset.name or "").strip()
+            if name:
+                return f"{base} [{name}]"
+    return base

--- a/backend/tests/test_expense_source_resolver.py
+++ b/backend/tests/test_expense_source_resolver.py
@@ -1,0 +1,280 @@
+"""Tests for ``backend.services.expense_source_resolver`` (Issue #891).
+
+Cover the three behaviours that the confirmation flow depends on:
+
+1. ``_parse_source_key`` decodes the four key shapes plus garbage.
+2. ``apply_default_source`` is a no-op for money-in, for callers that
+   already populated a source, and for users without a profile default.
+3. ``resolve_source_label_for_expense`` returns the right VN label, with
+   bank/card suffix when available.
+"""
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.models.credit_card import CreditCard
+from backend.models.expense import Expense
+from backend.profile.models.user_profile import UserProfile
+from backend.schemas.expense import ExpenseCreate
+from backend.services import expense_source_resolver as resolver
+from backend.wealth.models.asset import Asset
+
+
+def _mk_user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+def _db_with_profile(profile: UserProfile | None, **extra) -> MagicMock:
+    db = MagicMock()
+    db.get = AsyncMock(return_value=profile)
+    return db
+
+
+def _base_expense_payload() -> ExpenseCreate:
+    return ExpenseCreate(
+        amount=120_000.0,
+        merchant="Phở",
+        note="phở",
+        source="manual",
+        expense_date=date.today(),
+    )
+
+
+# -------------------- _parse_source_key --------------------
+
+
+class TestParseSourceKey:
+    def test_cash(self):
+        assert resolver._parse_source_key("cash") == ("cash", None, None)
+
+    def test_bank_account(self):
+        aid = uuid.uuid4()
+        assert resolver._parse_source_key(f"bank_account:{aid}") == (
+            "bank_account",
+            aid,
+            None,
+        )
+
+    def test_e_wallet(self):
+        aid = uuid.uuid4()
+        assert resolver._parse_source_key(f"e_wallet:{aid}") == (
+            "e_wallet",
+            aid,
+            None,
+        )
+
+    def test_credit_card(self):
+        cid = uuid.uuid4()
+        assert resolver._parse_source_key(f"credit_card:{cid}") == (
+            "credit_card",
+            None,
+            cid,
+        )
+
+    @pytest.mark.parametrize(
+        "key", [None, "", "garbage", "bank_account:notauuid", "unknown:abc"]
+    )
+    def test_invalid(self, key):
+        assert resolver._parse_source_key(key) == (None, None, None)
+
+
+# -------------------- apply_default_source --------------------
+
+
+@pytest.mark.asyncio
+class TestApplyDefaultSource:
+    async def test_noop_for_money_in(self):
+        data = _base_expense_payload().model_copy(
+            update={"transaction_type": "money_in"}
+        )
+        db = _db_with_profile(
+            UserProfile(user_id=_mk_user_id(), default_expense_source="cash")
+        )
+        result = await resolver.apply_default_source(db, _mk_user_id(), data)
+        assert result is data  # untouched
+
+    async def test_noop_when_source_already_set(self):
+        data = _base_expense_payload().model_copy(update={"source_type": "cash"})
+        db = _db_with_profile(
+            UserProfile(
+                user_id=_mk_user_id(),
+                default_expense_source=f"bank_account:{uuid.uuid4()}",
+            )
+        )
+        result = await resolver.apply_default_source(db, _mk_user_id(), data)
+        assert result is data
+
+    async def test_noop_when_no_profile(self):
+        data = _base_expense_payload()
+        db = _db_with_profile(None)
+        result = await resolver.apply_default_source(db, _mk_user_id(), data)
+        assert result is data
+
+    async def test_noop_when_profile_has_no_default(self):
+        data = _base_expense_payload()
+        db = _db_with_profile(
+            UserProfile(user_id=_mk_user_id(), default_expense_source=None)
+        )
+        result = await resolver.apply_default_source(db, _mk_user_id(), data)
+        assert result is data
+
+    async def test_applies_cash(self):
+        data = _base_expense_payload()
+        db = _db_with_profile(
+            UserProfile(user_id=_mk_user_id(), default_expense_source="cash")
+        )
+        result = await resolver.apply_default_source(db, _mk_user_id(), data)
+        assert result.source_type == "cash"
+        assert result.source_asset_id is None
+        assert result.source_credit_card_id is None
+
+    async def test_applies_credit_card(self):
+        card_id = uuid.uuid4()
+        data = _base_expense_payload()
+        db = _db_with_profile(
+            UserProfile(
+                user_id=_mk_user_id(),
+                default_expense_source=f"credit_card:{card_id}",
+            )
+        )
+        result = await resolver.apply_default_source(db, _mk_user_id(), data)
+        assert result.source_type == "credit_card"
+        assert result.source_credit_card_id == card_id
+        assert result.source_asset_id is None
+
+    async def test_applies_bank_account(self):
+        asset_id = uuid.uuid4()
+        data = _base_expense_payload()
+        db = _db_with_profile(
+            UserProfile(
+                user_id=_mk_user_id(),
+                default_expense_source=f"bank_account:{asset_id}",
+            )
+        )
+        result = await resolver.apply_default_source(db, _mk_user_id(), data)
+        assert result.source_type == "bank_account"
+        assert result.source_asset_id == asset_id
+
+
+# -------------------- resolve_source_label_for_expense --------------------
+
+
+def _expense(
+    *,
+    user_id: uuid.UUID,
+    source_type: str | None = None,
+    source_asset_id: uuid.UUID | None = None,
+    source_credit_card_id: uuid.UUID | None = None,
+    transaction_type: str = "expense",
+) -> Expense:
+    e = Expense(
+        user_id=user_id,
+        amount=Decimal("100000"),
+        category="food",
+        merchant="x",
+        source="manual",
+        expense_date=date.today(),
+    )
+    e.source_type = source_type
+    e.source_asset_id = source_asset_id
+    e.source_credit_card_id = source_credit_card_id
+    e.transaction_type = transaction_type
+    return e
+
+
+@pytest.mark.asyncio
+class TestResolveSourceLabel:
+    async def test_money_in_returns_none(self):
+        uid = _mk_user_id()
+        exp = _expense(user_id=uid, source_type="cash", transaction_type="money_in")
+        db = MagicMock()
+        assert await resolver.resolve_source_label_for_expense(db, exp) is None
+
+    async def test_no_source_type(self):
+        exp = _expense(user_id=_mk_user_id())
+        db = MagicMock()
+        assert await resolver.resolve_source_label_for_expense(db, exp) is None
+
+    async def test_cash_label(self):
+        exp = _expense(user_id=_mk_user_id(), source_type="cash")
+        db = MagicMock()
+        db.get = AsyncMock(return_value=None)
+        assert (
+            await resolver.resolve_source_label_for_expense(db, exp) == "Tiền mặt"
+        )
+
+    async def test_credit_card_with_bank_suffix(self):
+        uid = _mk_user_id()
+        card_id = uuid.uuid4()
+        card = CreditCard(
+            user_id=uid,
+            bank_name="Vietcombank",
+            credit_limit=Decimal("50000000"),
+            closing_date=15,
+        )
+        card.id = card_id
+        exp = _expense(
+            user_id=uid, source_type="credit_card", source_credit_card_id=card_id
+        )
+        db = MagicMock()
+        db.get = AsyncMock(return_value=card)
+        label = await resolver.resolve_source_label_for_expense(db, exp)
+        assert label == "Thẻ tín dụng [Vietcombank]"
+
+    async def test_bank_account_with_name_suffix(self):
+        uid = _mk_user_id()
+        aid = uuid.uuid4()
+        asset = Asset(
+            user_id=uid,
+            asset_type="cash",
+            name="VCB Premier",
+            current_value=Decimal("10000000"),
+        )
+        asset.id = aid
+        exp = _expense(
+            user_id=uid, source_type="bank_account", source_asset_id=aid
+        )
+        db = MagicMock()
+        db.get = AsyncMock(return_value=asset)
+        label = await resolver.resolve_source_label_for_expense(db, exp)
+        assert label == "Tài khoản thanh toán [VCB Premier]"
+
+    async def test_e_wallet_with_name_suffix(self):
+        uid = _mk_user_id()
+        aid = uuid.uuid4()
+        asset = Asset(
+            user_id=uid,
+            asset_type="cash",
+            name="Momo",
+            current_value=Decimal("500000"),
+        )
+        asset.id = aid
+        exp = _expense(user_id=uid, source_type="e_wallet", source_asset_id=aid)
+        db = MagicMock()
+        db.get = AsyncMock(return_value=asset)
+        label = await resolver.resolve_source_label_for_expense(db, exp)
+        assert label == "Ví điện tử [Momo]"
+
+    async def test_ignores_foreign_user_asset(self):
+        uid = _mk_user_id()
+        other = _mk_user_id()
+        aid = uuid.uuid4()
+        asset = Asset(
+            user_id=other,
+            asset_type="cash",
+            name="Stolen",
+            current_value=Decimal("0"),
+        )
+        asset.id = aid
+        exp = _expense(
+            user_id=uid, source_type="bank_account", source_asset_id=aid
+        )
+        db = MagicMock()
+        db.get = AsyncMock(return_value=asset)
+        label = await resolver.resolve_source_label_for_expense(db, exp)
+        assert label == "Tài khoản thanh toán"

--- a/backend/tests/test_intent/test_action_quick_transaction_handler.py
+++ b/backend/tests/test_intent/test_action_quick_transaction_handler.py
@@ -29,6 +29,7 @@ def _fake_db() -> MagicMock:
     db.flush = AsyncMock()
     db.commit = AsyncMock()
     db.execute = AsyncMock()
+    db.get = AsyncMock(return_value=None)
     db.add = MagicMock()
     return db
 

--- a/backend/tests/test_templates.py
+++ b/backend/tests/test_templates.py
@@ -18,7 +18,7 @@ class TestTransactionConfirmation:
             amount=45_000,
             category_code="food",
         )
-        assert "✅ Ghi xong!" in result
+        assert "✅ Đã ghi xong!" in result
         assert "Phở Bát Đàn" in result
         assert "45,000đ" in result
         assert "🍜" in result
@@ -68,6 +68,17 @@ class TestTransactionConfirmation:
         assert "Vượt ngân sách" in result
         assert "😅" in result
 
+    def test_source_label_and_edit_hint(self):
+        result = format_transaction_confirmation(
+            merchant="Sashimi cá hồi",
+            amount=4_000_000,
+            category_code="food",
+            source_label="Thẻ tín dụng [Vietcombank]",
+            show_edit_hint=True,
+        )
+        assert "Chi từ: Thẻ tín dụng [Vietcombank]" in result
+        assert "Quản lý chi tiêu" in result
+
     def test_unknown_category_falls_back_to_other(self):
         result = format_transaction_confirmation(
             merchant="?",
@@ -83,11 +94,20 @@ class TestTransactionBatchConfirmation:
             items=[("tiền xăng", 50_000, "transport"), ("ăn trưa", 50_000, "food")],
             time=datetime(2026, 5, 7, 19, 18),
         )
-        assert "✅ Ghi xong 2 khoản!" in result
+        assert "✅ Đã ghi xong 2 khoản!" in result
         assert "🚗 tiền xăng" in result
         assert "🍜 ăn trưa" in result
         assert "Tổng: 100,000đ" in result
         assert "19:18" in result
+
+    def test_batch_source_label_and_edit_hint(self):
+        result = format_transaction_batch_confirmation(
+            items=[("tiền xăng", 50_000, "transport"), ("ăn trưa", 50_000, "food")],
+            source_label="Tiền mặt",
+            show_edit_hint=True,
+        )
+        assert "Chi từ: Tiền mặt" in result
+        assert "Quản lý chi tiêu" in result
 
 
 class TestDailySummary:

--- a/content/transaction_copy.yaml
+++ b/content/transaction_copy.yaml
@@ -1,0 +1,14 @@
+confirmation:
+  title_done: "✅ Đã ghi xong!"
+  batch_title: "✅ Đã ghi xong {count} khoản!"
+  source_prefix: "💳 Chi từ: {source}"
+  edit_hint: >-
+    Nếu bạn cần sửa/xoá giao dịch này thì hãy vào mục Quản lý chi tiêu
+    trong menu Chi tiêu nhé.
+
+source_labels:
+  cash: "Tiền mặt"
+  bank_account: "Tài khoản thanh toán"
+  e_wallet: "Ví điện tử"
+  credit_card: "Thẻ tín dụng"
+  unknown: "Nguồn khác"


### PR DESCRIPTION
Close #891

## Summary
- Resolve `default_expense_source` từ profile và populate `ExpenseCreate.source_*` để pipeline `expense_service` hiện hữu tự trừ tiền (cash / bank / e-wallet) hoặc cộng dư nợ (credit card). Áp dụng cho cả manual ingestion, LLM fast-path và quick transaction (single + batch).
- Đổi copy confirmation: tiêu đề `✅ Đã ghi xong!`, thêm dòng `💳 Chi từ: <nguồn>` và ghi chú điều hướng vào *Quản lý chi tiêu*. Bỏ inline action keyboard cho expense (terminal); money-in giữ nguyên flow + keyboard cũ.
- Quick transaction khi không bắt được danh mục giờ fallback sang `other` (Khác) thay vì `needs_review`, vì luồng confirm là terminal — không còn cơ hội clarify.
- Tất cả VN strings mới nằm trong `content/transaction_copy.yaml` (tuân thủ rule không hardcode).

## Files
- `backend/services/expense_source_resolver.py` *(new)* — `_parse_source_key`, `apply_default_source`, `resolve_source_label_for_expense`.
- `backend/bot/formatters/templates.py` — copy + new `source_label` / `show_edit_hint` params.
- `backend/bot/handlers/transaction.py` — gắn source label, ẩn inline keyboard cho expense.
- `backend/bot/handlers/message.py`, `backend/intent/handlers/action_quick_transaction.py` — apply default source trước khi `create_expense`.
- `content/transaction_copy.yaml` *(new)* — title, source prefix, edit hint, source labels.

## Test plan
- [x] `pytest backend/tests/test_expense_source_resolver.py backend/tests/test_templates.py` — 42 passed
- [ ] CI: full suite + ruff
- [ ] Manual: ghi expense (cash / bank / credit card) → confirm có dòng *Chi từ* đúng + asset balance / debt cập nhật; money-in vẫn có action keyboard
