### PR TITLE
docs: mark Phase 4.2.5 + 4.3 done, sync roadmap & complete auto-sync flow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Read this before any code changes. For implementation details, open the correspo
 [`docs/current/phase-status.yaml`](docs/current/phase-status.yaml)):
 
 <!-- BEGIN: phase-status:current-line -->
-🚀 **Admin Observability** (current) — [detail](docs/current/phase-4.2.5/phase-4.2.5-detailed.md)
+📋 **Encryption End-to-End** (next) — [detail](#)
 <!-- END: phase-status:current-line -->
 
 For full roadmap, see [`docs/current/phase-status.yaml`](docs/current/phase-status.yaml).
@@ -151,8 +151,8 @@ docker-compose up -d                        # Start PostgreSQL + Redis
 This file is a **table of contents**, not an encyclopedia. When you need detail, read:
 
 - **Strategy & vision:** [`docs/current/strategy.md`](docs/current/strategy.md) — Ladder of Engagement, positioning, V2 pivot rationale
-- **Recently completed phase:** [`docs/current/phase-3.9/phase-3.9-detailed.md`](docs/current/phase-3.9/phase-3.9-detailed.md) — real market-data integration and quality gate
-- **Next phase:** Phase 4A — Financial Twin Conservative MVP
+- **Recently completed phase:** [`docs/current/phase-4.3/phase-4.3-detailed.md`](docs/current/phase-4.3/phase-4.3-detailed.md) — Twin enhancement (weather metaphor + story-first), habit loop, Twin admin dashboard
+- **Next phase:** Phase 5.0 — Encryption End-to-End (after June 2026 soft launch)
 - **Database schema:** Read latest migrations in `alembic/versions/` for current state
 - **Architecture decisions:** [`docs/architecture/`](docs/architecture/) — layer contract rationale, scaling decisions
 - **GitHub workflow:** [`docs/conventions/github-workflow.md`](docs/conventions/github-workflow.md) — PR conventions, sub-issue hierarchy, branch naming
@@ -178,27 +178,26 @@ Quick reference:
 
 ---
 
-## Phase 3.9 — Status: DONE ✅
+## Phase 4.3 — Status: DONE ✅
 
-**Status:** ✅ Implementation complete. Phase 3.9 replaced market-data stubs with real provider integrations and completed the Epic 5 quality gate.
+**Status:** ✅ Implementation complete. Phase 4.3 turned the Financial Twin from a hard-to-grasp feature into a habit-forming experience, and added a Twin admin dashboard. 4 Epics / 15 stories.
 
-### Shipped in Phase 3.9
+### Shipped in Phase 4.3
 
-- Real provider layer for VN stocks (SSI primary, VNDIRECT backup), crypto (CoinGecko), gold (SJC primary, PNJ backup), bank rates, and RSS news.
-- Redis cache and last-known fallback so briefings can show stale-data banners instead of failing hard.
-- Provider dispatcher with circuit breaker to protect failing upstreams.
-- Wealth valuation, morning briefing, portfolio analytics, price alerts, and agent market tools now consume normalized real quotes.
-- Epic 5 added end-to-end tests, an offline benchmark script, benchmark report, and provider ADR.
+- **Weather metaphor** thay P10/P50/P90 — 🌧️ Khiêm tốn / ⛅ Bình thường / ☀️ Lạc quan — để người dùng hiểu probability cone mà không cần đọc số percentile.
+- **Life-outcome translation** + **story-first narrative** (4-5 màn swipe) + **mascot personification** giúp Twin kể chuyện thay vì bày số liệu.
+- **Habit loop**: on-demand recompute (<5s) + causality ("vì sao thay đổi") + action prompt + negative delta handling + delta threshold + return tease để kéo người dùng quay lại.
+- **Twin admin dashboard** 4 sections: engagement funnel, loop health, comprehension, delta distribution.
 
 ### Next phase
 
-Phase 4A — Financial Twin Conservative MVP.
+Phase 5.0 — Encryption End-to-End (sau soft launch June 2026).
 
-Detail: [`docs/current/phase-3.9/phase-3.9-detailed.md`](docs/current/phase-3.9/phase-3.9-detailed.md)
+Detail: [`docs/current/phase-4.3/phase-4.3-detailed.md`](docs/current/phase-4.3/phase-4.3-detailed.md)
 
 ## Active Breaking Changes
 
-(None currently — Phase 3.8.5 is additive over 3.8)
+(None currently — Phase 4.3 is additive over 4.2.5)
 
 When breaking changes are active, list them here with migration path. Move to `docs/archive/` once complete.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 ## 🎯 Current Status
 
 <!-- BEGIN: phase-status:current-line -->
-🚀 **Admin Observability** (current) — [detail](docs/current/phase-4.2.5/phase-4.2.5-detailed.md)
+📋 **Encryption End-to-End** (next) — [detail](#)
 <!-- END: phase-status:current-line -->
 
 <!-- BEGIN: phase-status:status-list -->
@@ -23,11 +23,23 @@
 - ✅ Phase 3.8: Wealth Completion
 - ✅ Phase 3.8.5: Pre-Launch Readiness
 - ✅ Phase 3.9: Market Data Real
-- 📋 Phase 4A: Financial Twin Conservative MVP ← **next**
+- ✅ Phase 3.9.5: Pre-Launch UX Polish
 - 🔮 Phase 3B: Market Intelligence
-- 🔮 Phase 4: Investment Intelligence
-- 🔮 Phase 5: Behavioral Engine
-- 🔮 Phase 6: Scale & Commercialize
+- ✅ Phase 4A: Financial Twin Conservative MVP
+- ✅ Phase 4B: Twin Polish + Life Events + Cashflow v2 + Zalo
+- ✅ Phase 4.1: Pre-Launch Hardening
+- ✅ Phase 4.2: Customer Experience Hardening
+- ✅ Phase 4.2.5: Admin Observability
+- ✅ Phase 4.3: Twin Enhancement + Habit Loop + Admin Dashboard
+- 📋 Phase 5.0: Encryption End-to-End ← **next**
+- 🔮 Phase 5.1: Zalo Spike & OA Verification
+- 🔮 Phase 5.2: Zalo Core Product Parity
+- 🔮 Phase 5.3: Zalo Mini App
+- 🔮 Phase 5.4: Achievement & Badges
+- 🔮 Phase 5.5: Behavioral Engine
+- 🔮 Phase 5.6: Household Mode
+- 🔮 Phase 5.7: Monetization Infrastructure
+- 🔮 Phase 6.0: Tết Launch (Public)
 <!-- END: phase-status:status-list -->
 
 
@@ -214,7 +226,7 @@ Base URL: `http://localhost:8000/api/v1`
 
 - 🎯 **[Product Strategy](docs/current/strategy.md)** — Vision, positioning, roadmap
 - 🔧 **[Technical Spec (CLAUDE.md)](CLAUDE.md)** — Full system design, đọc trước khi code
-- 📋 **[Current Phase (3A)](docs/current/phase-3a-detailed.md)** — Implementation guide
+- 📋 **[Latest Phase (4.3)](docs/current/phase-4.3/phase-4.3-detailed.md)** — Twin Enhancement + Habit Loop + Admin Dashboard
 - 📚 **[All docs](docs/README.md)** — Navigation hub
 - 📝 **[Migration Notes V1→V2](docs/archive/MIGRATION_NOTES.md)** — Context về pivot
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -7,12 +7,9 @@
 ## 🎯 Current Focus
 
 <!-- BEGIN: phase-status:current-block -->
-🚀 **Phase 3.7 — Agent Architecture** (3 tuần)
+📋 **Phase 5.0 — Encryption End-to-End** (~2-3 tuần)
 
-- 📖 Detailed doc: [docs/current/phase-3.7-detailed.md](docs/current/phase-3.7-detailed.md)
-- 📋 Issues: [docs/current/phase-3.7-issues.md](docs/current/phase-3.7-issues.md)
-- 📝 Scope: Two-tier agent (DB-Agent + Premium Reasoning), tool-use, orchestrator routing
-
+- 📝 Scope: Encryption infrastructure improvement; trust copy hiện không mention user-facing để tránh confuse user về commitment chưa ship. Ship as infra, not as feature.
 <!-- END: phase-status:current-block -->
 
 **Auto-sync:** This block is regenerated from
@@ -51,8 +48,9 @@ and the GitHub Action `sync-phase-status.yml` runs on every push.
 | Twin Polish + Life Events + Cashflow v2 + Zalo | ✅ done | ~4 tuần | [phase-4B-detailed.md](docs/current/phase-4B/phase-4B-detailed.md) | Life Event Simulator (mua nhà/kết hôn/con cái injected into MC paths), Cashflow Forecasting v2 (auto-detect recurring + low-balance alerts), Twin UX polish, Zalo OA adapter foundation |
 | Pre-Launch Hardening | ✅ done | ~3 tuần | [phase-4.1-detailed.md](docs/current/phase-4.1/phase-4.1-detailed.md) | Onboarding 3-step + first-Twin shortcut, cost guardrail per user, Sentry + KPI digest + feedback triage SLA, shareable Twin image, predictions-vs-actual calibration, 50-user soft launch playbook (June 2026) |
 | Customer Experience Hardening | ✅ done | ~2 tuần | [phase-4.2-detailed.md](docs/current/phase-4.2/phase-4.2-detailed.md) | CX-ready bridge: Trust card + financial data integrity, Next Best Action 9-CTA matrix + briefing content quality + query-first prompts, Day 7 positioning micro-survey + kill criterion update. 7 stories + 3 migrations + 3 deploy tasks. |
-| Admin Observability | 🚀 current | ~3 tuần | [phase-4.2.5-detailed.md](docs/current/phase-4.2.5/phase-4.2.5-detailed.md) | Admin dashboard (React + Vite + FastAPI) cho operator monitor soft launch: KPI hero, 6 charts (growth, DAU, intent breakdown, tier distribution, feature clicks, cohort retention), user directory với search/filter/PII mask, audit log, JWT auth + force_password_change, license placeholder cho Phase 5.7. 23 stories / 7 Epics / ~66 SP. Ship trước soft launch tháng 6/2026. |
-| Encryption End-to-End | 🔮 planned | TBD | — | Encryption infrastructure improvement; trust copy hiện không mention user-facing để tránh confuse user về commitment chưa ship. Ship as infra, not as feature. |
+| Admin Observability | ✅ done | ~3 tuần | [phase-4.2.5-detailed.md](docs/current/phase-4.2.5/phase-4.2.5-detailed.md) | Admin dashboard (React + Vite + FastAPI) cho operator monitor soft launch: KPI hero, 6 charts (growth, DAU, intent breakdown, tier distribution, feature clicks, cohort retention), user directory với search/filter/PII mask, audit log, JWT auth + force_password_change, license placeholder cho Phase 5.7. 23 stories / 7 Epics / ~66 SP. Ship trước soft launch tháng 6/2026. |
+| Twin Enhancement + Habit Loop + Admin Dashboard | ✅ done | ~3 tuần | [phase-4.3-detailed.md](docs/current/phase-4.3/phase-4.3-detailed.md) | Twin từ feature khó hiểu → habit-forming experience: weather metaphor (Khiêm tốn/Bình thường/Lạc quan) thay P10/P50/P90, life-outcome translation, story-first narrative (4-5 màn swipe), mascot personification, habit loop (on-demand recompute <5s + causality + action + negative delta + delta threshold + return tease), Twin admin dashboard 4 sections (engagement funnel, loop health, comprehension, delta distribution). 4 Epics / 15 stories. |
+| Encryption End-to-End | 📋 next | ~2-3 tuần | — | Encryption infrastructure improvement; trust copy hiện không mention user-facing để tránh confuse user về commitment chưa ship. Ship as infra, not as feature. |
 | Zalo Spike & OA Verification | 🔮 planned | TBD | — | Zalo OA verified business account, webhook + adapter spike, validate 300-char limit + no-Markdown constraints with real flows |
 | Zalo Core Product Parity | 🔮 planned | TBD | — | Toàn bộ product hiện tại trên Zalo: intent classifier, asset entry, Twin view, briefing, advisory — content layer adapted for Zalo constraints |
 | Zalo Mini App | 🔮 planned | TBD | — | Zalo Mini App equivalent của Telegram Mini App: Twin dashboard, portfolio view, interactive cone, initData verification trên Zalo SDK |

--- a/docs/current/phase-status.yaml
+++ b/docs/current/phase-status.yaml
@@ -37,7 +37,7 @@
 #   2. If you flip current_phase, set the previous phase's status to "done".
 #   3. Commit. The workflow updates all marker sections.
 
-current_phase: "4.2.5"
+current_phase: "5.0"
 
 phases:
   - id: "1"
@@ -192,18 +192,28 @@ phases:
 
   - id: "4.2.5"
     name: "Admin Observability"
-    status: current
+    status: done
     duration: "~3 tuần"
     detail_doc: "docs/current/phase-4.2.5/phase-4.2.5-detailed.md"
     issues_doc: "docs/current/phase-4.2.5/phase-4.2.5-issues.md"
     description: "Admin dashboard (React + Vite + FastAPI) cho operator monitor soft launch: KPI hero, 6 charts (growth, DAU, intent breakdown, tier distribution, feature clicks, cohort retention), user directory với search/filter/PII mask, audit log, JWT auth + force_password_change, license placeholder cho Phase 5.7. 23 stories / 7 Epics / ~66 SP. Ship trước soft launch tháng 6/2026."
-    completed_date: ""
-    icon: "🛠"
+    completed_date: "2026-05-26"
+    icon: "✅"
+
+  - id: "4.3"
+    name: "Twin Enhancement + Habit Loop + Admin Dashboard"
+    status: done
+    duration: "~3 tuần"
+    detail_doc: "docs/current/phase-4.3/phase-4.3-detailed.md"
+    issues_doc: "docs/current/phase-4.3/phase-4.3-issues.md"
+    description: "Twin từ feature khó hiểu → habit-forming experience: weather metaphor (Khiêm tốn/Bình thường/Lạc quan) thay P10/P50/P90, life-outcome translation, story-first narrative (4-5 màn swipe), mascot personification, habit loop (on-demand recompute <5s + causality + action + negative delta + delta threshold + return tease), Twin admin dashboard 4 sections (engagement funnel, loop health, comprehension, delta distribution). 4 Epics / 15 stories."
+    completed_date: "2026-05-29"
+    icon: "✅"
 
   - id: "5.0"
     name: "Encryption End-to-End"
-    status: planned
-    duration: "TBD"
+    status: next
+    duration: "~2-3 tuần"
     detail_doc: ""
     issues_doc: ""
     description: "Encryption infrastructure improvement; trust copy hiện không mention user-facing để tránh confuse user về commitment chưa ship. Ship as infra, not as feature."

--- a/docs/current/strategy.md
+++ b/docs/current/strategy.md
@@ -125,7 +125,8 @@ Twin appeals MOST to Level 1-2 — họ đang **building** tài sản → Twin s
 - Trajectory comparison (current vs optimal) (Phase 4A) ✅
 - Daily twin updates (Phase 4A) ✅
 - Life event simulation (Phase 4B) ✅
-- **Operator monitoring** layer (Phase 4.2.5 — in planning) để track Twin engagement với cohort
+- **Operator monitoring** layer (Phase 4.2.5) ✅ để track Twin engagement với cohort
+- **Twin habit loop + weather metaphor** (Phase 4.3) ✅ — Twin từ feature khó hiểu → habit-forming experience (Khiêm tốn/Bình thường/Lạc quan thay P10/P50/P90, story-first narrative, on-demand recompute, Twin admin dashboard)
 
 ### Trụ Cột 5 (Operational): Customer Experience & Trust ✅ DONE
 - Onboarding 3-step + first-Twin shortcut (Phase 4.1) ✅
@@ -249,8 +250,8 @@ CX-ready bridge giữa engineering readiness và cohort expansion:
 - Epic 3: Day 7 positioning micro-survey + kill criterion update
 - 7 stories + 3 migrations + 3 deploy tasks
 
-#### Phase 4.2.5: Admin Observability — 🔵 PLANNING (current)
-**Duration:** ~3 tuần | **Target ship:** Trước soft launch tháng 6/2026
+#### Phase 4.2.5: Admin Observability — ✅ DONE
+**Shipped:** 2026-05-26 | **Duration:** ~3 tuần
 
 Admin dashboard (React + Vite + FastAPI) cho operator/founder monitor soft launch:
 - KPI hero (DAU/MAU/stickiness/cost per user)
@@ -260,6 +261,16 @@ Admin dashboard (React + Vite + FastAPI) cho operator/founder monitor soft launc
 - License data model placeholder (activate ở Phase 5.7 cùng Pro launch)
 - 23 stories / 7 Epics / ~66 SP
 - Inserted để không phải query DB tay khi cohort scale 50 → 500
+
+#### Phase 4.3: Twin Enhancement + Habit Loop + Admin Dashboard — ✅ DONE
+**Shipped:** 2026-05-29 | **Duration:** ~3 tuần
+
+Twin từ feature khó hiểu → habit-forming experience (4 Epics / 15 stories):
+- **Epic 1 — Comprehension:** weather metaphor (🌧️ Khiêm tốn / ⛅ Bình thường / ☀️ Lạc quan) thay P10/P50/P90, life-outcome translation
+- **Epic 2 — Story-first narrative:** 4-5 màn swipe story + mascot personification thay vì bày số liệu
+- **Epic 3 — Habit loop:** on-demand recompute (<5s) + causality + action prompt + negative delta handling + delta threshold + return tease
+- **Epic 4 — Twin admin dashboard:** engagement funnel, loop health, comprehension, delta distribution (4 sections)
+- **Roadmap impact:** Phase 5.0 (Encryption) lùi ~3 tuần; timeline soft launch tháng 6/2026 vẫn an toàn.
 
 **🎉 Tháng 6 SOFT LAUNCH** với foundation complete:
 - 50 founding member (50% lifetime discount khi Pro ra mắt — commitment honored)
@@ -494,6 +505,24 @@ Following decisions made during strategic review (May 2026):
 - Phase 5.0 (Encryption) push back ~3 tuần.
 - License placeholder ship sớm tránh migration đau đầu khi Phase 5.7 activate Pro tier.
 
+### Phase 4.3 Insertion (May 2026, post-Phase-4.2.5)
+
+**Decision:** Insert Phase 4.3 (Twin Enhancement + Habit Loop + Admin Dashboard) giữa Phase 4.2.5 và Phase 5.0.
+
+**Reason:** Financial Twin là *the differentiator* nhưng probability cone (P10/P50/P90) quá khó hiểu với mass-affluent user — risk là wow-factor không convert thành habit. Trước soft launch tháng 6 cần biến Twin từ feature "đọc một lần rồi thôi" → trải nghiệm kéo người dùng quay lại hàng tuần.
+
+**Scope:**
+- 4 Epics, 15 stories, ~3 tuần
+- Epic 1 — Comprehension: weather metaphor (🌧️ Khiêm tốn / ⛅ Bình thường / ☀️ Lạc quan) thay P10/P50/P90 + life-outcome translation
+- Epic 2 — Story-first narrative: 4-5 màn swipe story + mascot personification
+- Epic 3 — Habit loop: on-demand recompute (<5s) + causality + action prompt + negative delta + delta threshold + return tease
+- Epic 4 — Twin admin dashboard: engagement funnel, loop health, comprehension, delta distribution (4 sections)
+
+**Roadmap impact:**
+- Phase 4.2.5 ✅ Done (2026-05-26), Phase 4.3 ✅ Done (2026-05-29).
+- Phase 5.0 (Encryption) lùi thêm ~3 tuần.
+- Soft launch tháng 6/2026 vẫn an toàn — habit loop chính là leverage cho cohort retention từ ngày đầu.
+
 ---
 
 ## 📝 Changelog
@@ -505,6 +534,7 @@ Following decisions made during strategic review (May 2026):
 - Phase 3B/4/5/6 substantially redefined
 - Cashflow forecasting roadmap added (v1 → v2 → v3 progression)
 - Pivot rationale documented in [MIGRATION_NOTES_V2_V3.md](../archive/MIGRATION_NOTES_V2_V3.md)
+- **2026-05-29:** Phase 4.2.5 (Admin Observability) ✅ + Phase 4.3 (Twin Enhancement + Habit Loop) ✅ shipped. Next focus: Phase 5.0 (Encryption End-to-End) sau soft launch tháng 6.
 
 **V2:** [archived](../archive/strategy-v2.md) — Pivot to Personal CFO positioning (wealth-first instead of expense-first)
 

--- a/scripts/sync_phase_status.py
+++ b/scripts/sync_phase_status.py
@@ -2,11 +2,17 @@
 """
 Sync phase status from docs/current/phase-status.yaml to marker sections in target files.
 
-This script renders two types of marker sections:
+This script renders four types of marker sections:
 - `phase-status:current-line`: a single-line summary of the active phase
+- `phase-status:current-block`: a multi-line block (id, name, docs, scope)
+- `phase-status:status-list`: a bullet list of every phase, flagging the active one
 - `phase-status:roadmap-table`: a full markdown table of all phases
 
-Files can opt-in to either marker by including the BEGIN/END comments.
+The "active phase" is resolved from ``current_phase`` in the YAML (so a
+phase with status ``next`` is shown once dev finishes the prior phase),
+falling back to the first phase with status ``current``/``testing``.
+
+Files can opt-in to any marker by including the BEGIN/END comments.
 Files without a marker are skipped silently (no error).
 
 Also seeds a ``<!-- testing-signoff: need to be signed -->`` marker into any
@@ -60,6 +66,8 @@ TARGET_FILES = [
 
 CURRENT_LINE_MARKER = "phase-status:current-line"
 ROADMAP_TABLE_MARKER = "phase-status:roadmap-table"
+STATUS_LIST_MARKER = "phase-status:status-list"
+CURRENT_BLOCK_MARKER = "phase-status:current-block"
 
 # Map phase status → emoji used in rendered output.
 STATUS_EMOJI = {
@@ -91,8 +99,20 @@ def load_phase_status() -> dict:
     return data
 
 
-def find_active_phase(phases: list) -> dict | None:
-    """Find the phase that's currently being worked on (status: current or testing)."""
+def find_active_phase(data: dict) -> dict | None:
+    """Find the phase the team is focused on.
+
+    Resolution order:
+      1. The phase whose ``id`` matches ``current_phase`` (the schema's
+         declared focus — works for ``current``, ``testing`` *and* ``next``).
+      2. Fallback: first phase with status ``current`` then ``testing``.
+    """
+    phases = data["phases"]
+    current_id = data.get("current_phase")
+    if current_id is not None:
+        for phase in phases:
+            if str(phase.get("id")) == str(current_id):
+                return phase
     # Priority: 'current' > 'testing' (if both, pick first 'current')
     for status_priority in ("current", "testing"):
         for phase in phases:
@@ -103,16 +123,57 @@ def find_active_phase(phases: list) -> dict | None:
 
 def render_current_line(data: dict) -> str:
     """Render the active phase as a single line."""
-    active = find_active_phase(data["phases"])
+    active = find_active_phase(data)
     if not active:
         return "_(No active phase — all phases done or planned)_"
 
     emoji = STATUS_EMOJI.get(active["status"], "📌")
     name = active.get("name", active.get("id", "Unnamed phase"))
     status_label = active["status"]
-    detail_doc = active.get("detail_doc", "#")
+    detail_doc = active.get("detail_doc") or "#"
 
     return f"{emoji} **{name}** ({status_label}) — [detail]({detail_doc})"
+
+
+def render_current_block(data: dict) -> str:
+    """Render the active phase as a multi-line block (id, name, docs, scope)."""
+    active = find_active_phase(data)
+    if not active:
+        return "_(No active phase — all phases done or planned)_"
+
+    emoji = STATUS_EMOJI.get(active["status"], "📌")
+    phase_id = active.get("id", "?")
+    name = active.get("name", "Unnamed phase")
+    duration = active.get("duration", "TBD")
+    description = active.get("description", "TODO")
+
+    lines = [f"{emoji} **Phase {phase_id} — {name}** ({duration})", ""]
+
+    detail_doc = active.get("detail_doc")
+    if detail_doc:
+        lines.append(f"- 📖 Detailed doc: [{detail_doc}]({detail_doc})")
+    issues_doc = active.get("issues_doc")
+    if issues_doc:
+        lines.append(f"- 📋 Issues: [{issues_doc}]({issues_doc})")
+    lines.append(f"- 📝 Scope: {description}")
+
+    return "\n".join(lines)
+
+
+def render_status_list(data: dict) -> str:
+    """Render every phase as a bullet list, flagging the active one."""
+    current_id = data.get("current_phase")
+    lines = []
+    for phase in data["phases"]:
+        emoji = STATUS_EMOJI.get(phase["status"], "📌")
+        phase_id = phase.get("id", "?")
+        name = phase.get("name", "Unnamed")
+        line = f"- {emoji} Phase {phase_id}: {name}"
+        if current_id is not None and str(phase.get("id")) == str(current_id):
+            flag = "current" if phase.get("status") in ("current", "testing") else "next"
+            line += f" ← **{flag}**"
+        lines.append(line)
+    return "\n".join(lines)
 
 
 def render_roadmap_table(data: dict) -> str:
@@ -159,10 +220,12 @@ def update_marker(content: str, marker_id: str, new_content: str) -> tuple[str, 
     return pattern.sub(rf"\1{new_content}\2", content), True
 
 
-def sync_file(path: Path, current_line: str, roadmap_table: str, dry_run: bool = False) -> bool:
+def sync_file(path: Path, rendered: dict[str, str], dry_run: bool = False) -> bool:
     """
     Update markers in a single file. Returns True if file was changed.
     Skips silently if file doesn't exist or no markers present.
+
+    ``rendered`` maps marker_id → rendered content for every supported marker.
     """
     rel_path = path.relative_to(REPO_ROOT)
 
@@ -173,34 +236,26 @@ def sync_file(path: Path, current_line: str, roadmap_table: str, dry_run: bool =
     content = path.read_text(encoding="utf-8")
     original = content
 
-    content, current_found = update_marker(content, CURRENT_LINE_MARKER, current_line)
-    content, roadmap_found = update_marker(content, ROADMAP_TABLE_MARKER, roadmap_table)
+    found_markers = []
+    for marker_id, new_content in rendered.items():
+        content, found = update_marker(content, marker_id, new_content)
+        if found:
+            # short label = part after the colon
+            found_markers.append(marker_id.split(":", 1)[-1])
 
-    if not (current_found or roadmap_found):
+    if not found_markers:
         print(f"  SKIP: {rel_path} (no markers found)")
         return False
 
     if content == original:
-        markers = []
-        if current_found:
-            markers.append("current-line")
-        if roadmap_found:
-            markers.append("roadmap-table")
-        print(f"  UNCHANGED: {rel_path} (markers: {', '.join(markers)})")
+        print(f"  UNCHANGED: {rel_path} (markers: {', '.join(found_markers)})")
         return False
 
-    if dry_run:
-        print(f"  WOULD UPDATE: {rel_path}")
-    else:
+    if not dry_run:
         path.write_text(content, encoding="utf-8")
 
-    markers_updated = []
-    if current_found:
-        markers_updated.append("current-line")
-    if roadmap_found:
-        markers_updated.append("roadmap-table")
     action = "WOULD UPDATE" if dry_run else "✓ UPDATED"
-    print(f"  {action}: {rel_path} (markers: {', '.join(markers_updated)})")
+    print(f"  {action}: {rel_path} (markers: {', '.join(found_markers)})")
     return True
 
 
@@ -255,11 +310,15 @@ def main():
     args = parser.parse_args()
 
     data = load_phase_status()
-    current_line = render_current_line(data)
-    roadmap_table = render_roadmap_table(data)
+    rendered = {
+        CURRENT_LINE_MARKER: render_current_line(data),
+        ROADMAP_TABLE_MARKER: render_roadmap_table(data),
+        STATUS_LIST_MARKER: render_status_list(data),
+        CURRENT_BLOCK_MARKER: render_current_block(data),
+    }
 
     print(f"Phase status source: {PHASE_STATUS_FILE.relative_to(REPO_ROOT)}")
-    print(f"Active phase line: {current_line}")
+    print(f"Active phase line: {rendered[CURRENT_LINE_MARKER]}")
     print(f"Total phases in roadmap: {len(data['phases'])}")
     print()
 
@@ -273,7 +332,7 @@ def main():
 
     any_updated = False
     for target in TARGET_FILES:
-        if sync_file(target, current_line, roadmap_table, dry_run=args.dry_run):
+        if sync_file(target, rendered, dry_run=args.dry_run):
             any_updated = True
 
     print()


### PR DESCRIPTION
## Tóm tắt

Cập nhật tiến độ & roadmap sau khi **Phase 4.3** (Twin Enhancement + Habit Loop + Admin Dashboard) hoàn thành, đồng thời **hoàn thiện flow tự động sync trạng thái** vốn đang bị thiếu.

## Thay đổi

### Source of truth — `docs/current/phase-status.yaml`
- Phase **4.2.5** Admin Observability → `done` (2026-05-26)
- Thêm Phase **4.3** Twin Enhancement + Habit Loop + Admin Dashboard → `done` (2026-05-29), 4 Epics / 15 stories
- Phase **5.0** Encryption End-to-End → `next` (~2-3 tuần); `current_phase: "5.0"`

### Sửa flow auto-sync — `scripts/sync_phase_status.py`
Trước đây script chỉ render 2/4 marker đang dùng trong repo → `status-list` (README.md) và `current-block` (docs/README.md) bị drift (docs/README còn hiển thị Phase 3.7 là current).
- Render đủ **cả 4 marker**: `current-line`, `current-block`, `status-list`, `roadmap-table`
- `find_active_phase` resolve theo `current_phase` id trước → phase status `next` cũng surface đúng

### Prose thủ công
- **CLAUDE.md**: thay section "Phase 3.9 DONE" → "Phase 4.3 DONE", cập nhật Documentation References + Active Breaking Changes
- **README.md**: link "Latest Phase (4.3)" (thay link 3A đã chết)
- **strategy.md**: Trụ Cột 4, roadmap headings 4.2.5/4.3, Decisions Log entry + Changelog

## Trả lời "nếu cần update tiến độ thì sửa ở đâu?"

1. **Chỉ cần sửa 1 file:** `docs/current/phase-status.yaml` — đổi `status`, `completed_date`, `current_phase`. Đây là single source of truth.
2. GitHub Action `sync-phase-status.yml` (chạy mỗi lần push đụng file đó) sẽ tự cập nhật **4 vùng marker** trong CLAUDE.md / README.md / docs/README.md. Chạy tay: `python scripts/sync_phase_status.py`.
3. **Phần KHÔNG auto-sync** (phải sửa tay): prose tự do trong `strategy.md`, section "Phase X DONE" trong CLAUDE.md, link doc trong README.

https://claude.ai/code/session_015J8o2avTXj86mhXWJH1EuG