### PR TITLE
Refine asset edit picker UI and compact delete button (Closes #NNN)

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -422,6 +422,34 @@ async def show_asset_edit_picker(
     )
 
 
+async def show_asset_edit_picker_for_all_assets(
+    db: AsyncSession, chat_id: int, user: User
+) -> None:
+    """Show only the edit picker list (no report header/body)."""
+    assets = _sort_assets_for_dashboard(
+        await asset_service.get_user_assets(db, user.id),
+        _dashboard_sort_for_user(user),
+    )
+    rows = [
+        (asset.id, _asset_dashboard_row_label(asset))
+        for asset in assets
+        if asset.is_active
+    ]
+    if not rows:
+        await send_message(
+            chat_id=chat_id,
+            text="Bạn chưa có tài sản nào. Tap /themtaisan để bắt đầu nhé.",
+        )
+        return
+
+    await send_message(
+        chat_id=chat_id,
+        text="✏️ Chọn dòng cụ thể để sửa nhé:",
+        parse_mode="HTML",
+        reply_markup=asset_dashboard_edit_keyboard(rows),
+    )
+
+
 async def start_asset_edit_wizard(
     db: AsyncSession,
     chat_id: int,

--- a/backend/bot/keyboards/asset_keyboard.py
+++ b/backend/bot/keyboards/asset_keyboard.py
@@ -932,7 +932,7 @@ def asset_dashboard_edit_keyboard(
                     "callback_data": build_callback(CB_ASSET_ROW, "edit", asset_id),
                 },
                 {
-                    "text": "🗑️",
+                    "text": "🗑",
                     "callback_data": build_callback(CB_ASSET_ROW, "delete", asset_id),
                 },
             ]

--- a/backend/intent/handlers/action_edit_asset.py
+++ b/backend/intent/handlers/action_edit_asset.py
@@ -199,12 +199,14 @@ class ActionEditAssetHandler(IntentHandler):
             await send_message(
                 chat_id=chat_id,
                 text=(
-                    "Mình không tìm thấy tài sản loại này 🌱 — đây là toàn bộ "
-                    "danh mục, bạn chọn dòng cần sửa nhé."
+                    "Mình không tìm thấy tài sản loại này 🌱 — "
+                    "mình mở danh sách để bạn chọn dòng cần sửa nhé."
                 ),
             )
 
-        await asset_entry_handlers.show_asset_dashboard_report(db, chat_id, user)
+        await asset_entry_handlers.show_asset_edit_picker_for_all_assets(
+            db, chat_id, user
+        )
         return ""
 
     async def _apply_inline_edit(

--- a/backend/tests/test_asset_entry_handler.py
+++ b/backend/tests/test_asset_entry_handler.py
@@ -2423,6 +2423,35 @@ async def test_grouped_dashboard_picker_uses_one_user_scoped_asset_query():
 
 
 @pytest.mark.asyncio
+async def test_show_asset_edit_picker_for_all_assets_renders_only_picker_list():
+    user = _user()
+    db = _db(user)
+    first = _asset(value=10_000_000)
+    second = _asset(value=20_000_000)
+    first.user_id = second.user_id = user.id
+
+    with (
+        patch.object(
+            asset_entry.asset_service,
+            "get_user_assets",
+            AsyncMock(return_value=[first, second]),
+        ) as get_assets,
+        patch.object(asset_entry, "send_message", AsyncMock()) as send,
+    ):
+        await asset_entry.show_asset_edit_picker_for_all_assets(db, 100, user)
+
+    get_assets.assert_awaited_once_with(db, user.id)
+    assert "Báo cáo" not in send.await_args.kwargs["text"]
+    callbacks = [
+        button["callback_data"]
+        for row in send.await_args.kwargs["reply_markup"]["inline_keyboard"]
+        for button in row
+    ]
+    assert f"asset:edit:{first.id}" in callbacks
+    assert f"asset:edit:{second.id}" in callbacks
+
+
+@pytest.mark.asyncio
 async def test_show_asset_delete_matches_list_builds_manage_callbacks():
     first = _asset()
     second = _asset()

--- a/backend/tests/test_asset_keyboard_pagination.py
+++ b/backend/tests/test_asset_keyboard_pagination.py
@@ -109,6 +109,11 @@ class TestDashboardKeyboardSize:
             cbs = [b["callback_data"] for b in first_row]
             assert all(cb.startswith("asset:sort:") for cb in cbs)
 
+    def test_delete_button_uses_compact_icon_for_more_edit_label_space(self):
+        kb = asset_dashboard_edit_keyboard(_rows(1))
+        delete_btn = kb["inline_keyboard"][1][1]
+        assert delete_btn["text"] == "🗑"
+
     def test_returns_none_for_empty(self):
         assert asset_dashboard_edit_keyboard([]) is None
 


### PR DESCRIPTION
### Motivation
- Make the generic `sửa tài sản` edit flow consistent with type-specific flows by removing the redundant full asset report and showing only the actionable picker list. 
- Reduce visual clutter and allow longer asset label text by shrinking the delete button, while keeping performance, consistency and ownership safety intact.

### Description
- Replace the dashboard-report fallback in the edit handler with a new picker-only flow by calling `show_asset_edit_picker_for_all_assets(...)` from `ActionEditAssetHandler`.
- Add `show_asset_edit_picker_for_all_assets` in `backend/bot/handlers/asset_entry.py` to render only the picker prompt + inline edit rows for the user’s active assets. 
- Compact the dashboard delete button in `asset_dashboard_edit_keyboard` from `"🗑️"` to `"🗑"` to free horizontal space for asset labels. 
- Add unit tests verifying the new picker-only rendering and the compact delete icon to lock in the UI/UX changes.

### Testing
- Ran `pytest -q backend/tests/test_asset_keyboard_pagination.py backend/tests/test_asset_entry_handler.py -q` and the suite completed successfully. 
- New tests `test_show_asset_edit_picker_for_all_assets_renders_only_picker_list` and `test_delete_button_uses_compact_icon_for_more_edit_label_space` were added and passed. 
- Close #NNN

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a18177c4cc0832fa29eaebd9a6f369d)