### PR TITLE
fix(time): render all user-facing timestamps in Vietnam time (UTC+7)

### DIFF
--- a/backend/bot/formatters/templates.py
+++ b/backend/bot/formatters/templates.py
@@ -3,35 +3,18 @@
 Nguyên tắc: Một function = một loại tin nhắn.
 """
 
-from datetime import date, datetime, timezone
+from datetime import date, datetime
 from functools import lru_cache
 from html import escape as _html_escape
 from pathlib import Path
 from typing import Any
-from zoneinfo import ZoneInfo
 
 import yaml
 
 from backend.bot.formatters.money import format_money_full, format_money_short
 from backend.bot.formatters.progress_bar import make_category_bar, make_progress_bar
 from backend.config.categories import get_category
-
-_VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
-
-
-def _as_vn_time(dt: datetime | None) -> datetime | None:
-    """Normalize any timestamp to Asia/Ho_Chi_Minh for display.
-
-    Centralized here so every confirmation template renders VN time
-    regardless of whether the caller remembered to convert. PG TIMESTAMPTZ
-    columns come back as aware UTC; naive datetimes are assumed UTC (the
-    historical default of ``datetime.utcnow``).
-    """
-    if dt is None:
-        return None
-    if dt.tzinfo is None:
-        dt = dt.replace(tzinfo=timezone.utc)
-    return dt.astimezone(_VN_TZ)
+from backend.utils.time_vn import to_vn as _as_vn_time
 
 _TRANSACTION_COPY_PATH = (
     Path(__file__).resolve().parents[3] / "content" / "transaction_copy.yaml"

--- a/backend/bot/handlers/menu_handler.py
+++ b/backend/bot/handlers/menu_handler.py
@@ -80,6 +80,7 @@ from backend.services.telegram_service import (
     send_chat_action,
     send_message,
 )
+from backend.utils.time_vn import to_vn
 
 if TYPE_CHECKING:
     from backend.wealth.services.net_worth_calculator import NetWorthBreakdown
@@ -1506,7 +1507,7 @@ async def _action_market_vnindex(
                 "price": iq.price,
                 "change": dec(iq.metadata.get("change")),
                 "pct": dec(iq.metadata.get("change_pct")),
-                "updated": iq.fetched_at.astimezone().strftime("%H:%M %d/%m"),
+                "updated": to_vn(iq.fetched_at).strftime("%H:%M %d/%m"),
                 "stale_note": " · dữ liệu cũ/ngoài giờ" if iq.is_stale else "",
             }
         except Exception:

--- a/backend/intent/handlers/query_market.py
+++ b/backend/intent/handlers/query_market.py
@@ -3,9 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
 from decimal import Decimal
-from zoneinfo import ZoneInfo
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +19,7 @@ from backend.market_data.providers.gold_pnj_json import PNJ_GOLD_MENU_PRODUCTS
 from backend.market_data.normalizer import PriceQuote
 from backend.models.market_snapshot import MarketSnapshot
 from backend.models.user import User
+from backend.utils.time_vn import now_vn, to_vn
 from backend.wealth.models.asset import Asset
 
 logger = logging.getLogger(__name__)
@@ -130,7 +129,7 @@ class QueryMarketHandler(IntentHandler):
         generic stock-style "which ticker?" clarification.
         """
         symbols = ("BTC", "ETH", "BNB", "SOL", "XRP")
-        today_label = datetime.now(ZoneInfo("Asia/Ho_Chi_Minh")).strftime("%d/%m/%Y")
+        today_label = now_vn().strftime("%d/%m/%Y")
         lines = [f"₿ *Giá tiền số phổ biến — {today_label}:*"]
         had_quote = False
 
@@ -165,7 +164,7 @@ class QueryMarketHandler(IntentHandler):
             lines.append(f"• {symbol}: {quote.price:,.0f}đ{change_text}{stale}")
 
         if stale_times:
-            latest = max(stale_times).astimezone().strftime("%H:%M")
+            latest = to_vn(max(stale_times)).strftime("%H:%M")
             lines.insert(1, f"⚠️ Dữ liệu cập nhật lần cuối: {latest}")
 
         if not had_quote:
@@ -230,8 +229,7 @@ class QueryMarketHandler(IntentHandler):
                 lines.append(f"• {label}: {quote.price:,.0f}đ/lượng{stale}")
 
         if fetched_times:
-            tz = ZoneInfo("Asia/Ho_Chi_Minh")
-            latest = max(fetched_times).astimezone(tz)
+            latest = to_vn(max(fetched_times))
             stamp = latest.strftime("%H:%M ngày %d/%m/%Y")
             lines[0] = f"🥇 *Giá vàng hôm nay* (cập nhật {stamp}):"
 

--- a/backend/services/chart_generator.py
+++ b/backend/services/chart_generator.py
@@ -11,7 +11,6 @@ generate_portfolio_chart(assets_data, *, change_pct, timestamp) -> bytes
 """
 import io
 import logging
-from datetime import datetime
 
 import matplotlib
 matplotlib.use("Agg")  # non-interactive, must come before pyplot import
@@ -20,6 +19,7 @@ import matplotlib.patches as mpatches
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 
+from backend.utils.time_vn import now_vn
 from backend.wealth.asset_types import get_label
 
 logger = logging.getLogger(__name__)
@@ -134,7 +134,7 @@ def generate_portfolio_chart(
     # Header
     fig.text(0.04, 0.945, "Báo cáo danh mục tài sản",
              ha="left", va="top", fontsize=13, fontweight="bold", color=_WHITE)
-    today_str = datetime.now().strftime("%d/%m/%Y")
+    today_str = now_vn().strftime("%d/%m/%Y")
     fig.text(0.96, 0.945, today_str,
              ha="right", va="top", fontsize=10, color=_MUTED)
 

--- a/backend/services/morning_report_service.py
+++ b/backend/services/morning_report_service.py
@@ -5,12 +5,13 @@ and sends everything to the user via Telegram.
 """
 import logging
 import uuid
-from datetime import date, datetime, timedelta
+from datetime import date, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.user import User
 from backend.ports.notifier import get_notifier
+from backend.utils.time_vn import now_vn
 from backend.services.chart_generator import generate_portfolio_chart
 from backend.wealth.asset_types import get_icon, get_label
 from backend.wealth.services import asset_service, net_worth_calculator
@@ -97,9 +98,9 @@ async def build_morning_report(
     if prev_total and prev_total > 0:
         change_pct = round(((total_value - prev_total) / prev_total) * 100, 1)
 
-    # Timestamp
-    now = datetime.now()
-    timestamp = now.strftime("%H:%M %d/%m/%Y")
+    # Timestamp — VN local time (the prod server runs UTC, so a naive
+    # datetime.now() would render an hour-skewed, non-VN clock).
+    timestamp = now_vn().strftime("%H:%M %d/%m/%Y")
 
     # Render chart (fallback to None on failure)
     assets_data = [

--- a/backend/utils/time_vn.py
+++ b/backend/utils/time_vn.py
@@ -1,0 +1,59 @@
+"""Vietnam-time helpers — single source of truth for user-facing timestamps.
+
+Every timestamp shown to a user must read in Vietnam local time (UTC+7,
+``Asia/Ho_Chi_Minh``, no DST). Historically each call site rolled its own
+conversion and several drifted:
+
+- ``datetime.now()`` returns *naive system-local* time — on a UTC prod
+  server that renders as UTC, one hour shy of seven off VN.
+- A bare ``dt.astimezone()`` (no argument) also resolves to *system-local*,
+  so a UTC-aware DB value stays UTC instead of shifting to +7.
+
+Both look correct on a developer laptop in ICT and silently wrong in
+production. Route every display path through the helpers here so the bug
+cannot reappear:
+
+- :func:`now_vn` for "current time" displays (chart watermarks, report
+  timestamps) instead of ``datetime.now()``.
+- :func:`to_vn` to convert a stored timestamp (naive=UTC or aware) to VN
+  instead of a bare ``.astimezone()``.
+- :func:`format_vn` for the common convert-then-strftime in one call.
+
+Storage code (DB writes) should keep using ``datetime.utcnow`` — asyncpg
+treats naive values as UTC on insert, so the instant round-trips intact;
+these helpers are for *rendering*, not persistence.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+VN_TZ = ZoneInfo("Asia/Ho_Chi_Minh")
+
+
+def now_vn() -> datetime:
+    """Current wall-clock time in Vietnam (aware, UTC+7)."""
+    return datetime.now(VN_TZ)
+
+
+def to_vn(dt: datetime | None) -> datetime | None:
+    """Convert any timestamp to Vietnam time for display.
+
+    Naive datetimes are assumed UTC (the historical default of
+    ``datetime.utcnow``); aware datetimes are shifted to ``Asia/Ho_Chi_Minh``.
+    Returns ``None`` unchanged so callers can format defensively.
+    """
+    if dt is None:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(VN_TZ)
+
+
+def format_vn(dt: datetime | None, fmt: str, *, default: str = "") -> str:
+    """Convert ``dt`` to VN time and ``strftime`` it, with a null fallback."""
+    vn = to_vn(dt)
+    if vn is None:
+        return default
+    return vn.strftime(fmt)

--- a/tests/test_time_vn.py
+++ b/tests/test_time_vn.py
@@ -1,0 +1,47 @@
+"""Unit tests for the centralized Vietnam-time helpers.
+
+These lock in the contract that every user-facing timestamp renders in
+``Asia/Ho_Chi_Minh`` (UTC+7) regardless of the server's clock — the bug
+that recurred because call sites used naive ``datetime.now()`` or a bare
+``.astimezone()`` (both system-local) instead of an explicit VN conversion.
+"""
+
+from datetime import datetime, timezone
+from zoneinfo import ZoneInfo
+
+from backend.utils.time_vn import VN_TZ, format_vn, now_vn, to_vn
+
+
+def test_now_vn_offset_is_plus_seven():
+    assert now_vn().utcoffset().total_seconds() == 7 * 3600
+
+
+def test_to_vn_treats_naive_as_utc():
+    # Naive UTC midnight is the historical ``datetime.utcnow`` shape.
+    result = to_vn(datetime(2026, 5, 29, 0, 0, 0))
+    assert result.strftime("%H:%M") == "07:00"
+    assert result.tzinfo == VN_TZ
+
+
+def test_to_vn_shifts_aware_utc():
+    result = to_vn(datetime(2026, 5, 29, 0, 0, 0, tzinfo=timezone.utc))
+    assert result.strftime("%H:%M") == "07:00"
+
+
+def test_to_vn_preserves_instant_across_zones():
+    # An aware value already in another zone must convert by instant, not
+    # by wall clock.
+    tokyo = datetime(2026, 5, 29, 9, 0, 0, tzinfo=ZoneInfo("Asia/Tokyo"))
+    assert to_vn(tokyo).strftime("%H:%M") == "07:00"  # JST+9 -> ICT+7
+
+
+def test_to_vn_none_passthrough():
+    assert to_vn(None) is None
+
+
+def test_format_vn_default_on_none():
+    assert format_vn(None, "%H:%M", default="--:--") == "--:--"
+
+
+def test_format_vn_renders_vn_clock():
+    assert format_vn(datetime(2026, 5, 29, 0, 30), "%H:%M") == "07:30"


### PR DESCRIPTION
## Vấn đề

Thời gian hiển thị vẫn không phải giờ Việt Nam (UTC+7) dù đã sửa 2 lần. Lần sửa trước chỉ chạm vào đường đi của tin nhắn xác nhận giao dịch (`templates._as_vn_time`) — đường đi đó đã đúng. Bug còn lại nằm ở **các điểm render khác** tính giờ theo *system-local*, mà prod server chạy **UTC**:

- `datetime.now()` (naive) trong `morning_report_service.py` (timestamp báo cáo sáng) và `chart_generator.py` (watermark biểu đồ) → hiện giờ UTC thay vì +7.
- `.astimezone()` **không tham số** trong `menu_handler.py` (cập nhật VNINDEX) và `query_market.py` (giờ dữ liệu cũ) → resolve về system-local (UTC), nên giá trị aware-UTC **không** được dịch sang +7.

Cả hai dạng đều trông đúng trên máy dev ở múi giờ ICT nhưng âm thầm sai trên prod UTC.

## Cách xử lý (tận gốc, chống tái phát)

Thêm `backend/utils/time_vn.py` làm **nguồn chân lý duy nhất** cho mọi timestamp hiển thị:

- `now_vn()` — giờ hiện tại VN (+7), thay cho `datetime.now()`.
- `to_vn(dt)` — chuyển bất kỳ timestamp nào sang VN (naive coi như UTC; aware dịch theo instant), thay cho `.astimezone()` trần.
- `format_vn(dt, fmt, default=...)` — convert rồi `strftime` trong một bước, có fallback khi `None`.

Mọi đường render giờ đi qua helper này, và `templates._as_vn_time` được gộp vào `to_vn` để conversion không còn lệch theo từng call site.

Code **lưu trữ** vẫn dùng `datetime.utcnow` — asyncpg coi naive là UTC khi insert nên instant round-trip nguyên vẹn; helper mới chỉ dùng để *render*, không phải để *persist*.

## Test

- Thêm `tests/test_time_vn.py` khóa hợp đồng +7 (naive=UTC → 07:00, aware UTC → 07:00, JST+9 → ICT+7, `None` passthrough, fallback).
- Toàn bộ test liên quan (template / morning / market / chart) pass.

## Files

- `backend/utils/time_vn.py` (mới)
- `backend/bot/formatters/templates.py` — dùng lại `to_vn`
- `backend/services/morning_report_service.py`, `backend/services/chart_generator.py` — `now_vn()`
- `backend/bot/handlers/menu_handler.py`, `backend/intent/handlers/query_market.py` — `to_vn()`
- `tests/test_time_vn.py` (mới)

https://claude.ai/code/session_01VU7KNuAjDKNwTh3uoRARG8