### PR TITLE
feat(quick-tx): apply default source on signed expense + italic edit hint

### DIFF
--- a/backend/bot/formatters/templates.py
+++ b/backend/bot/formatters/templates.py
@@ -5,6 +5,7 @@ Nguyên tắc: Một function = một loại tin nhắn.
 
 from datetime import date, datetime
 from functools import lru_cache
+from html import escape as _html_escape
 from pathlib import Path
 from typing import Any
 
@@ -57,11 +58,13 @@ def format_transaction_confirmation(
 
     title = _confirmation_copy("title_done", "✅ Đã ghi xong!")
     lines: list[str] = [title, ""]
-    lines.append(f"{cat.emoji} {merchant}  —  {format_money_full(amount)}")
+    lines.append(
+        f"{cat.emoji} {_html_escape(merchant)}  —  {format_money_full(amount)}"
+    )
 
     context_parts: list[str] = []
     if location:
-        context_parts.append(f"📍 {location}")
+        context_parts.append(f"📍 {_html_escape(location)}")
     if time:
         context_parts.append(time.strftime("%H:%M"))
     if context_parts:
@@ -71,7 +74,7 @@ def format_transaction_confirmation(
         source_template = _confirmation_copy(
             "source_prefix", "💳 Chi từ: {source}"
         )
-        lines.append(source_template.format(source=source_label))
+        lines.append(source_template.format(source=_html_escape(source_label)))
 
     if daily_spent is not None and daily_budget is not None and daily_budget > 0:
         lines.append("")
@@ -174,7 +177,9 @@ def format_transaction_batch_confirmation(
 
     for merchant, amount, category_code in items:
         cat = get_category(category_code)
-        lines.append(f"{cat.emoji} {merchant}  —  {format_money_full(amount)}")
+        lines.append(
+            f"{cat.emoji} {_html_escape(merchant)}  —  {format_money_full(amount)}"
+        )
 
     lines.append("")
     lines.append(f"Tổng: {format_money_full(total)}")
@@ -185,7 +190,7 @@ def format_transaction_batch_confirmation(
         source_template = _confirmation_copy(
             "source_prefix", "💳 Chi từ: {source}"
         )
-        lines.append(source_template.format(source=source_label))
+        lines.append(source_template.format(source=_html_escape(source_label)))
 
     if show_edit_hint:
         hint = _confirmation_copy("edit_hint")

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -183,6 +183,33 @@ async def _start_source_prompt(
     return True
 
 
+async def _record_signed_expense_with_default(
+    db: AsyncSession, user, parsed: dict
+) -> bool:
+    """Record an expense from the signed/amount-led fast-path using the
+    user's ``default_expense_source``.
+
+    Returns True when the expense was created and the confirmation card
+    was sent — caller then skips the wizard. Returns False when the user
+    has no default source configured (caller falls back to the picker).
+    """
+    merchant = (parsed.get("merchant") or parsed.get("note") or "Giao dịch").strip()
+    expense_data = ExpenseCreate(
+        amount=float(parsed["amount"]),
+        merchant=merchant or "Giao dịch",
+        note=parsed.get("note"),
+        source="manual",
+        category="other",
+        expense_date=date.today(),
+    )
+    resolved = await apply_default_source(db, user.id, expense_data)
+    if not resolved.source_type:
+        return False
+    expense = await expense_service.create_expense(db, user.id, resolved)
+    await send_transaction_confirmation(db, expense)
+    return True
+
+
 # Outcome kinds that mean "the user got their answer / a follow-up
 # prompt — do NOT fall through to the LLM transaction parser".
 _TERMINAL_OUTCOMES = frozenset(
@@ -236,6 +263,9 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
     # Fast-path for explicit +/- expense syntax before generic intent routing.
     signed = _parse_signed_transaction(text)
     if signed is not None:
+        if signed["transaction_type"] == "expense":
+            if await _record_signed_expense_with_default(db, user, signed):
+                return True
         return await _start_source_prompt(db, chat_id, user, signed)
 
     # Phase 3.5 — full intent flow with confirm/clarify state handling.

--- a/backend/bot/handlers/transaction.py
+++ b/backend/bot/handlers/transaction.py
@@ -76,7 +76,7 @@ async def send_transaction_confirmation(
     await send_message(
         chat_id=user.telegram_id,
         text=text,
-        parse_mode=None,
+        parse_mode="HTML",
         reply_markup=reply_markup,
         **message_kwargs_for_animation(text, "transaction"),
     )
@@ -144,7 +144,7 @@ async def send_transaction_batch_confirmation(
     await send_message(
         chat_id=user.telegram_id,
         text=text,
-        parse_mode=None,
+        parse_mode="HTML",
         reply_markup=reply_markup,
         **message_kwargs_for_animation(text, "transaction"),
     )

--- a/backend/tests/test_signed_transaction_fast_path.py
+++ b/backend/tests/test_signed_transaction_fast_path.py
@@ -1,0 +1,153 @@
+"""Fast-path tests for the signed / amount-led transaction entry.
+
+Regression for the follow-up to PR #892: when the user has configured a
+``default_expense_source``, the ``+/-`` or amount-led typed text MUST
+skip the source-picker wizard and create the expense directly (mirroring
+the LLM-fallback path). When no default is configured, the wizard
+remains as a graceful fallback.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.bot.handlers import message as message_handler
+
+
+def _fake_user():
+    user = MagicMock()
+    user.id = "user-1"
+    user.telegram_id = 555
+    return user
+
+
+def _fake_db():
+    db = MagicMock()
+    db.flush = AsyncMock()
+    db.commit = AsyncMock()
+    db.execute = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+    db.add = MagicMock()
+    return db
+
+
+@pytest.mark.asyncio
+async def test_amount_led_expense_uses_default_source_when_set():
+    """``45k phở`` with a default source must NOT pop the wizard — it
+    should create the expense and send the confirmation card directly.
+    """
+    db = _fake_db()
+    user = _fake_user()
+    message = {"chat": {"id": 555}, "from": {"id": 555}, "text": "45k phở"}
+
+    fake_expense = MagicMock(user_id="user-1")
+
+    async def fake_apply_default_source(_db, _uid, data):
+        return data.model_copy(update={"source_type": "cash"})
+
+    with patch(
+        "backend.bot.handlers.message.get_user_by_telegram_id",
+        AsyncMock(return_value=user),
+    ), patch(
+        "backend.bot.handlers.message.report_service.is_report_query",
+        return_value=False,
+    ), patch(
+        "backend.bot.handlers.message.apply_default_source",
+        side_effect=fake_apply_default_source,
+    ), patch(
+        "backend.bot.handlers.message.expense_service.create_expense",
+        AsyncMock(return_value=fake_expense),
+    ) as mock_create, patch(
+        "backend.bot.handlers.message.send_transaction_confirmation",
+        AsyncMock(),
+    ) as mock_confirm, patch(
+        "backend.bot.handlers.message._start_source_prompt",
+        AsyncMock(return_value=True),
+    ) as mock_wizard:
+        ok = await message_handler.handle_text_message(db, message)
+
+    assert ok is True
+    mock_create.assert_awaited_once()
+    mock_confirm.assert_awaited_once()
+    mock_wizard.assert_not_called()
+    expense_data = mock_create.call_args.args[2]
+    assert expense_data.amount == 45_000.0
+    assert expense_data.category == "other"
+    assert expense_data.source_type == "cash"
+
+
+@pytest.mark.asyncio
+async def test_amount_led_expense_falls_back_to_wizard_when_no_default():
+    """Without a configured default source, the wizard must still run."""
+    db = _fake_db()
+    user = _fake_user()
+    message = {"chat": {"id": 555}, "from": {"id": 555}, "text": "45k phở"}
+
+    async def fake_apply_default_source(_db, _uid, data):
+        return data  # unchanged → no default configured
+
+    with patch(
+        "backend.bot.handlers.message.get_user_by_telegram_id",
+        AsyncMock(return_value=user),
+    ), patch(
+        "backend.bot.handlers.message.report_service.is_report_query",
+        return_value=False,
+    ), patch(
+        "backend.bot.handlers.message.apply_default_source",
+        side_effect=fake_apply_default_source,
+    ), patch(
+        "backend.bot.handlers.message.expense_service.create_expense",
+        AsyncMock(),
+    ) as mock_create, patch(
+        "backend.bot.handlers.message.send_transaction_confirmation",
+        AsyncMock(),
+    ) as mock_confirm, patch(
+        "backend.bot.handlers.message._start_source_prompt",
+        AsyncMock(return_value=True),
+    ) as mock_wizard:
+        ok = await message_handler.handle_text_message(db, message)
+
+    assert ok is True
+    mock_create.assert_not_called()
+    mock_confirm.assert_not_called()
+    mock_wizard.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_money_in_always_uses_wizard():
+    """Money-in (+) keeps the existing source-picker wizard regardless
+    of the ``default_expense_source`` setting (only expense flows changed).
+    """
+    db = _fake_db()
+    user = _fake_user()
+    message = {"chat": {"id": 555}, "from": {"id": 555}, "text": "+5tr lương"}
+
+    async def fake_apply_default_source(_db, _uid, data):
+        return data.model_copy(update={"source_type": "cash"})
+
+    with patch(
+        "backend.bot.handlers.message.get_user_by_telegram_id",
+        AsyncMock(return_value=user),
+    ), patch(
+        "backend.bot.handlers.message.report_service.is_report_query",
+        return_value=False,
+    ), patch(
+        "backend.bot.handlers.message.apply_default_source",
+        side_effect=fake_apply_default_source,
+    ), patch(
+        "backend.bot.handlers.message.expense_service.create_expense",
+        AsyncMock(),
+    ) as mock_create, patch(
+        "backend.bot.handlers.message.send_transaction_confirmation",
+        AsyncMock(),
+    ), patch(
+        "backend.bot.handlers.message._start_source_prompt",
+        AsyncMock(return_value=True),
+    ) as mock_wizard:
+        ok = await message_handler.handle_text_message(db, message)
+
+    assert ok is True
+    mock_create.assert_not_called()
+    mock_wizard.assert_awaited_once()

--- a/backend/tests/test_templates.py
+++ b/backend/tests/test_templates.py
@@ -78,6 +78,8 @@ class TestTransactionConfirmation:
         )
         assert "Chi từ: Thẻ tín dụng [Vietcombank]" in result
         assert "Quản lý chi tiêu" in result
+        assert "<i>" in result and "</i>" in result
+        assert "💡" in result
 
     def test_unknown_category_falls_back_to_other(self):
         result = format_transaction_confirmation(
@@ -108,6 +110,8 @@ class TestTransactionBatchConfirmation:
         )
         assert "Chi từ: Tiền mặt" in result
         assert "Quản lý chi tiêu" in result
+        assert "<i>" in result and "</i>" in result
+        assert "💡" in result
 
 
 class TestDailySummary:

--- a/content/transaction_copy.yaml
+++ b/content/transaction_copy.yaml
@@ -2,9 +2,7 @@ confirmation:
   title_done: "✅ Đã ghi xong!"
   batch_title: "✅ Đã ghi xong {count} khoản!"
   source_prefix: "💳 Chi từ: {source}"
-  edit_hint: >-
-    Nếu bạn cần sửa/xoá giao dịch này thì hãy vào mục Quản lý chi tiêu
-    trong menu Chi tiêu nhé.
+  edit_hint: "<i>💡 Cần sửa/xoá? Vào mục Quản lý chi tiêu trong menu Chi tiêu nhé.</i>"
 
 source_labels:
   cash: "Tiền mặt"


### PR DESCRIPTION
## Summary

Follow-up to #891 / PR #892. Two corrections requested by the user:

1. **Quick transaction (signed / amount-led) expense path now uses `default_expense_source`.**
   Previously only the LLM-fallback path was wired to `apply_default_source`; typed inputs like `45k phở` or `-45k phở` still popped the source-picker wizard. They now resolve the default source, create the expense directly, and send the same rich confirmation card as the LLM/manual flow. The wizard remains as a graceful fallback when no default is configured. Money-in (`+5tr lương`) is unchanged.
   - Default category is `"other"` when none detected.

2. **Edit-hint reformatted: italic + 💡 icon.**
   - `content/transaction_copy.yaml` `edit_hint` switched to `<i>💡 …</i>`.
   - `send_transaction_confirmation` / `send_transaction_batch_confirmation` now use `parse_mode="HTML"`.
   - User-supplied strings (`merchant`, `location`, `source_label`, batch item merchants) HTML-escaped to prevent injection / parse errors.

## Test plan

- [x] `backend/tests/test_signed_transaction_fast_path.py` (new):
  - expense + default source → no wizard, expense created, confirmation sent, category `"other"`, source applied
  - expense + no default → wizard fallback, no expense created
  - money-in → always uses wizard
- [x] `backend/tests/test_templates.py` updated to assert `<i>…</i>` + 💡 in both single and batch edit-hint paths
- [x] `pytest backend/tests/test_signed_transaction_fast_path.py backend/tests/test_templates.py backend/tests/test_signed_transaction_parser.py backend/tests/test_intent/test_action_quick_transaction_handler.py` — 56 passed

Closes #891
