### PR TITLE
docs: June soft-launch runbook (technical + business/go-to-market)

### DIFF
--- a/docs/current/soft-launch-runbook.md
+++ b/docs/current/soft-launch-runbook.md
@@ -1,0 +1,247 @@
+# Soft Launch Runbook — Tháng 6/2026 (50 Founding Members)
+
+> **Mục đích:** một nơi duy nhất để chạy ngày launch. Gom checklist kỹ thuật,
+> vận hành và **business / go-to-market** (seeding message, kênh, lịch phát
+> invite). Tick trực tiếp trên file này.
+>
+> **Nguồn tổng hợp:** `phase-4.1/deploy-checklist.md`, `phase-4.1/success-metrics.md`,
+> `phase-4.1/phase-4.1-detailed.md` (Epic C playbook), `founding-promise.md`,
+> `phase-4.2.5/phase-4.2.5-detailed.md`, `phase-4.3/phase-4.3-deploy-announcement.md`.
+>
+> **Status code đến launch:** Phase 4.1 → 4.3 đã `done`. Phần còn lại là
+> **verify + vận hành**, KHÔNG phải code feature mới.
+
+---
+
+## 0. Lưu ý positioning (đọc trước khi viết bất kỳ message nào)
+
+- **KHÔNG** dùng "Personal CFO" / "CFO" trong bất kỳ text nào người dùng đọc
+  (welcome, seeding post, announcement, share image). Dùng **"người đồng hành
+  quản lý tài sản"** / **"trợ lý tài chính cá nhân"**.
+- Persona **Bé Tiền**: ấm áp, đồng hành, không phán xét chi tiêu. Đọc to —
+  nếu nghe sượng hoặc "robot", viết lại.
+- ⚠️ **Cần verify:** spec cũ (`phase-4.1-detailed.md:466`) có copy welcome
+  cho source `vn_finance_community` ghi *"Bé Tiền là Personal CFO..."* — phải
+  kiểm tra `content/onboarding/welcome_v2.yaml` đã sửa thành "người đồng hành
+  quản lý tài sản" chưa. (Xem mục 3.)
+
+---
+
+## 1. Kỹ thuật — Verify trên staging (T-7 → T-3)
+
+- [ ] `alembic upgrade head` chạy sạch; xác nhận 4 migration Phase 4.1 có mặt
+      (`user_cost_budgets`, `feedback_sla`, `twin_calibration`, `founding_member`)
+- [ ] Spot-check bảng tồn tại: `invite_codes`, `onboarding_sessions`,
+      `user_cost_budgets`, `twin_calibration_snapshots`
+- [ ] Cost report + KPI digest 08:00 ICT chạy đủ **3 ngày liên tiếp** trên staging
+- [ ] Sentry test exception xuất hiện kèm `user_id` hash + intent context;
+      PII (số >6 chữ số, email, phone) bị scrub
+- [ ] `vi-localization-checker` pass: không có string tiếng Việt hardcode;
+      content YAML đủ 4 wealth level; persona Bé Tiền nhất quán
+
+### Gate Zalo — CRITICAL (3 lớp phòng thủ)
+
+- [ ] Code gate `if settings.zalo_channel_enabled:` quanh Zalo router, default `False`
+- [ ] Prod `.env`: `ZALO_CHANNEL_ENABLED=false` (operator + dev xác nhận **cùng nhau**)
+- [ ] `curl -sI https://<prod>/api/v1/zalo/webhook` → 404/405
+- [ ] Log boot in đúng string `"Zalo channel disabled (ZALO_CHANNEL_ENABLED=false)..."`
+- [ ] Zalo OA console: webhook URL để trống (belt + braces)
+
+---
+
+## 2. Vận hành & dogfood (T-3)
+
+- [ ] **Operator tự dogfood toàn flow từ cả 5 source** (`friends`, `personal_fb`,
+      `vn_finance_community`, `direct_msg`, `tg_finance_groups`):
+      `/start` → goal → first asset → narrative → cone → nút 😍 → completion.
+      **Đo time-to-first-Twin (<5 phút).**
+- [ ] Briefing sáng hôm sau có explainer + nút "💡 Bé Tiền đang nói gì?"
+- [ ] Demo mode: skip asset → banner "📌 Demo Mode..." → "Xem Twin của tôi" → quay lại asset entry
+- [ ] Resume nudge: drop ở step 2, chờ 10 phút → nhận đúng **1 nudge** (không trùng)
+- [ ] Operator gửi `/feedback` → `/feedback_inbox` thấy row có cờ 🌱 → reply bằng template
+- [ ] Test SLA: để 1 feedback >24h → worker alert bắn **đúng 1 lần**
+- [ ] **Xoá sạch test account** khỏi `invite_codes` + `users` để không chiếm seat founding
+
+---
+
+## 3. Content & localization cần verify
+
+- [ ] `content/onboarding/welcome_v2.yaml`: copy source-aware đủ 5 variant; **không
+      có "Personal CFO"** (xem mục 0)
+- [ ] `content/onboarding/founding_welcome.yaml`: banner `#N` + 50% trọn đời + bản `cap_reached`
+- [ ] Briefing #1 explainer string
+- [ ] 5 template feedback triage: `thanks_logged`, `clarify_request`,
+      `feature_acknowledged`, `bug_apology`, `not_supported_yet`
+
+---
+
+## 4. Founding member — sinh 50 invite (T-3 → T-1)
+
+- [ ] Chạy `scripts/soft_launch_acquisition.py --batch soft-launch-2026-06`
+- [ ] Verify đúng **50 row**, **10/source × 5 source**, tất cả `grants_founding_status=TRUE`:
+      ```sql
+      SELECT COUNT(*), source FROM invite_codes
+      WHERE batch_name='soft-launch-2026-06' GROUP BY source;
+      ```
+- [ ] Test redeem 1 invite (account sạch) → banner Founding Member `#1` + 50% trọn đời;
+      DB set `redeemed_by_user_id`, `redeemed_at`
+- [ ] **Race test:** redeem 5 invite song song → sequence 1–5 distinct, không trùng/nhảy số
+- [ ] CSV invite chuyển sang folder private, **KHÔNG commit vào git**;
+      operator mở 3 row random ở trình duyệt ẩn danh để kiểm
+
+---
+
+## 5. T-0 (sáng launch)
+
+- [ ] Lặp lại verify gate Zalo (mục 1) trên **production**
+- [ ] KPI digest 08:00 ICT tới hộp operator
+- [ ] Sentry test exception trên prod OK
+- [ ] `git tag v4.1.0-soft-launch && git push --tags`
+- [ ] Gửi announcement Phase 4.3 lúc **9–10h sáng VN** (sau briefing) — 3 biến thể
+      sẵn trong `phase-4.3/phase-4.3-deploy-announcement.md`
+
+---
+
+## 6. 📣 BUSINESS / GO-TO-MARKET
+
+### 6.1 Cam kết Founding Member (wording chuẩn — không tự chế thêm)
+
+> 🌱 **Bạn là Founding Member #N của Bé Tiền** — 1 trong 50 người đầu tiên.
+> Trong giai đoạn này toàn bộ tính năng **miễn phí**. Khi Bé Tiền Pro ra mắt
+> chính thức (dự kiến cuối 2026), bạn được **giảm 50% trọn đời** —
+> 44.000đ/tháng thay vì 88.000đ — để cảm ơn sự đồng hành.
+
+**Quy tắc:** chỉ hứa đúng điều này. Không hứa quà/bonus khác trừ khi document
+trong `founding-promise.md`. (Chi tiết & corner case: xem `founding-promise.md`.)
+
+### 6.2 Phân bổ 50 seat theo source & cadence phát invite
+
+| Source | Seat | Kênh thực tế | Tone |
+|---|---|---|---|
+| `friends` | 10 | Nhắn tay bạn bè thân | Ấm, cá nhân |
+| `personal_fb` | 10 | Post Facebook cá nhân | Ấm, kể chuyện |
+| `vn_finance_community` | 10 | Group/cộng đồng tài chính VN | Chuyên nghiệp, không khoe |
+| `direct_msg` | 10 | DM người đã quan tâm trước đó | Cá nhân, follow-up |
+| `tg_finance_groups` | 10 | Group Telegram tài chính | Ngắn, đúng trọng tâm |
+
+**Cadence (tránh dồn 50 người vào cùng lúc, để kịp triage):**
+- Ngày 1 sáng: 15 invite · Ngày 1 chiều: 15 · Ngày 2 sáng: 10 · Ngày 2 chiều: 10
+
+### 6.3 Seeding messages (operator copy-paste — KHÔNG phải in-app string)
+
+> Tất cả đều warm, không hype, không "CFO". Mỗi link kèm đúng source:
+> `t.me/BeTienBot?start=invite_<token>`
+
+**A. `friends` — nhắn tay bạn bè thân**
+```
+Mình đang làm Bé Tiền — một trợ lý tài chính cá nhân nhắn qua Telegram, giúp
+theo dõi tài sản và "nhìn trước" tương lai tài chính của mình. Đang mở cho 50
+người đầu tiên dùng miễn phí. Bạn thử giúp mình với nhé, 5 phút thôi, rồi cho
+mình xin cảm nhận thật 🙏
+👉 [invite link]
+```
+
+**B. `personal_fb` — post Facebook cá nhân**
+```
+Sau một thời gian ấp ủ, mình mở cửa Bé Tiền cho 50 người đầu tiên 🌱
+
+Bé Tiền là người đồng hành quản lý tài sản cho người Việt — nhắn tin qua
+Telegram như chat với một người bạn hiểu tiền. Nó giúp bạn:
+• Ghi lại tài sản & chi tiêu chỉ bằng một câu nhắn
+• Thấy bức tranh tài chính tương lai của mình (mưa / nắng / bình thường)
+• Nhận lời nhắc nhẹ nhàng mỗi sáng, không phán xét
+
+50 người đầu là Founding Member: dùng miễn phí bây giờ, và giảm 50% trọn đời
+khi bản Pro ra mắt. Ai muốn thử, nhắn mình hoặc vào link dưới nhé 👇
+👉 [invite link]
+```
+
+**C. `vn_finance_community` — group/cộng đồng tài chính**
+```
+Chào cả nhà, mình đang phát triển Bé Tiền — trợ lý quản lý tài sản cá nhân cho
+người Việt (Telegram bot). Trọng tâm là giúp người dùng hình dung quỹ đạo tài
+sản tương lai bằng mô phỏng, thay vì chỉ ghi chép chi tiêu.
+
+Đang tuyển 50 người dùng đầu để lấy feedback nghiêm túc. Hoàn toàn miễn phí
+giai đoạn này. Rất mong được nghe góc nhìn từ cộng đồng. Cảm ơn cả nhà.
+👉 [invite link]
+```
+
+**D. `direct_msg` — DM người từng quan tâm**
+```
+Chào [tên] 👋 Hồi trước bạn có nói quan tâm tới chuyện quản lý tài chính cá
+nhân — giờ Bé Tiền đã mở cho nhóm đầu tiên rồi. Mình giữ một suất Founding
+Member cho bạn (miễn phí giai đoạn này + giảm 50% trọn đời khi có bản Pro).
+Bạn thử nhé, mình rất muốn nghe bạn nghĩ gì.
+👉 [invite link]
+```
+
+**E. `tg_finance_groups` — group Telegram (ngắn)**
+```
+Bé Tiền — trợ lý quản lý tài sản cá nhân trên Telegram, đang mở 50 suất dùng
+sớm miễn phí. Ghi tài sản bằng 1 câu nhắn, xem quỹ đạo tài chính tương lai.
+Ai muốn thử & góp ý: 👉 [invite link]
+```
+
+### 6.4 Checklist trước khi gửi mỗi đợt seeding
+
+- [ ] Link đúng `source` tương ứng (để `/cohort_stats` đo sạch theo kênh)
+- [ ] Người Việt đọc lại 1 lượt — nghe tự nhiên, không sượng, không "CFO"
+- [ ] Founder đọc cuối cùng trước khi post
+- [ ] Không hứa gì ngoài cam kết ở 6.1
+- [ ] Đăng đúng nơi được phép (tránh spam group vi phạm rule cộng đồng)
+
+### 6.5 Theo dõi cohort theo kênh (sau khi phát)
+
+- [ ] `/cohort_stats` — breakdown user theo source mỗi sáng
+- [ ] So redemption rate giữa các kênh → biết kênh nào hiệu quả cho lần scale 50 → 500
+- [ ] Ghi lại insight vào retro (kênh nào convert tốt, message nào resonate)
+
+---
+
+## 7. 📊 Success metrics (theo dõi qua admin dashboard + KPI digest)
+
+| Metric | Target |
+|---|---|
+| D1 retention | ≥70% |
+| D7 retention | ≥40% |
+| Twin shown trong session 1 | ≥70% |
+| Real assets logged (7 ngày) | ≥60% |
+| Intent classification accuracy | ≥85% confirmed |
+| Feedback SLA <24h | ≥95% |
+| In-onboarding emoji 😍 | ≥50% |
+| Twin satisfaction (D7, định tính) | phỏng vấn tay 10 founding member |
+
+---
+
+## 8. ⛔ Kill criteria (đã document ở Story C.3)
+
+Dừng/điều chỉnh nếu chạm bất kỳ ngưỡng nào:
+- 4-week retention <20%
+- Cost >50k VND/user/tháng
+- P1 bug rate >1/ngày
+- Persona violation >5/tuần
+- In-onboarding emoji 😕 >30%
+- Twin calibration <40% within-band
+
+### Rollback
+
+**Trước khi phát hết 50 invite:** ngừng phát, DM người chưa redeem
+("Bé Tiền đang chỉnh sửa, sẽ quay lại sau X ngày"), điều tra theo action plan.
+
+**Sau khi phát hết:** nhắn cohort ("Tuần tới Bé Tiền tạm dừng để cải thiện X.
+Tài sản & lịch sử được giữ nguyên."), feature-flag-off surface bị ảnh hưởng.
+**Cam kết founding vẫn giữ nguyên** dù cohort tạm dừng.
+
+---
+
+## 9. Cam kết vận hành của operator (soft launch fail nếu bỏ)
+
+- [ ] Block **1 giờ/ngày × 7 ngày** cho feedback triage (đặt lịch lặp trên calendar)
+- [ ] Theo dõi KPI digest mỗi sáng, phản hồi feedback trong SLA 24h
+- [ ] Sau soft launch: viết retro → đưa insight vào kế hoạch scale 50 → 500
+
+---
+
+*Tạo cho soft launch tháng 6/2026. Sau launch: chuyển file này vào
+`docs/archive/` cùng retro, hoặc cập nhật thành runbook cho đợt scale tiếp theo.*


### PR DESCRIPTION
## Mục đích

Tạo **một runbook hợp nhất** cho soft launch tháng 6/2026 — gộp cả checklist kỹ thuật/ops *và* phần business/go-to-market vào một nơi duy nhất, để operator chạy launch không phải nhảy giữa nhiều doc.

File: `docs/current/soft-launch-runbook.md`

## Nội dung

**Phần kỹ thuật / vận hành**
- §0 — Positioning guardrails: KHÔNG dùng "Personal CFO" trong text hiển thị cho user, dùng *người đồng hành quản lý tài sản*. Flag lại design issue ở `phase-4.1-detailed.md:466`.
- §1 — Technical verify checklist + Zalo gate (3 lớp phòng vệ, `ZALO_CHANNEL_ENABLED=false`)
- §2 — Ops / dogfood
- §3 — Content / localization
- §4 — Sinh invite founding member (50 ghế / 10 mỗi nguồn / 5 nguồn; race test; CSV KHÔNG commit vào git)
- §5 — Trình tự launch T-0

**Phần business / go-to-market (theo yêu cầu)**
- §6 — Founding-promise wording, bảng phân bổ 50 ghế theo 5 nguồn + cadence (Day1 AM 15/PM 15, Day2 AM 10/PM 10), **5 message seeding tiếng Việt (A–E)** cho friends / personal_fb / vn_finance_community / direct_msg / tg_finance_groups, pre-send checklist, tracking qua `/cohort_stats`
- §7 — Success metrics (D1≥70%, D7≥40%, Twin shown≥70%…)
- §8 — Kill criteria + rollback
- §9 — Cam kết operator (1h/ngày × 7 ngày triage)

## Ghi chú

- Pure docs — không đụng code, không migration.
- Đây là change **mới**, tách biệt với PR #900 (đã merge).

https://claude.ai/code/session_015J8o2avTXj86mhXWJH1EuG