### PR TITLE
fix(tx): VN time in formatter + default source for saving & OCR

### DIFF
--- a/backend/bot/formatters/templates.py
+++ b/backend/bot/formatters/templates.py
@@ -3,17 +3,35 @@
 Nguyên tắc: Một function = một loại tin nhắn.
 """
 
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from functools import lru_cache
 from html import escape as _html_escape
 from pathlib import Path
 from typing import Any
+from zoneinfo import ZoneInfo
 
 import yaml
 
 from backend.bot.formatters.money import format_money_full, format_money_short
 from backend.bot.formatters.progress_bar import make_category_bar, make_progress_bar
 from backend.config.categories import get_category
+
+_VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
+
+
+def _as_vn_time(dt: datetime | None) -> datetime | None:
+    """Normalize any timestamp to Asia/Ho_Chi_Minh for display.
+
+    Centralized here so every confirmation template renders VN time
+    regardless of whether the caller remembered to convert. PG TIMESTAMPTZ
+    columns come back as aware UTC; naive datetimes are assumed UTC (the
+    historical default of ``datetime.utcnow``).
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(_VN_TZ)
 
 _TRANSACTION_COPY_PATH = (
     Path(__file__).resolve().parents[3] / "content" / "transaction_copy.yaml"
@@ -65,8 +83,9 @@ def format_transaction_confirmation(
     context_parts: list[str] = []
     if location:
         context_parts.append(f"📍 {_html_escape(location)}")
-    if time:
-        context_parts.append(time.strftime("%H:%M"))
+    time_vn = _as_vn_time(time)
+    if time_vn:
+        context_parts.append(time_vn.strftime("%H:%M"))
     if context_parts:
         lines.append("  •  ".join(context_parts))
 
@@ -183,8 +202,9 @@ def format_transaction_batch_confirmation(
 
     lines.append("")
     lines.append(f"Tổng: {format_money_full(total)}")
-    if time:
-        lines.append(time.strftime("%H:%M"))
+    time_vn = _as_vn_time(time)
+    if time_vn:
+        lines.append(time_vn.strftime("%H:%M"))
 
     if source_label:
         source_template = _confirmation_copy(

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -18,10 +18,8 @@ and edit the triggering message in place.
 from __future__ import annotations
 
 import logging
-import uuid
 from datetime import datetime, timezone
 from typing import Any
-from zoneinfo import ZoneInfo
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -59,8 +57,6 @@ from backend.services.telegram_service import (
     edit_message_text,
     send_message,
 )
-
-_VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
 
 logger = logging.getLogger(__name__)
 
@@ -229,14 +225,6 @@ async def _handle_source_selection_callback(
     return True
 
 
-def _to_vn_time(dt: datetime | None) -> datetime | None:
-    if dt is None:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(_VN_TZ)
-
-
 async def _rerender_transaction_message(
     chat_id: int,
     message_id: int,
@@ -257,7 +245,7 @@ async def _rerender_transaction_message(
         merchant=expense.merchant or expense.note or "Giao dịch",
         amount=float(expense.amount),
         category_code=_normalize_category(expense.category),
-        time=_to_vn_time(expense.created_at),
+        time=expense.created_at,
         source_label=source_label,
         show_edit_hint=is_expense,
     )

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -519,6 +519,7 @@ async def _handle_confirm_callback(
             category="saving",
             expense_date=date.today(),
         )
+        expense_data = await apply_default_source(db, user.id, expense_data)
         expense = await expense_service.create_expense(db, user.id, expense_data)
         await send_transaction_confirmation(db, expense)
         analytics.track(

--- a/backend/bot/handlers/photo_receipt.py
+++ b/backend/bot/handlers/photo_receipt.py
@@ -53,6 +53,7 @@ from backend.config.categories import get_all_categories
 from backend.models.user import User
 from backend.schemas.expense import VALID_CATEGORIES, ExpenseCreate
 from backend.services import expense_service
+from backend.services.expense_source_resolver import apply_default_source
 from backend.services.ocr_service import parse_receipt_image
 from backend.services.telegram_service import (
     download_file,
@@ -400,26 +401,24 @@ async def confirm_pending_receipt(*, db: AsyncSession, user: User, token: str) -
         return False
     if time.monotonic() - float(payload.get("created_at", 0)) > _PENDING_RECEIPT_TTL_S:
         return False
-    await expense_service.create_expense(
-        db,
-        user.id,
-        ExpenseCreate(
-            amount=float(payload["amount"]),
-            currency=str(payload["currency"]),
-            merchant=payload.get("merchant"),
-            category=str(payload["category"]),
-            source="ocr",
-            expense_date=date.fromisoformat(str(payload["expense_date"])),
-            note=payload.get("note"),
-            raw_data={
-                "ocr": {
-                    "confidence": payload.get("confidence"),
-                    "category_suggestion": payload.get("category_suggestion"),
-                    "items": payload.get("items") or [],
-                }
-            },
-        ),
+    expense_data = ExpenseCreate(
+        amount=float(payload["amount"]),
+        currency=str(payload["currency"]),
+        merchant=payload.get("merchant"),
+        category=str(payload["category"]),
+        source="ocr",
+        expense_date=date.fromisoformat(str(payload["expense_date"])),
+        note=payload.get("note"),
+        raw_data={
+            "ocr": {
+                "confidence": payload.get("confidence"),
+                "category_suggestion": payload.get("category_suggestion"),
+                "items": payload.get("items") or [],
+            }
+        },
     )
+    expense_data = await apply_default_source(db, user.id, expense_data)
+    await expense_service.create_expense(db, user.id, expense_data)
     return True
 
 

--- a/backend/bot/handlers/transaction.py
+++ b/backend/bot/handlers/transaction.py
@@ -5,8 +5,6 @@ OCR confirm, or SMS parsing) to display a rich confirmation in Telegram.
 """
 
 import uuid
-from datetime import datetime, timezone
-from zoneinfo import ZoneInfo
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -28,18 +26,6 @@ from backend.services.expense_source_resolver import (
 from backend.services.telegram_service import send_message
 
 # Legacy category codes (from earlier phases) → new shared codes.
-_VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
-
-
-def _to_vn_time(dt: datetime | None) -> datetime | None:
-    """Convert a (possibly naive-UTC) timestamp to Asia/Ho_Chi_Minh."""
-    if dt is None:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(_VN_TZ)
-
-
 _LEGACY_CATEGORY_ALIASES = {
     "food_drink": "food",
     "utilities": "utility",
@@ -75,7 +61,7 @@ async def send_transaction_confirmation(
         merchant=expense.merchant or expense.note or "Giao dịch",
         amount=float(expense.amount),
         category_code=_normalize_category(expense.category),
-        time=_to_vn_time(expense.created_at),
+        time=expense.created_at,
         daily_spent=daily_spent,
         daily_budget=daily_budget,
         source_label=source_label,
@@ -143,9 +129,7 @@ async def send_transaction_batch_confirmation(
             )
             for expense in expenses
         ],
-        time=_to_vn_time(
-            max((expense.created_at for expense in expenses), default=None)
-        ),
+        time=max((expense.created_at for expense in expenses), default=None),
         source_label=source_label,
         show_edit_hint=all_expense,
     )

--- a/backend/tests/test_action_record_saving_default_source.py
+++ b/backend/tests/test_action_record_saving_default_source.py
@@ -1,0 +1,55 @@
+"""Saving intent confirm path must honour ``default_expense_source``.
+
+Mirrors the quick-transaction and OCR paths: any handler that turns user
+intent into a persisted expense routes the payload through
+``apply_default_source`` before service-level persistence.
+"""
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.bot.handlers import message as message_handler
+from backend.intent import pending_action
+
+
+def _user():
+    u = MagicMock()
+    u.id = uuid.uuid4()
+    u.telegram_id = 42
+    return u
+
+
+@pytest.mark.asyncio
+async def test_action_record_saving_applies_default_source():
+    user = _user()
+    state = {
+        "flow": pending_action.FLOW_PENDING_ACTION,
+        "intent": "action_record_saving",
+        "parameters": {"amount": 1_000_000},
+    }
+
+    async def _stamp(_db, _uid, data):
+        data.source_type = "cash"
+        return data
+
+    create_expense = AsyncMock(return_value=MagicMock(id=uuid.uuid4()))
+    with patch.object(message_handler, "send_message", AsyncMock()), \
+         patch.object(message_handler, "apply_default_source",
+                       AsyncMock(side_effect=_stamp)) as apply_src, \
+         patch.object(message_handler.expense_service, "create_expense",
+                       create_expense), \
+         patch.object(message_handler, "send_transaction_confirmation",
+                       AsyncMock()), \
+         patch.object(message_handler.pending_action, "clear", AsyncMock()):
+        ok = await message_handler._handle_confirm_callback(
+            db=MagicMock(), chat_id=42, user=user, state=state, action="yes"
+        )
+
+    assert ok is True
+    apply_src.assert_awaited_once()
+    create_expense.assert_awaited_once()
+    passed = create_expense.await_args.args[2]
+    assert passed.source_type == "cash"

--- a/backend/tests/test_intent/test_message_router.py
+++ b/backend/tests/test_intent/test_message_router.py
@@ -77,6 +77,9 @@ async def test_confirm_yes_creates_expense_and_clears_state():
     with patch.object(
         message, "get_user_by_telegram_id", AsyncMock(return_value=user)
     ), patch.object(
+        message, "apply_default_source",
+        AsyncMock(side_effect=lambda _db, _u, d: d),
+    ), patch.object(
         message.expense_service,
         "create_expense",
         AsyncMock(return_value=expense_obj),

--- a/backend/tests/test_photo_receipt_handler.py
+++ b/backend/tests/test_photo_receipt_handler.py
@@ -255,6 +255,8 @@ async def test_confirm_pending_receipt_success_creates_expense():
     }
     create = AsyncMock()
     with patch.object(photo_receipt, "time") as t, \
+         patch.object(photo_receipt, "apply_default_source",
+                       AsyncMock(side_effect=lambda _db, _u, d: d)), \
          patch.object(photo_receipt.expense_service, "create_expense", create):
         t.monotonic.return_value = 101.0
         ok = await photo_receipt.confirm_pending_receipt(
@@ -262,6 +264,41 @@ async def test_confirm_pending_receipt_success_creates_expense():
         )
     assert ok is True
     create.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_confirm_pending_receipt_applies_default_source():
+    """OCR confirm path must honour the user's default_expense_source."""
+    user = _user()
+    token = "tok_default_src"
+    photo_receipt._pending_receipt_confirms[token] = {
+        "created_at": 100.0,
+        "user_id": str(user.id),
+        "amount": 50000.0,
+        "currency": "VND",
+        "merchant": "Phở",
+        "category": "food",
+        "expense_date": "2026-05-28",
+    }
+
+    async def _stamp(_db, _uid, data):
+        data.source = "cash"
+        return data
+
+    create = AsyncMock()
+    with patch.object(photo_receipt, "time") as t, \
+         patch.object(photo_receipt, "apply_default_source",
+                       AsyncMock(side_effect=_stamp)) as apply_src, \
+         patch.object(photo_receipt.expense_service, "create_expense", create):
+        t.monotonic.return_value = 101.0
+        ok = await photo_receipt.confirm_pending_receipt(
+            db=MagicMock(), user=user, token=token
+        )
+    assert ok is True
+    apply_src.assert_awaited_once()
+    create.assert_awaited_once()
+    passed = create.await_args.args[2]
+    assert passed.source == "cash"
 
 
 @pytest.mark.asyncio
@@ -620,6 +657,8 @@ async def test_confirm_pending_receipt_persists_picked_category():
     }
     create = AsyncMock()
     with patch.object(photo_receipt, "time") as t, \
+         patch.object(photo_receipt, "apply_default_source",
+                       AsyncMock(side_effect=lambda _db, _u, d: d)), \
          patch.object(photo_receipt.expense_service, "create_expense", create):
         t.monotonic.return_value = 101.0
         ok = await photo_receipt.confirm_pending_receipt(

--- a/backend/tests/test_templates.py
+++ b/backend/tests/test_templates.py
@@ -1,6 +1,7 @@
 """Tests for message templates (Issue #27)."""
 
 from datetime import datetime
+from zoneinfo import ZoneInfo
 
 from backend.bot.formatters.templates import (
     format_budget_alert,
@@ -9,6 +10,8 @@ from backend.bot.formatters.templates import (
     format_transaction_confirmation,
     format_welcome_message,
 )
+
+_VN = ZoneInfo("Asia/Ho_Chi_Minh")
 
 
 class TestTransactionConfirmation:
@@ -29,7 +32,7 @@ class TestTransactionConfirmation:
             amount=85_000,
             category_code="food",
             location="Hà Nội",
-            time=datetime(2026, 4, 15, 12, 15),
+            time=datetime(2026, 4, 15, 12, 15, tzinfo=_VN),
         )
         assert "📍 Hà Nội" in result
         assert "12:15" in result
@@ -94,7 +97,7 @@ class TestTransactionBatchConfirmation:
     def test_contains_each_item_and_total(self):
         result = format_transaction_batch_confirmation(
             items=[("tiền xăng", 50_000, "transport"), ("ăn trưa", 50_000, "food")],
-            time=datetime(2026, 5, 7, 19, 18),
+            time=datetime(2026, 5, 7, 19, 18, tzinfo=_VN),
         )
         assert "✅ Đã ghi xong 2 khoản!" in result
         assert "🚗 tiền xăng" in result

--- a/backend/tests/test_transaction_confirmation_tz.py
+++ b/backend/tests/test_transaction_confirmation_tz.py
@@ -1,35 +1,52 @@
-"""Issue #897 — confirm message must render timestamps in Vietnam time."""
+"""Issue #897 — confirm message must render timestamps in Vietnam time.
+
+The conversion lives in the formatter so no call site can forget. These
+tests exercise the public contract by inspecting the rendered text.
+"""
 
 from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
 
-from backend.bot.handlers.callbacks import _to_vn_time
+from backend.bot.formatters.templates import (
+    format_transaction_batch_confirmation,
+    format_transaction_confirmation,
+)
 
 
-def test_to_vn_time_converts_utc_to_ict():
+def _render_single(time):
+    return format_transaction_confirmation(
+        merchant="Phở",
+        amount=45000,
+        category_code="food_drink",
+        time=time,
+    )
+
+
+def test_formatter_converts_utc_to_ict():
     utc = datetime(2026, 5, 28, 5, 15, tzinfo=timezone.utc)
-    vn = _to_vn_time(utc)
-    assert vn is not None
-    assert vn.hour == 12
-    assert vn.minute == 15
+    assert "12:15" in _render_single(utc)
 
 
-def test_to_vn_time_naive_treated_as_utc():
+def test_formatter_treats_naive_as_utc():
     naive = datetime(2026, 5, 28, 5, 15)
-    vn = _to_vn_time(naive)
-    assert vn is not None
-    assert vn.hour == 12
-    assert vn.minute == 15
+    assert "12:15" in _render_single(naive)
 
 
-def test_to_vn_time_passes_aware_local():
-    from zoneinfo import ZoneInfo
-
+def test_formatter_passes_aware_local_through():
     aware = datetime(2026, 5, 28, 12, 15, tzinfo=ZoneInfo("Asia/Ho_Chi_Minh"))
-    vn = _to_vn_time(aware)
-    assert vn is not None
-    assert vn.hour == 12
-    assert vn.minute == 15
+    assert "12:15" in _render_single(aware)
 
 
-def test_to_vn_time_none_returns_none():
-    assert _to_vn_time(None) is None
+def test_formatter_none_time_omits_clock():
+    text = _render_single(None)
+    assert "12:15" not in text
+    assert ":15" not in text
+
+
+def test_batch_formatter_converts_utc_to_ict():
+    utc = datetime(2026, 5, 28, 5, 15, tzinfo=timezone.utc)
+    text = format_transaction_batch_confirmation(
+        items=[("Phở", 45000, "food_drink"), ("Trà", 20000, "food_drink")],
+        time=utc,
+    )
+    assert "12:15" in text


### PR DESCRIPTION
## Summary

Follow-up to PR #898 after user feedback that two paths were still wrong:

1. **Vietnam time everywhere.** Move `Asia/Ho_Chi_Minh` conversion into the formatter (`format_transaction_confirmation` / `format_transaction_batch_confirmation`) so no caller can render UTC by accident. Removes the duplicated `_to_vn_time` helpers from `transaction.py` and `callbacks.py`. PG TIMESTAMPTZ aware datetimes are converted; naive datetimes are treated as UTC.
2. **Default expense source on every write path.** Apply `apply_default_source` on the two remaining intent paths that bypassed it:
   - `ACTION_RECORD_SAVING` confirm (manual "tiết kiệm 1tr" flow)
   - OCR receipt confirm (`confirm_pending_receipt`)
   Quick-transaction already routed through it; these were the last gaps.

## Test plan
- [x] `backend/tests/test_transaction_confirmation_tz.py` — new public-contract tests (UTC→ICT, naive→ICT, aware-local pass-through, None omission, batch).
- [x] `backend/tests/test_action_record_saving_default_source.py` — new test for saving confirm.
- [x] `backend/tests/test_photo_receipt_handler.py` — new test that OCR confirm calls `apply_default_source`.
- [x] `backend/tests/test_templates.py` updated to use ICT-aware datetimes.
- [x] `backend/tests/test_intent/test_message_router.py` updated (stub `apply_default_source`).
- [x] 133 affected tests pass; ruff clean on changed files.

Closes #898
