### PR TITLE
feat(tx-confirm): icon action row + ✅ Đồng ý + VN time

### DIFF
--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -21,6 +21,7 @@ import logging
 import uuid
 from datetime import datetime, timezone
 from typing import Any
+from zoneinfo import ZoneInfo
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -39,14 +40,17 @@ from backend.bot.keyboards.transaction_keyboard import (
     credit_card_source_keyboard,
     e_wallet_provider_keyboard,
     source_asset_keyboard,
+    source_picker_keyboard,
     transaction_actions_keyboard,
+    transaction_actions_with_done_keyboard,
     transaction_source_keyboard,
 )
 from backend.config.categories import get_all_categories
 from backend.models.expense import Expense
-from backend.schemas.expense import ExpenseCreate
-from backend.services import expense_service
+from backend.schemas.expense import ExpenseCreate, ExpenseUpdate
+from backend.services import expense_service, wizard_service
 from backend.services.credit_card_service import list_credit_cards
+from backend.services.expense_source_resolver import resolve_source_label_for_expense
 from backend.services.portfolio_service import list_assets
 from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.telegram_service import (
@@ -55,6 +59,8 @@ from backend.services.telegram_service import (
     edit_message_text,
     send_message,
 )
+
+_VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
 
 logger = logging.getLogger(__name__)
 
@@ -223,23 +229,49 @@ async def _handle_source_selection_callback(
     return True
 
 
+def _to_vn_time(dt: datetime | None) -> datetime | None:
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_VN_TZ)
+
+
 async def _rerender_transaction_message(
     chat_id: int,
     message_id: int,
     expense: Expense,
+    *,
+    edited: bool = False,
+    db: AsyncSession | None = None,
 ) -> None:
+    is_expense = expense.transaction_type == "expense"
+    source_label = None
+    if is_expense and db is not None:
+        try:
+            source_label = await resolve_source_label_for_expense(db, expense)
+        except Exception:
+            logger.exception("resolve_source_label_for_expense failed")
+            source_label = None
     text = format_transaction_confirmation(
         merchant=expense.merchant or expense.note or "Giao dịch",
         amount=float(expense.amount),
         category_code=_normalize_category(expense.category),
-        time=expense.created_at,
+        time=_to_vn_time(expense.created_at),
+        source_label=source_label,
+        show_edit_hint=is_expense,
+    )
+    reply_markup = (
+        transaction_actions_with_done_keyboard(str(expense.id))
+        if edited
+        else transaction_actions_keyboard(str(expense.id))
     )
     await edit_message_text(
         chat_id=chat_id,
         message_id=message_id,
         text=text,
         parse_mode="HTML",
-        reply_markup=transaction_actions_keyboard(str(expense.id)),
+        reply_markup=reply_markup,
     )
 
 
@@ -289,10 +321,20 @@ async def handle_transaction_callback(
         await answer_callback(callback_query["id"])
         return True
 
+    if (
+        data.startswith("chsrc_bk:")
+        or data.startswith("chsrc_wl:")
+        or data.startswith("chsrc_cc:")
+    ):
+        return await _handle_change_source_subpicker(db, callback_query)
+
     prefix, args = parse_callback(data)
 
     handlers = {
         CallbackPrefix.CHANGE_CATEGORY: _handle_change_category,
+        CallbackPrefix.CHANGE_SOURCE: _handle_change_source,
+        CallbackPrefix.EDIT_AMOUNT: _handle_edit_amount,
+        CallbackPrefix.CONFIRM_EDIT_DONE: _handle_done_edit,
         CallbackPrefix.DELETE_TRANSACTION: _handle_delete_transaction,
         CallbackPrefix.CONFIRM_ACTION: _handle_confirm_action,
         CallbackPrefix.CANCEL_ACTION: _handle_cancel_action,
@@ -386,7 +428,9 @@ async def _handle_change_category(*, db, user, args, callback_id, chat_id, messa
     await db.flush()
     await db.refresh(expense)
 
-    await _rerender_transaction_message(chat_id, message_id, expense)
+    await _rerender_transaction_message(
+        chat_id, message_id, expense, edited=True, db=db
+    )
     await answer_callback(callback_id, text="Đổi danh mục xong 👌")
     analytics.track(
         analytics.EventType.CATEGORY_CHANGED,
@@ -641,6 +685,305 @@ async def _handle_edit_transaction(*, db, user, args, callback_id, chat_id, mess
         text="Sửa số tiền sẽ có trong bản cập nhật sắp tới — tạm thời dùng 'Đổi danh mục' hoặc 'Xóa' nhé",
         show_alert=True,
     )
+
+
+# --------- Issue #897: change source / edit amount / done-edit ---------
+
+
+_SOURCE_TYPE_BY_SHORT = {
+    "cash": "cash",
+    "bank": "bank_account",
+    "wallet": "e_wallet",
+    "card": "credit_card",
+}
+
+
+async def _handle_change_source(*, db, user, args, callback_id, chat_id, message_id):
+    """2-step source edit (mirror change_category).
+
+    args[0] = expense_id (always)
+    args[1] (optional) = "cash" | "bank" | "wallet" | "card"
+        - "cash" applies immediately.
+        - others swap the keyboard to the relevant sub-picker.
+    """
+    if not args:
+        await answer_callback(
+            callback_id,
+            text="Hmm, thiếu thông tin giao dịch — thử tap lại giúp mình?",
+            show_alert=True,
+        )
+        return
+
+    expense = await resolve_transaction_by_callback_id(db, user.id, args[0])
+    if not expense:
+        await answer_callback(
+            callback_id, text="Giao dịch này mình không thấy nữa 🫣", show_alert=True
+        )
+        return
+
+    if len(args) == 1:
+        await wizard_service.start_flow(
+            db,
+            user.id,
+            flow="transaction_source_edit",
+            step="pick_kind",
+            draft={
+                "expense_id": str(expense.id),
+                "chat_id": chat_id,
+                "message_id": message_id,
+            },
+        )
+        await edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=source_picker_keyboard(str(expense.id)),
+        )
+        await answer_callback(callback_id)
+        return
+
+    kind = str(args[1]).strip().lower()
+    if kind == "cash":
+        updated = await expense_service.update_expense(
+            db,
+            user.id,
+            expense.id,
+            ExpenseUpdate(
+                source_type="cash",
+                source_asset_id=None,
+                source_credit_card_id=None,
+                e_wallet_provider=None,
+            ),
+        )
+        await wizard_service.clear(db, user.id)
+        if updated is None:
+            await answer_callback(
+                callback_id, text="Không cập nhật được — thử lại nhé.", show_alert=True
+            )
+            return
+        await _rerender_transaction_message(
+            chat_id, message_id, updated, edited=True, db=db
+        )
+        await answer_callback(callback_id, text="Đổi nguồn tiền xong 👌")
+        return
+
+    if kind == "bank":
+        assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
+        bank_assets = [
+            a for a in assets if (a.subtype or "").lower() in ("bank_checking", "bank_account")
+        ]
+        if not bank_assets:
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có tài khoản thanh toán nào 🌱",
+                show_alert=True,
+            )
+            return
+        rows: list[list[dict]] = [
+            [
+                {
+                    "text": f"🏦 Thẻ thanh toán - {a.name}",
+                    "callback_data": f"chsrc_bk:{a.id}",
+                }
+            ]
+            for a in bank_assets
+        ]
+        rows.append(
+            [
+                {
+                    "text": "↩️ Quay lại",
+                    "callback_data": f"{CallbackPrefix.CHANGE_SOURCE}:{expense.id}",
+                }
+            ]
+        )
+        await edit_message_reply_markup(
+            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+        )
+        await answer_callback(callback_id)
+        return
+
+    if kind == "wallet":
+        rows = [
+            [
+                {"text": "Momo", "callback_data": "chsrc_wl:momo"},
+                {"text": "VNPay", "callback_data": "chsrc_wl:vnpay"},
+            ],
+            [
+                {"text": "ZaloPay", "callback_data": "chsrc_wl:zalopay"},
+                {"text": "ViettelPay", "callback_data": "chsrc_wl:viettelpay"},
+            ],
+            [
+                {
+                    "text": "↩️ Quay lại",
+                    "callback_data": f"{CallbackPrefix.CHANGE_SOURCE}:{expense.id}",
+                }
+            ],
+        ]
+        await edit_message_reply_markup(
+            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+        )
+        await answer_callback(callback_id)
+        return
+
+    if kind == "card":
+        cards = await list_credit_cards(db, user.id)
+        if not cards:
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có thẻ tín dụng nào 🌱",
+                show_alert=True,
+            )
+            return
+        rows = [
+            [
+                {
+                    "text": f"💳 {c.bank_name}",
+                    "callback_data": f"chsrc_cc:{c.id}",
+                }
+            ]
+            for c in cards
+        ]
+        rows.append(
+            [
+                {
+                    "text": "↩️ Quay lại",
+                    "callback_data": f"{CallbackPrefix.CHANGE_SOURCE}:{expense.id}",
+                }
+            ]
+        )
+        await edit_message_reply_markup(
+            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+        )
+        await answer_callback(callback_id)
+        return
+
+    await answer_callback(callback_id)
+
+
+async def _handle_change_source_subpicker(
+    db: AsyncSession, callback_query: dict[str, Any]
+) -> bool:
+    """Apply a source pick coming from a sub-picker (bank/wallet/card)."""
+    callback_id = callback_query["id"]
+    data = callback_query.get("data", "")
+    from_user = callback_query.get("from") or {}
+    telegram_id = from_user.get("id")
+    message = callback_query.get("message") or {}
+    chat_id = message.get("chat", {}).get("id")
+    message_id = message.get("message_id")
+
+    user = await get_user_by_telegram_id(db, telegram_id) if telegram_id else None
+    if not user:
+        await answer_callback(
+            callback_id, text="Bạn gửi /start trước nhé 🌱", show_alert=True
+        )
+        return True
+
+    state = user.wizard_state or {}
+    if state.get("flow") != "transaction_source_edit":
+        await answer_callback(
+            callback_id, text="Yêu cầu này đã hết hạn rồi 🌱", show_alert=True
+        )
+        return True
+    draft = dict(state.get("draft") or {})
+    expense_id_str = draft.get("expense_id")
+    if not expense_id_str:
+        await answer_callback(callback_id, text="Yêu cầu này đã hết hạn rồi 🌱", show_alert=True)
+        return True
+
+    expense = await resolve_transaction_by_callback_id(db, user.id, expense_id_str)
+    if not expense:
+        await wizard_service.clear(db, user.id)
+        await answer_callback(
+            callback_id, text="Giao dịch này mình không thấy nữa 🫣", show_alert=True
+        )
+        return True
+
+    update: ExpenseUpdate
+    if data.startswith("chsrc_bk:"):
+        asset_id = data.split(":", 1)[1]
+        update = ExpenseUpdate(
+            source_type="bank_account",
+            source_asset_id=asset_id,
+            source_credit_card_id=None,
+            e_wallet_provider=None,
+        )
+    elif data.startswith("chsrc_wl:"):
+        provider = data.split(":", 1)[1]
+        update = ExpenseUpdate(
+            source_type="e_wallet",
+            e_wallet_provider=provider,
+            source_asset_id=None,
+            source_credit_card_id=None,
+        )
+    elif data.startswith("chsrc_cc:"):
+        card_id = data.split(":", 1)[1]
+        update = ExpenseUpdate(
+            source_type="credit_card",
+            source_credit_card_id=card_id,
+            source_asset_id=None,
+            e_wallet_provider=None,
+        )
+    else:
+        await answer_callback(callback_id)
+        return True
+
+    updated = await expense_service.update_expense(db, user.id, expense.id, update)
+    await wizard_service.clear(db, user.id)
+    if updated is None:
+        await answer_callback(
+            callback_id, text="Không cập nhật được — thử lại nhé.", show_alert=True
+        )
+        return True
+    await _rerender_transaction_message(
+        chat_id, message_id, updated, edited=True, db=db
+    )
+    await answer_callback(callback_id, text="Đổi nguồn tiền xong 👌")
+    return True
+
+
+async def _handle_edit_amount(*, db, user, args, callback_id, chat_id, message_id):
+    """Prompt user via force_reply, set wizard to capture next text message."""
+    if not args:
+        await answer_callback(
+            callback_id,
+            text="Hmm, thiếu thông tin giao dịch — thử tap lại giúp mình?",
+            show_alert=True,
+        )
+        return
+
+    expense = await resolve_transaction_by_callback_id(db, user.id, args[0])
+    if not expense:
+        await answer_callback(
+            callback_id, text="Giao dịch này mình không thấy nữa 🫣", show_alert=True
+        )
+        return
+
+    await wizard_service.start_flow(
+        db,
+        user.id,
+        flow="transaction_amount_edit",
+        step="await_amount",
+        draft={
+            "expense_id": str(expense.id),
+            "chat_id": chat_id,
+            "message_id": message_id,
+        },
+    )
+    await send_message(
+        chat_id=chat_id,
+        text="Số tiền mới là bao nhiêu? (ví dụ: 45k, 1.2tr)",
+        parse_mode=None,
+        reply_markup={"force_reply": True, "selective": True},
+    )
+    await answer_callback(callback_id)
+
+
+async def _handle_done_edit(*, db, user, args, callback_id, chat_id, message_id):
+    """User taps ✅ Đồng ý — strip the keyboard, keep the message text."""
+    await edit_message_reply_markup(
+        chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": []}
+    )
+    await answer_callback(callback_id, text="Đã lưu ✅")
 
 
 __all__ = [

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -35,7 +35,7 @@ from backend.intent.dispatcher import (
     OUTCOME_UNCLEAR,
 )
 from backend.intent.intents import IntentType
-from backend.schemas.expense import ExpenseCreate
+from backend.schemas.expense import ExpenseCreate, ExpenseUpdate
 from backend.services import expense_service, report_service, wizard_service
 from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.expense_source_resolver import apply_default_source
@@ -226,6 +226,55 @@ async def _send_report(
     await send_message(chat_id, result)
 
 
+async def _maybe_handle_amount_edit(
+    db: AsyncSession, user, chat_id: int, text: str
+) -> bool:
+    """If user is in the transaction_amount_edit wizard, apply the new amount."""
+    state = user.wizard_state or {}
+    if state.get("flow") != "transaction_amount_edit":
+        return False
+    draft = dict(state.get("draft") or {})
+    expense_id = draft.get("expense_id")
+    if not expense_id:
+        await wizard_service.clear(db, user.id)
+        return False
+
+    try:
+        amount = parse_amount(text)
+    except Exception:
+        amount = None
+    if amount is None or amount <= 0:
+        await send_message(
+            chat_id,
+            "Mình chưa hiểu số tiền — bạn nhập lại giúp mình nhé (ví dụ: 45k, 1.2tr).",
+        )
+        return True
+
+    updated = await expense_service.update_expense(
+        db, user.id, expense_id, ExpenseUpdate(amount=float(amount))
+    )
+    await wizard_service.clear(db, user.id)
+    if updated is None:
+        await send_message(chat_id, "Giao dịch này mình không thấy nữa 🫣")
+        return True
+
+    original_message_id = draft.get("message_id")
+    original_chat_id = draft.get("chat_id", chat_id)
+    if original_message_id is not None:
+        from backend.bot.handlers.callbacks import _rerender_transaction_message
+
+        await _rerender_transaction_message(
+            original_chat_id,
+            original_message_id,
+            updated,
+            edited=True,
+            db=db,
+        )
+    else:
+        await send_message(chat_id, f"Đã cập nhật số tiền thành {float(amount):,.0f}đ")
+    return True
+
+
 async def handle_report_command(db: AsyncSession, message: dict) -> None:
     """Handle /report command — extracts Telegram data, delegates to service."""
     chat_id = message["chat"]["id"]
@@ -258,6 +307,11 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
     user = await get_user_by_telegram_id(db, telegram_id)
     if not user:
         await send_message(chat_id, _NOT_REGISTERED)
+        return True
+
+    # Issue #897 — capture amount-edit reply for an existing transaction
+    # before any other text routing.
+    if await _maybe_handle_amount_edit(db, user, chat_id, text):
         return True
 
     # Fast-path for explicit +/- expense syntax before generic intent routing.

--- a/backend/bot/handlers/transaction.py
+++ b/backend/bot/handlers/transaction.py
@@ -5,6 +5,8 @@ OCR confirm, or SMS parsing) to display a rich confirmation in Telegram.
 """
 
 import uuid
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -26,6 +28,18 @@ from backend.services.expense_source_resolver import (
 from backend.services.telegram_service import send_message
 
 # Legacy category codes (from earlier phases) → new shared codes.
+_VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
+
+
+def _to_vn_time(dt: datetime | None) -> datetime | None:
+    """Convert a (possibly naive-UTC) timestamp to Asia/Ho_Chi_Minh."""
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_VN_TZ)
+
+
 _LEGACY_CATEGORY_ALIASES = {
     "food_drink": "food",
     "utilities": "utility",
@@ -61,18 +75,13 @@ async def send_transaction_confirmation(
         merchant=expense.merchant or expense.note or "Giao dịch",
         amount=float(expense.amount),
         category_code=_normalize_category(expense.category),
-        time=expense.created_at,
+        time=_to_vn_time(expense.created_at),
         daily_spent=daily_spent,
         daily_budget=daily_budget,
         source_label=source_label,
         show_edit_hint=is_expense,
     )
-    # Expense confirmations are terminal (edit-hint instead of inline
-    # actions); money-in keeps the legacy action keyboard so the user can
-    # still tweak category / undo.
-    reply_markup = (
-        None if is_expense else transaction_actions_keyboard(str(expense.id))
-    )
+    reply_markup = transaction_actions_keyboard(str(expense.id))
     await send_message(
         chat_id=user.telegram_id,
         text=text,
@@ -134,7 +143,9 @@ async def send_transaction_batch_confirmation(
             )
             for expense in expenses
         ],
-        time=max((expense.created_at for expense in expenses), default=None),
+        time=_to_vn_time(
+            max((expense.created_at for expense in expenses), default=None)
+        ),
         source_label=source_label,
         show_edit_hint=all_expense,
     )

--- a/backend/bot/keyboards/common.py
+++ b/backend/bot/keyboards/common.py
@@ -21,6 +21,9 @@ TELEGRAM_CALLBACK_DATA_MAX_BYTES: Final[int] = 64
 class CallbackPrefix:
     EDIT_TRANSACTION = "edit_tx"
     CHANGE_CATEGORY = "change_cat"
+    CHANGE_SOURCE = "change_src"
+    EDIT_AMOUNT = "edit_amt"
+    CONFIRM_EDIT_DONE = "tx_done"
     DELETE_TRANSACTION = "del_tx"
     UNDO_TRANSACTION = "undo_tx"
     UNDO_TRANSACTION_BATCH = "undo_batch"

--- a/backend/bot/keyboards/transaction_keyboard.py
+++ b/backend/bot/keyboards/transaction_keyboard.py
@@ -11,44 +11,96 @@ InlineKeyboardMarkup = dict
 """Alias for clarity — we build raw dicts matching Telegram's schema."""
 
 
-def transaction_actions_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
-    """Keyboard xuất hiện SAU khi ghi giao dịch thành công.
+def _action_row(transaction_id: str) -> list[dict]:
+    tx = str(transaction_id)
+    return [
+        {
+            "text": "🏷",
+            "callback_data": build_callback(CallbackPrefix.CHANGE_CATEGORY, tx),
+        },
+        {
+            "text": "💳",
+            "callback_data": build_callback(CallbackPrefix.CHANGE_SOURCE, tx),
+        },
+        {
+            "text": "💵",
+            "callback_data": build_callback(CallbackPrefix.EDIT_AMOUNT, tx),
+        },
+        {
+            "text": "🗑",
+            "callback_data": build_callback(CallbackPrefix.DELETE_TRANSACTION, tx),
+        },
+    ]
 
-    Layout:
-        [🏷 Đổi danh mục] [✏️ Sửa] [🗑 Xóa]
-        [↶ Hủy (5s)]
+
+def transaction_actions_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
+    """Icon-only action row hiển thị sau khi ghi giao dịch thành công.
+
+    Layout: [🏷] [💳] [💵] [🗑]
     """
+    return {"inline_keyboard": [_action_row(transaction_id)]}
+
+
+def transaction_actions_with_done_keyboard(
+    transaction_id: str,
+) -> InlineKeyboardMarkup:
+    """Action row + nút ✅ Đồng ý (chỉ xuất hiện sau khi user đã sửa)."""
     tx = str(transaction_id)
     return {
         "inline_keyboard": [
+            _action_row(tx),
             [
                 {
-                    "text": "🏷 Đổi danh mục",
-                    "callback_data": build_callback(CallbackPrefix.CHANGE_CATEGORY, tx),
-                },
-                {
-                    "text": "✏️ Sửa",
+                    "text": "✅ Đồng ý",
                     "callback_data": build_callback(
-                        CallbackPrefix.EDIT_TRANSACTION, tx
+                        CallbackPrefix.CONFIRM_EDIT_DONE, tx
                     ),
-                },
-                {
-                    "text": "🗑 Xóa",
-                    "callback_data": build_callback(
-                        CallbackPrefix.DELETE_TRANSACTION, tx
-                    ),
-                },
+                }
             ],
-            [
-                {
-                    "text": "↶ Hủy (5s)",
-                    "callback_data": build_callback(
-                        CallbackPrefix.UNDO_TRANSACTION, tx
-                    ),
-                },
-            ],
-        ],
+        ]
     }
+
+
+def source_picker_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
+    """Picker chọn nguồn tiền khi user sửa expense (mirror category_picker)."""
+    tx = str(transaction_id)
+    rows: list[list[dict]] = [
+        [
+            {
+                "text": "💵 Tiền mặt",
+                "callback_data": build_callback(
+                    CallbackPrefix.CHANGE_SOURCE, tx, "cash"
+                ),
+            },
+            {
+                "text": "🏦 Tài khoản",
+                "callback_data": build_callback(
+                    CallbackPrefix.CHANGE_SOURCE, tx, "bank"
+                ),
+            },
+        ],
+        [
+            {
+                "text": "👛 Ví điện tử",
+                "callback_data": build_callback(
+                    CallbackPrefix.CHANGE_SOURCE, tx, "wallet"
+                ),
+            },
+            {
+                "text": "💳 Thẻ tín dụng",
+                "callback_data": build_callback(
+                    CallbackPrefix.CHANGE_SOURCE, tx, "card"
+                ),
+            },
+        ],
+        [
+            {
+                "text": "❌ Hủy",
+                "callback_data": build_callback(CallbackPrefix.CANCEL_ACTION, tx),
+            }
+        ],
+    ]
+    return {"inline_keyboard": rows}
 
 
 def transaction_batch_actions_keyboard(batch_id: str) -> InlineKeyboardMarkup:

--- a/backend/tests/test_callback_keyboards.py
+++ b/backend/tests/test_callback_keyboards.py
@@ -13,7 +13,9 @@ from backend.bot.keyboards.common import (
 from backend.bot.keyboards.transaction_keyboard import (
     category_picker_keyboard,
     confirm_delete_keyboard,
+    source_picker_keyboard,
     transaction_actions_keyboard,
+    transaction_actions_with_done_keyboard,
     transaction_batch_actions_keyboard,
 )
 from backend.config.categories import get_all_categories
@@ -79,21 +81,69 @@ class TestTransactionActionsKeyboard:
         kb = transaction_actions_keyboard("abc")
         assert "inline_keyboard" in kb
         rows = kb["inline_keyboard"]
-        assert len(rows) == 2
-        assert len(rows[0]) == 3  # Đổi danh mục / Sửa / Xóa
-        assert len(rows[1]) == 1  # Hủy (5s)
+        assert len(rows) == 1
+        assert len(rows[0]) == 4  # 🏷 / 💳 / 💵 / 🗑
 
-    def test_button_labels(self):
+    def test_button_labels_icon_only(self):
         kb = transaction_actions_keyboard("abc")
         labels = [btn["text"] for row in kb["inline_keyboard"] for btn in row]
-        assert "🏷 Đổi danh mục" in labels
-        assert "✏️ Sửa" in labels
-        assert "🗑 Xóa" in labels
-        assert "↶ Hủy (5s)" in labels
+        assert labels == ["🏷", "💳", "💵", "🗑"]
+
+    def test_callback_prefixes(self):
+        tx = str(uuid.uuid4())
+        kb = transaction_actions_keyboard(tx)
+        prefixes = [
+            parse_callback(btn["callback_data"])[0]
+            for row in kb["inline_keyboard"]
+            for btn in row
+        ]
+        assert prefixes == [
+            CallbackPrefix.CHANGE_CATEGORY,
+            CallbackPrefix.CHANGE_SOURCE,
+            CallbackPrefix.EDIT_AMOUNT,
+            CallbackPrefix.DELETE_TRANSACTION,
+        ]
 
     def test_callback_data_within_limit(self):
         tx = str(uuid.uuid4())
         kb = transaction_actions_keyboard(tx)
+        for row in kb["inline_keyboard"]:
+            for btn in row:
+                assert (
+                    len(btn["callback_data"].encode("utf-8"))
+                    <= TELEGRAM_CALLBACK_DATA_MAX_BYTES
+                )
+
+
+class TestTransactionActionsWithDoneKeyboard:
+    def test_adds_done_row(self):
+        tx = str(uuid.uuid4())
+        kb = transaction_actions_with_done_keyboard(tx)
+        rows = kb["inline_keyboard"]
+        assert len(rows) == 2
+        assert len(rows[0]) == 4
+        assert len(rows[1]) == 1
+        done_btn = rows[1][0]
+        assert "Đồng ý" in done_btn["text"]
+        prefix, args = parse_callback(done_btn["callback_data"])
+        assert prefix == CallbackPrefix.CONFIRM_EDIT_DONE
+        assert args == [tx]
+
+
+class TestSourcePickerKeyboard:
+    def test_has_all_source_types_and_cancel(self):
+        tx = str(uuid.uuid4())
+        kb = source_picker_keyboard(tx)
+        labels = [btn["text"] for row in kb["inline_keyboard"] for btn in row]
+        assert any("Tiền mặt" in label for label in labels)
+        assert any("Tài khoản" in label for label in labels)
+        assert any("Ví điện tử" in label for label in labels)
+        assert any("Thẻ tín dụng" in label for label in labels)
+        assert kb["inline_keyboard"][-1][0]["text"] == "❌ Hủy"
+
+    def test_callbacks_within_limit(self):
+        tx = str(uuid.uuid4())
+        kb = source_picker_keyboard(tx)
         for row in kb["inline_keyboard"]:
             for btn in row:
                 assert (

--- a/backend/tests/test_callbacks_change_category.py
+++ b/backend/tests/test_callbacks_change_category.py
@@ -71,5 +71,5 @@ async def test_change_category_accepts_valid_category(monkeypatch):
     assert expense.category == "shopping"
     db.flush.assert_awaited_once()
     db.refresh.assert_awaited_once_with(expense)
-    rerender.assert_awaited_once_with(1, 10, expense)
+    rerender.assert_awaited_once_with(1, 10, expense, edited=True, db=db)
     analytics_track.assert_called_once()

--- a/backend/tests/test_callbacks_change_source.py
+++ b/backend/tests/test_callbacks_change_source.py
@@ -1,0 +1,184 @@
+"""Issue #897 — 2-step source edit via inline keyboard."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.bot.handlers import callbacks
+
+
+@pytest.mark.asyncio
+async def test_change_source_one_arg_swaps_to_picker_and_starts_wizard(monkeypatch):
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    start_flow = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "start_flow", start_flow)
+    edit_markup = AsyncMock()
+    monkeypatch.setattr(callbacks, "edit_message_reply_markup", edit_markup)
+    answer = AsyncMock()
+    monkeypatch.setattr(callbacks, "answer_callback", answer)
+
+    db = SimpleNamespace()
+    user = SimpleNamespace(id=42)
+
+    await callbacks._handle_change_source(
+        db=db,
+        user=user,
+        args=["tx-1"],
+        callback_id="cb1",
+        chat_id=10,
+        message_id=20,
+    )
+
+    start_flow.assert_awaited_once()
+    kwargs = start_flow.await_args.kwargs
+    assert kwargs["flow"] == "transaction_source_edit"
+    assert kwargs["step"] == "pick_kind"
+    assert kwargs["draft"]["expense_id"] == "tx-1"
+    edit_markup.assert_awaited_once()
+    answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_change_source_cash_applies_immediately(monkeypatch):
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    updated = SimpleNamespace(id="tx-1", transaction_type="expense")
+
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    update_expense = AsyncMock(return_value=updated)
+    monkeypatch.setattr(callbacks.expense_service, "update_expense", update_expense)
+    clear = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "clear", clear)
+    rerender = AsyncMock()
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", rerender)
+    monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
+
+    db = SimpleNamespace()
+    user = SimpleNamespace(id=42)
+
+    await callbacks._handle_change_source(
+        db=db,
+        user=user,
+        args=["tx-1", "cash"],
+        callback_id="cb1",
+        chat_id=10,
+        message_id=20,
+    )
+
+    update_expense.assert_awaited_once()
+    update_arg = update_expense.await_args.args[3]
+    assert update_arg.source_type == "cash"
+    clear.assert_awaited_once()
+    rerender.assert_awaited_once_with(10, 20, updated, edited=True, db=db)
+
+
+@pytest.mark.asyncio
+async def test_change_source_wallet_swaps_to_subpicker(monkeypatch):
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    edit_markup = AsyncMock()
+    monkeypatch.setattr(callbacks, "edit_message_reply_markup", edit_markup)
+    monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
+
+    await callbacks._handle_change_source(
+        db=SimpleNamespace(),
+        user=SimpleNamespace(id=42),
+        args=["tx-1", "wallet"],
+        callback_id="cb1",
+        chat_id=10,
+        message_id=20,
+    )
+    edit_markup.assert_awaited_once()
+    markup = edit_markup.await_args.kwargs["reply_markup"]
+    callbacks_data = [
+        btn["callback_data"]
+        for row in markup["inline_keyboard"]
+        for btn in row
+    ]
+    assert any(cd.startswith("chsrc_wl:momo") for cd in callbacks_data)
+
+
+@pytest.mark.asyncio
+async def test_change_source_subpicker_applies_bank(monkeypatch):
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    updated = SimpleNamespace(id="tx-1", transaction_type="expense")
+
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_source_edit",
+            "step": "pick_kind",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+
+    monkeypatch.setattr(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    update_expense = AsyncMock(return_value=updated)
+    monkeypatch.setattr(callbacks.expense_service, "update_expense", update_expense)
+    clear = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "clear", clear)
+    rerender = AsyncMock()
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", rerender)
+    monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
+
+    callback_query = {
+        "id": "cb1",
+        "data": "chsrc_bk:11111111-1111-1111-1111-111111111111",
+        "from": {"id": 7},
+        "message": {"chat": {"id": 10}, "message_id": 20},
+    }
+    handled = await callbacks._handle_change_source_subpicker(
+        SimpleNamespace(), callback_query
+    )
+    assert handled is True
+    update_arg = update_expense.await_args.args[3]
+    assert update_arg.source_type == "bank_account"
+    assert str(update_arg.source_asset_id) == "11111111-1111-1111-1111-111111111111"
+    clear.assert_awaited_once()
+    rerender.assert_awaited_once()
+    assert rerender.await_args.args[:3] == (10, 20, updated)
+    assert rerender.await_args.kwargs["edited"] is True
+
+
+@pytest.mark.asyncio
+async def test_change_source_subpicker_rejects_when_not_in_flow(monkeypatch):
+    user = SimpleNamespace(id=42, wizard_state={"flow": "something_else"})
+    monkeypatch.setattr(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    )
+    answer = AsyncMock()
+    monkeypatch.setattr(callbacks, "answer_callback", answer)
+
+    callback_query = {
+        "id": "cb1",
+        "data": "chsrc_wl:momo",
+        "from": {"id": 7},
+        "message": {"chat": {"id": 10}, "message_id": 20},
+    }
+    handled = await callbacks._handle_change_source_subpicker(
+        SimpleNamespace(), callback_query
+    )
+    assert handled is True
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True

--- a/backend/tests/test_callbacks_done_edit.py
+++ b/backend/tests/test_callbacks_done_edit.py
@@ -1,0 +1,32 @@
+"""Issue #897 — ✅ Đồng ý strips the inline keyboard."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.bot.handlers import callbacks
+
+
+@pytest.mark.asyncio
+async def test_done_edit_strips_keyboard(monkeypatch):
+    edit_markup = AsyncMock()
+    monkeypatch.setattr(callbacks, "edit_message_reply_markup", edit_markup)
+    answer = AsyncMock()
+    monkeypatch.setattr(callbacks, "answer_callback", answer)
+
+    await callbacks._handle_done_edit(
+        db=SimpleNamespace(),
+        user=SimpleNamespace(id=42),
+        args=["tx-1"],
+        callback_id="cb1",
+        chat_id=10,
+        message_id=20,
+    )
+
+    edit_markup.assert_awaited_once()
+    kwargs = edit_markup.await_args.kwargs
+    assert kwargs["chat_id"] == 10
+    assert kwargs["message_id"] == 20
+    assert kwargs["reply_markup"] == {"inline_keyboard": []}
+    answer.assert_awaited_once()

--- a/backend/tests/test_callbacks_edit_amount.py
+++ b/backend/tests/test_callbacks_edit_amount.py
@@ -1,0 +1,107 @@
+"""Issue #897 — 💵 button prompts via force_reply + wizard captures text."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from backend.bot.handlers import callbacks, message as message_handler
+
+
+@pytest.mark.asyncio
+async def test_edit_amount_starts_wizard_and_sends_force_reply(monkeypatch):
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    start_flow = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "start_flow", start_flow)
+    send = AsyncMock()
+    monkeypatch.setattr(callbacks, "send_message", send)
+    monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
+
+    await callbacks._handle_edit_amount(
+        db=SimpleNamespace(),
+        user=SimpleNamespace(id=42),
+        args=["tx-1"],
+        callback_id="cb1",
+        chat_id=10,
+        message_id=20,
+    )
+
+    start_flow.assert_awaited_once()
+    kwargs = start_flow.await_args.kwargs
+    assert kwargs["flow"] == "transaction_amount_edit"
+    assert kwargs["draft"]["expense_id"] == "tx-1"
+    send.assert_awaited_once()
+    send_kwargs = send.await_args.kwargs
+    assert send_kwargs["reply_markup"] == {"force_reply": True, "selective": True}
+
+
+@pytest.mark.asyncio
+async def test_amount_edit_text_reply_applies_update(monkeypatch):
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_amount_edit",
+            "step": "await_amount",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+    updated = SimpleNamespace(id="tx-1", transaction_type="expense")
+    update_expense = AsyncMock(return_value=updated)
+    monkeypatch.setattr(
+        message_handler.expense_service, "update_expense", update_expense
+    )
+    clear = AsyncMock()
+    monkeypatch.setattr(message_handler.wizard_service, "clear", clear)
+    monkeypatch.setattr(message_handler, "send_message", AsyncMock())
+    rerender = AsyncMock()
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", rerender)
+
+    handled = await message_handler._maybe_handle_amount_edit(
+        SimpleNamespace(), user, chat_id=10, text="60k"
+    )
+    assert handled is True
+    update_expense.assert_awaited_once()
+    update_arg = update_expense.await_args.args[3]
+    assert float(update_arg.amount) == 60000.0
+    clear.assert_awaited_once()
+    rerender.assert_awaited_once()
+    assert rerender.await_args.kwargs["edited"] is True
+
+
+@pytest.mark.asyncio
+async def test_amount_edit_invalid_text_asks_retry(monkeypatch):
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_amount_edit",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+    update_expense = AsyncMock()
+    monkeypatch.setattr(
+        message_handler.expense_service, "update_expense", update_expense
+    )
+    monkeypatch.setattr(message_handler.wizard_service, "clear", AsyncMock())
+    send = AsyncMock()
+    monkeypatch.setattr(message_handler, "send_message", send)
+
+    handled = await message_handler._maybe_handle_amount_edit(
+        SimpleNamespace(), user, chat_id=10, text="không phải số"
+    )
+    assert handled is True
+    update_expense.assert_not_awaited()
+    send.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_amount_edit_not_in_flow_returns_false():
+    user = SimpleNamespace(id=42, wizard_state={"flow": "something_else"})
+    handled = await message_handler._maybe_handle_amount_edit(
+        SimpleNamespace(), user, chat_id=10, text="60k"
+    )
+    assert handled is False

--- a/backend/tests/test_templates.py
+++ b/backend/tests/test_templates.py
@@ -77,7 +77,7 @@ class TestTransactionConfirmation:
             show_edit_hint=True,
         )
         assert "Chi từ: Thẻ tín dụng [Vietcombank]" in result
-        assert "Quản lý chi tiêu" in result
+        assert "chi tiêu đã được ghi lại" in result
         assert "<i>" in result and "</i>" in result
         assert "💡" in result
 
@@ -109,7 +109,7 @@ class TestTransactionBatchConfirmation:
             show_edit_hint=True,
         )
         assert "Chi từ: Tiền mặt" in result
-        assert "Quản lý chi tiêu" in result
+        assert "chi tiêu đã được ghi lại" in result
         assert "<i>" in result and "</i>" in result
         assert "💡" in result
 

--- a/backend/tests/test_transaction_confirmation_tz.py
+++ b/backend/tests/test_transaction_confirmation_tz.py
@@ -1,0 +1,35 @@
+"""Issue #897 — confirm message must render timestamps in Vietnam time."""
+
+from datetime import datetime, timezone
+
+from backend.bot.handlers.callbacks import _to_vn_time
+
+
+def test_to_vn_time_converts_utc_to_ict():
+    utc = datetime(2026, 5, 28, 5, 15, tzinfo=timezone.utc)
+    vn = _to_vn_time(utc)
+    assert vn is not None
+    assert vn.hour == 12
+    assert vn.minute == 15
+
+
+def test_to_vn_time_naive_treated_as_utc():
+    naive = datetime(2026, 5, 28, 5, 15)
+    vn = _to_vn_time(naive)
+    assert vn is not None
+    assert vn.hour == 12
+    assert vn.minute == 15
+
+
+def test_to_vn_time_passes_aware_local():
+    from zoneinfo import ZoneInfo
+
+    aware = datetime(2026, 5, 28, 12, 15, tzinfo=ZoneInfo("Asia/Ho_Chi_Minh"))
+    vn = _to_vn_time(aware)
+    assert vn is not None
+    assert vn.hour == 12
+    assert vn.minute == 15
+
+
+def test_to_vn_time_none_returns_none():
+    assert _to_vn_time(None) is None

--- a/content/transaction_copy.yaml
+++ b/content/transaction_copy.yaml
@@ -2,7 +2,7 @@ confirmation:
   title_done: "✅ Đã ghi xong!"
   batch_title: "✅ Đã ghi xong {count} khoản!"
   source_prefix: "💳 Chi từ: {source}"
-  edit_hint: "<i>💡 Cần sửa/xoá? Vào mục Quản lý chi tiêu trong menu Chi tiêu nhé.</i>"
+  edit_hint: "<i>💡 chi tiêu đã được ghi lại, nếu đúng bạn không cần làm gì thêm!</i>"
 
 source_labels:
   cash: "Tiền mặt"


### PR DESCRIPTION
## Summary

Restores the inline action row on every expense confirmation message and wires
up an inline editing flow as requested in issue #897.

- **4 icon buttons** below every confirmation: 🏷 (danh mục) · 💳 (nguồn tiền) ·
  💵 (số tiền) · 🗑 (xoá).
- **✅ Đồng ý** appears only after the user taps one of the four — tapping it
  hides the keyboard while keeping the message body.
- 🏷 keeps the existing category-picker wizard.
- 💳 swaps the keyboard to a source picker (cash / bank / wallet / card). Bank,
  wallet and card surface a sub-picker; "Quay lại" returns to the kind picker.
  Only this transaction's source is updated — `user.default_expense_source` is
  untouched.
- 💵 sends a Telegram `force_reply` prompt; the user's reply is parsed via
  `parse_amount` and applied through `expense_service.update_expense`.
- 🗑 keeps the existing delete confirmation flow.
- Confirmation timestamps are now rendered in `Asia/Ho_Chi_Minh` (naive UTC is
  assumed for legacy rows).
- Footer hint changed to: *"chi tiêu đã được ghi lại, nếu đúng bạn không cần
  làm gì thêm!"*.

Layer contract preserved: handlers call services, services flush only, callback
data stays ≤ 64 bytes (sub-picker uses short `chsrc_bk:` / `chsrc_wl:` /
`chsrc_cc:` prefixes and stores the expense id in `wizard_state.draft`).

## Test plan

- [x] `pytest backend/tests/test_callbacks_change_source.py`
- [x] `pytest backend/tests/test_callbacks_edit_amount.py`
- [x] `pytest backend/tests/test_callbacks_done_edit.py`
- [x] `pytest backend/tests/test_transaction_confirmation_tz.py`
- [x] `pytest backend/tests/test_callback_keyboards.py`
- [x] `pytest backend/tests/test_callbacks_change_category.py`
- [x] `pytest backend/tests/test_templates.py`
- [ ] Manual smoke in Telegram: log expense → tap each of 🏷 / 💳 / 💵 / 🗑 →
      verify keyboard transitions, Đồng ý hides keyboard, time shows VN local.

Close #897
