### PR TITLE
Fix credit-card debt direction on edit/reverse + deterministic "latest" ordering

### DIFF
--- a/backend/services/expense_service.py
+++ b/backend/services/expense_service.py
@@ -52,11 +52,26 @@ async def _adjust_source_asset(
     db: AsyncSession, expense: Expense, multiplier: int = 1
 ) -> None:
     if expense.source_type == "credit_card" and expense.source_credit_card_id:
-        card = await db.get(CreditCard, expense.source_credit_card_id)
-        if card is not None and card.user_id == expense.user_id:
-            card.debt_balance = Decimal(card.debt_balance or 0) + (
-                Decimal(str(expense.amount or 0)) * multiplier
+        # Lock the card row so concurrent edits/reverses can't race on the
+        # debt balance (same SELECT … FOR UPDATE guard the asset branch uses).
+        stmt = (
+            select(CreditCard)
+            .where(
+                CreditCard.id == expense.source_credit_card_id,
+                CreditCard.user_id == expense.user_id,
             )
+            .with_for_update()
+        )
+        card = (await db.execute(stmt)).scalar_one_or_none()
+        if card is not None:
+            # Debt moves opposite to a cash/bank balance: an expense charged
+            # to the card *raises* debt, a money_in (refund/repayment) *lowers*
+            # it. ``_source_asset_delta`` already encodes direction (expense =
+            # −amount, money_in = +amount), so negate it for the debt side.
+            card.debt_balance = Decimal(card.debt_balance or 0) + (
+                -_source_asset_delta(expense) * multiplier
+            )
+            card.updated_at = datetime.utcnow()
         return
     if not expense.source_asset_id:
         return
@@ -441,7 +456,19 @@ async def list_expenses(
         stmt = stmt.where(Expense.category == category)
     if transaction_type:
         stmt = stmt.where(Expense.transaction_type == transaction_type)
-    stmt = stmt.order_by(Expense.expense_date.desc()).limit(limit).offset(offset)
+    # ``expense_date`` is day-precision (user-provided date), so two rows on
+    # the same day would tie. Break the tie by ``created_at`` (second-precision
+    # insert time) then ``id`` so ordering — and "latest transaction" lookups —
+    # are deterministic.
+    stmt = (
+        stmt.order_by(
+            Expense.expense_date.desc(),
+            Expense.created_at.desc(),
+            Expense.id.desc(),
+        )
+        .limit(limit)
+        .offset(offset)
+    )
     result = await db.execute(stmt)
     return list(result.scalars().all())
 

--- a/backend/services/income_service.py
+++ b/backend/services/income_service.py
@@ -79,7 +79,17 @@ async def list_incomes(
         stmt = stmt.where(IncomeRecord.period >= period_from)
     if period_to:
         stmt = stmt.where(IncomeRecord.period <= period_to)
-    stmt = stmt.order_by(IncomeRecord.period.desc()).limit(limit).offset(offset)
+    # ``period`` is day-precision; tie-break by ``created_at`` (second-precision
+    # insert time) then ``id`` so "latest income" lookups are deterministic.
+    stmt = (
+        stmt.order_by(
+            IncomeRecord.period.desc(),
+            IncomeRecord.created_at.desc(),
+            IncomeRecord.id.desc(),
+        )
+        .limit(limit)
+        .offset(offset)
+    )
     result = await db.execute(stmt)
     return list(result.scalars().all())
 

--- a/backend/wealth/services/asset_service.py
+++ b/backend/wealth/services/asset_service.py
@@ -167,7 +167,10 @@ async def get_user_assets(
         stmt = stmt.where(Asset.is_placeholder_asset.is_(False), Asset.is_confirmed.is_(True))
     if asset_type is not None:
         stmt = stmt.where(Asset.asset_type == asset_type)
-    stmt = stmt.order_by(Asset.created_at.desc())
+    # ``created_at`` is second-precision; add ``id`` as a final tiebreaker so
+    # two assets created in the same second still order deterministically
+    # ("latest asset" lookups must be unambiguous).
+    stmt = stmt.order_by(Asset.created_at.desc(), Asset.id.desc())
     return list((await db.execute(stmt)).scalars().all())
 
 

--- a/tests/test_expense_transaction_logic.py
+++ b/tests/test_expense_transaction_logic.py
@@ -1,5 +1,6 @@
 import uuid
 from datetime import datetime
+from decimal import Decimal
 from types import SimpleNamespace
 
 import pytest
@@ -32,6 +33,46 @@ class FakeDB:
 
     async def get(self, _model, _id):
         return None
+
+
+def _make_card(debt="100000"):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        debt_balance=Decimal(debt),
+        updated_at=None,
+    )
+
+
+def _make_asset(user_id, value="1000000"):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        current_value=Decimal(value),
+        last_valued_at=None,
+    )
+
+
+def _expense_on_card(card, *, amount, transaction_type):
+    return SimpleNamespace(
+        user_id=card.user_id,
+        source_type="credit_card",
+        source_credit_card_id=card.id,
+        source_asset_id=None,
+        amount=amount,
+        transaction_type=transaction_type,
+    )
+
+
+def _expense_on_asset(asset, *, source_type, amount, transaction_type):
+    return SimpleNamespace(
+        user_id=asset.user_id,
+        source_type=source_type,
+        source_credit_card_id=None,
+        source_asset_id=asset.id,
+        amount=amount,
+        transaction_type=transaction_type,
+    )
 
 
 @pytest.mark.asyncio
@@ -118,24 +159,127 @@ async def test_update_expense_marks_old_tx_edited_and_creates_new(monkeypatch):
     assert created.get("edited_at") is not None
 
 
+# ---------------------------------------------------------------------------
+# Credit-card debt adjustments — direction must be honoured.
+# ---------------------------------------------------------------------------
+
+
 @pytest.mark.asyncio
-async def test_adjust_source_asset_credit_card_increases_debt():
-    card = SimpleNamespace(id=uuid.uuid4(), user_id=uuid.uuid4(), debt_balance=100000)
-    expense = SimpleNamespace(
-        user_id=card.user_id,
-        source_type="credit_card",
-        source_credit_card_id=card.id,
-        amount=250000,
-        source_asset_id=None,
-    )
-    db = FakeDB()
+async def test_adjust_credit_card_expense_increases_debt():
+    """An expense charged to a credit card raises the debt balance."""
+    card = _make_card("100000")
+    expense = _expense_on_card(card, amount=250000, transaction_type="expense")
+    db = FakeDB([card])
 
-    async def _get(_model, _id):
-        return card
-
-    db.get = _get
     await expense_service._adjust_source_asset(db, expense, multiplier=1)
-    assert float(card.debt_balance) == 350000
+
+    assert card.debt_balance == Decimal("350000")
+    assert card.updated_at is not None
+
+
+@pytest.mark.asyncio
+async def test_adjust_credit_card_money_in_decreases_debt():
+    """A money_in (refund/repayment) on a credit card lowers the debt.
+
+    This is the regression guard for the original bug, where money_in
+    wrongly *increased* the debt because direction was ignored.
+    """
+    card = _make_card("500000")
+    expense = _expense_on_card(card, amount=200000, transaction_type="money_in")
+    db = FakeDB([card])
+
+    await expense_service._adjust_source_asset(db, expense, multiplier=1)
+
+    assert card.debt_balance == Decimal("300000")
+
+
+@pytest.mark.asyncio
+async def test_adjust_credit_card_expense_reverse_restores_debt():
+    """Reversing an expense (multiplier=-1) undoes the debt increase."""
+    card = _make_card("350000")
+    expense = _expense_on_card(card, amount=250000, transaction_type="expense")
+    db = FakeDB([card])
+
+    await expense_service._adjust_source_asset(db, expense, multiplier=-1)
+
+    assert card.debt_balance == Decimal("100000")
+
+
+@pytest.mark.asyncio
+async def test_adjust_credit_card_money_in_reverse_restores_debt():
+    card = _make_card("300000")
+    expense = _expense_on_card(card, amount=200000, transaction_type="money_in")
+    db = FakeDB([card])
+
+    await expense_service._adjust_source_asset(db, expense, multiplier=-1)
+
+    assert card.debt_balance == Decimal("500000")
+
+
+@pytest.mark.asyncio
+async def test_adjust_credit_card_skips_other_user():
+    """A card owned by a different user must not be mutated."""
+    card = _make_card("100000")
+    expense = _expense_on_card(card, amount=250000, transaction_type="expense")
+    expense.user_id = uuid.uuid4()  # different owner
+    # The owner-scoped SELECT returns nothing → no card row.
+    db = FakeDB([None])
+
+    await expense_service._adjust_source_asset(db, expense, multiplier=1)
+
+    assert card.debt_balance == Decimal("100000")
+
+
+# ---------------------------------------------------------------------------
+# Asset-backed sources (cash / bank_account / e_wallet) — balance moves with
+# direction: expense lowers the balance, money_in raises it.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("source_type", ["cash", "bank_account", "e_wallet"])
+@pytest.mark.asyncio
+async def test_adjust_asset_expense_decreases_balance(source_type):
+    user_id = uuid.uuid4()
+    asset = _make_asset(user_id, "1000000")
+    expense = _expense_on_asset(
+        asset, source_type=source_type, amount=300000, transaction_type="expense"
+    )
+    db = FakeDB([asset])
+
+    await expense_service._adjust_source_asset(db, expense, multiplier=1)
+
+    assert asset.current_value == Decimal("700000")
+    assert asset.last_valued_at is not None
+
+
+@pytest.mark.parametrize("source_type", ["cash", "bank_account", "e_wallet"])
+@pytest.mark.asyncio
+async def test_adjust_asset_money_in_increases_balance(source_type):
+    user_id = uuid.uuid4()
+    asset = _make_asset(user_id, "1000000")
+    expense = _expense_on_asset(
+        asset, source_type=source_type, amount=300000, transaction_type="money_in"
+    )
+    db = FakeDB([asset])
+
+    await expense_service._adjust_source_asset(db, expense, multiplier=1)
+
+    assert asset.current_value == Decimal("1300000")
+
+
+@pytest.mark.parametrize("source_type", ["cash", "bank_account", "e_wallet"])
+@pytest.mark.asyncio
+async def test_adjust_asset_expense_reverse_restores_balance(source_type):
+    user_id = uuid.uuid4()
+    asset = _make_asset(user_id, "700000")
+    expense = _expense_on_asset(
+        asset, source_type=source_type, amount=300000, transaction_type="expense"
+    )
+    db = FakeDB([asset])
+
+    await expense_service._adjust_source_asset(db, expense, multiplier=-1)
+
+    assert asset.current_value == Decimal("1000000")
 
 
 @pytest.mark.asyncio

--- a/tests/test_expense_transaction_logic.py
+++ b/tests/test_expense_transaction_logic.py
@@ -282,6 +282,84 @@ async def test_adjust_asset_expense_reverse_restores_balance(source_type):
     assert asset.current_value == Decimal("1000000")
 
 
+# ---------------------------------------------------------------------------
+# Edit flow that switches the funding source AND changes the amount in one go.
+# The double-entry (reverse old source, then apply new source) must refund the
+# original amount to the OLD asset and debit the NEW amount from the NEW asset.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_update_expense_switch_ewallet_to_bank_with_amount_change(monkeypatch):
+    """Edit a 300k e-wallet expense into a 500k bank-account expense.
+
+    Expected: the e-wallet is refunded the *original* 300k (reverse of an
+    expense adds the amount back) and the bank account is debited the *new*
+    500k. Both run through the same asset branch of ``_adjust_source_asset``.
+    """
+    user_id = uuid.uuid4()
+    ewallet_asset = _make_asset(user_id, "1000000")
+    bank_asset = _make_asset(user_id, "5000000")
+
+    expense = SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=user_id,
+        amount=300000,
+        transaction_type="expense",
+        source="manual",
+        source_asset_id=ewallet_asset.id,
+        source_credit_card_id=None,
+        source_type="e_wallet",
+        e_wallet_provider="momo",
+        raw_data=None,
+        expense_date=datetime.utcnow().date(),
+        category="food_drink",
+        currency="VND",
+        merchant="cafe",
+        note="n",
+        needs_review=False,
+        month_key="2026-05",
+    )
+
+    async def _get_expense(_db, _uid, _eid):
+        return expense
+
+    async def _resolve(_db, _uid, _data):
+        # Mirror the resolver picking the requested bank asset for the new source.
+        return expense_service.SourceResolution(
+            bank_asset.id, None, None, "bank_account", None
+        )
+
+    async def _latest(_db, _eid):
+        return None
+
+    async def _create(_db, _uid, _expense, **kwargs):
+        return SimpleNamespace(id=uuid.uuid4())
+
+    monkeypatch.setattr(expense_service, "get_expense", _get_expense)
+    monkeypatch.setattr(expense_service, "resolve_source_asset_for_payload", _resolve)
+    monkeypatch.setattr(expense_service, "_latest_active_transaction", _latest)
+    monkeypatch.setattr(expense_service, "_create_transaction_record", _create)
+
+    # execute() queue order: (1) reverse on OLD e-wallet, (2) apply on NEW bank.
+    db = FakeDB([ewallet_asset, bank_asset])
+
+    payload = expense_service.ExpenseUpdate(
+        amount=500000, source_type="bank_account", source_asset_id=bank_asset.id
+    )
+    got = await expense_service.update_expense(db, user_id, expense.id, payload)
+
+    assert got is expense
+    # OLD e-wallet refunded the ORIGINAL amount: 1,000,000 + 300,000.
+    assert ewallet_asset.current_value == Decimal("1300000")
+    # NEW bank account debited the NEW amount: 5,000,000 − 500,000.
+    assert bank_asset.current_value == Decimal("4500000")
+    # Expense itself now points at the new source/amount.
+    assert expense.source_asset_id == bank_asset.id
+    assert expense.source_type == "bank_account"
+    assert expense.amount == 500000
+
+
 @pytest.mark.asyncio
 async def test_resolve_source_asset_for_payload_credit_card_invalid_owner(monkeypatch):
     user_id = uuid.uuid4()


### PR DESCRIPTION
Close #901

## What & why

Audit + fix of transaction balance logic across all four funding-source types, plus deterministic ordering so "most-recent transaction / asset" lookups are reliable.

### 1. Credit-card debt ignored transaction direction (correctness bug)

`expense_service._adjust_source_asset` adjusted credit-card `debt_balance` by `amount * multiplier`, **ignoring transaction direction**. A `money_in` (refund/repayment) on a credit card therefore wrongly **increased** the debt. The asset branch (cash/bank/e-wallet) already encoded direction via `_source_asset_delta`; the credit-card branch did not, and it skipped the `SELECT … FOR UPDATE` row lock the asset branch uses.

**Fix:** debt moves opposite to a cash/bank balance — `debt_balance += -_source_asset_delta(expense) * multiplier`:
- expense → debt **+amount**
- money_in → debt **−amount**
- reverse (`multiplier=-1`) restores the prior balance

…and the card row is now locked with `SELECT … FOR UPDATE`.

Both edit entry points — the **Expense Dashboard miniapp** (`PATCH /miniapp/api/expenses/{id}`) and **Telegram message edits** — funnel through `update_expense` / `delete_expense`, which already reverse-then-reapply via `_adjust_source_asset`. So this one centralized fix covers both surfaces for **Tiền mặt**, **Ví điện tử**, **Thẻ tín dụng** (số dư nợ), and **Tài khoản thanh toán**.

### 2. Ambiguous "latest" ordering

Storage was already second-precision (`DateTime(timezone=True)`); the gap was in `ORDER BY` clauses that sorted on day-precision date columns alone:
- `list_expenses`: now `expense_date DESC, created_at DESC, id DESC`
- `list_incomes`: now `period DESC, created_at DESC, id DESC`
- asset listing: added `id` tie-breaker after `created_at DESC`

No Alembic migration needed — columns already carry second precision.

## Layer contract

No `db.commit()` added to the service layer; routers/workers/miniapp still own the transaction boundary. Money stays `Decimal` throughout.

## Tests

`tests/test_expense_transaction_logic.py` extended to cover edit/reverse for **cash, bank_account, e_wallet** (parametrized) and **credit_card**, including the **credit-card money_in regression** (debt decreases) and an owner-scoping guard.

```
$ python -m pytest tests/test_expense_transaction_logic.py tests/test_credit_card_service.py -q
22 passed
$ ruff check <changed files>
All checks passed!
```