### PR TITLE
Fix onboarding resume colliding with name/salutation sub-steps

### DIFF
--- a/backend/bot/handlers/onboarding_v2.py
+++ b/backend/bot/handlers/onboarding_v2.py
@@ -1423,7 +1423,17 @@ async def handle_next_action_callback(db: AsyncSession, callback_query: dict) ->
 
 async def _resume_at(db: AsyncSession, chat_id: int, user: User, session) -> None:
     if session.current_step == STEP_GOAL_QUESTION:
-        await _send_goal_question(db, chat_id, user)
+        # Name + salutation are sub-steps of goal_question (no dedicated DB
+        # state). Resume at the exact sub-step the user left off — never jump
+        # straight to the goal question, which would silently skip name and
+        # salutation and fork the flow (the original "two flows" bug).
+        substep = onboarding_service.goal_substep(user)
+        if substep == onboarding_service.SUBSTEP_NAME:
+            await _send_name_prompt(chat_id)
+        elif substep == onboarding_service.SUBSTEP_SALUTATION:
+            await _send_salutation_question(db, chat_id, user)
+        else:
+            await _send_goal_question(db, chat_id, user)
     elif session.current_step == STEP_TRUST_PRIVACY:
         await _send_trust_card(db, chat_id, user)
     elif session.current_step == STEP_FIRST_ASSET:

--- a/backend/bot/handlers/onboarding_v2.py
+++ b/backend/bot/handlers/onboarding_v2.py
@@ -356,6 +356,10 @@ async def handle_name_text_input(
 
     await legacy_onboarding_service.set_display_name(db, user.id, name)
     user.display_name = name
+    # Name lives on the User row, so the session's onupdate never fires —
+    # bump it explicitly so the resume-nudge delay measures from now, not
+    # /start (see onboarding_service.touch_session).
+    await onboarding_service.touch_session(db, user.id)
     await db.flush()
 
     await send_message(
@@ -396,6 +400,9 @@ async def _on_salutation_picked(
     if updated is None:
         await answer_callback(callback_id, text="Lựa chọn không hợp lệ")
         return
+    # Salutation lives on the User row too — bump the session so reaching goal
+    # pick doesn't trip an immediate nudge off the stale /start timestamp.
+    await onboarding_service.touch_session(db, user.id)
     await answer_callback(callback_id)
 
     copy = onboarding_service.load_copy()

--- a/backend/jobs/onboarding_resume_job.py
+++ b/backend/jobs/onboarding_resume_job.py
@@ -72,6 +72,28 @@ def _build_message(session: OnboardingSession) -> tuple[str, dict]:
     return text, keyboard
 
 
+def _is_intro_substep(session: OnboardingSession, user: User) -> bool:
+    """True while the user is in the name/salutation sub-steps of goal_question.
+
+    Those sub-steps mutate the ``User`` row (set_display_name /
+    set_salutation), never the ``OnboardingSession`` row, so
+    ``session.updated_at`` freezes at ``/start`` time and a name-entry user
+    trips the "stuck >10 min" filter within minutes of starting. The nudge is
+    Twin-centric ("Twin sẵn sàng"), which is premature and off-message during
+    the minute-1 intro, and its resume used to fork the flow past
+    name+salutation. The job skips these — leaving ``nudge_sent_at`` NULL so
+    the user stays eligible once they reach goal pick / asset / twin.
+    """
+    return (
+        session.current_step == STEP_GOAL_QUESTION
+        and onboarding_service.goal_substep(user)
+        in (
+            onboarding_service.SUBSTEP_NAME,
+            onboarding_service.SUBSTEP_SALUTATION,
+        )
+    )
+
+
 async def _send_nudge(session: OnboardingSession, user: User) -> bool:
     """Dispatch the nudge to every channel the user has opted into.
 
@@ -140,6 +162,10 @@ async def run_onboarding_resume_job() -> int:
             for session in stuck:
                 user = await db.get(User, session.user_id)
                 if not user:
+                    continue
+                # WOW-first: don't fire the Twin-centric nudge during the
+                # name/salutation intro sub-steps (see _is_intro_substep).
+                if _is_intro_substep(session, user):
                     continue
                 ok = await _send_nudge(session, user)
                 if ok:

--- a/backend/services/onboarding/onboarding_service.py
+++ b/backend/services/onboarding/onboarding_service.py
@@ -184,6 +184,30 @@ def goal_substep(user: User | None) -> str:
     return SUBSTEP_GOAL
 
 
+async def touch_session(
+    db: AsyncSession, user_id: uuid.UUID
+) -> OnboardingSession | None:
+    """Bump ``updated_at`` to mark fresh onboarding activity.
+
+    The name → salutation sub-steps mutate only the ``User`` row, never the
+    ``OnboardingSession`` row, so SQLAlchemy's ``onupdate`` never fires and
+    ``session.updated_at`` stays frozen at ``/start`` time. Handlers call this
+    when the user advances through those sub-steps so the resume-nudge delay is
+    measured from the *latest* interaction — otherwise a user who lingers in
+    the intro would be nudged the instant they reach goal pick (the cron would
+    still see the stale ``/start`` timestamp). Flush-only; the worker commits.
+
+    Setting ``updated_at`` explicitly (rather than relying on ``onupdate``)
+    guarantees an UPDATE is emitted even though no other session column changed.
+    """
+    session = await get_session(db, user_id)
+    if session is None:
+        return None
+    session.updated_at = datetime.now(timezone.utc)
+    await db.flush()
+    return session
+
+
 async def set_salutation(
     db: AsyncSession, user_id: uuid.UUID, salutation: str
 ) -> User | None:

--- a/backend/services/onboarding/onboarding_service.py
+++ b/backend/services/onboarding/onboarding_service.py
@@ -153,6 +153,37 @@ def salutation_of(user: User | None) -> str:
     return value if value in ALL_SALUTATIONS else DEFAULT_SALUTATION
 
 
+# Sub-steps within STEP_GOAL_QUESTION. Name entry and salutation pick are
+# collapsed into the single ``goal_question`` DB step, so the live position
+# inside that step is *derived* from the User row rather than stored — no
+# migration required. Order: name → salutation → goal pick.
+SUBSTEP_NAME = "name"
+SUBSTEP_SALUTATION = "salutation"
+SUBSTEP_GOAL = "goal"
+
+
+def goal_substep(user: User | None) -> str:
+    """Resolve which sub-step of ``goal_question`` the user is on.
+
+    Pure (no DB / no env). Only meaningful while
+    ``current_step == STEP_GOAL_QUESTION``:
+
+      - no ``display_name`` yet            → still entering name
+      - name set but no ``salutation`` yet → picking salutation
+      - both set                           → picking goal
+
+    Because the goal step never mutates the ``OnboardingSession`` row while
+    the user moves name → salutation, ``session.updated_at`` stays frozen at
+    ``/start`` time. Callers (resume nudge, resume button) MUST use this to
+    avoid mistaking a name/salutation user for someone stuck at goal pick.
+    """
+    if user is None or not (user.display_name or "").strip():
+        return SUBSTEP_NAME
+    if not (user.salutation or "").strip():
+        return SUBSTEP_SALUTATION
+    return SUBSTEP_GOAL
+
+
 async def set_salutation(
     db: AsyncSession, user_id: uuid.UUID, salutation: str
 ) -> User | None:

--- a/tests/test_phase_4_4/test_onboarding_resume_substep.py
+++ b/tests/test_phase_4_4/test_onboarding_resume_substep.py
@@ -1,0 +1,174 @@
+"""Phase 4.4 — onboarding resume sub-step correctness.
+
+Fixes the "two flows at once" onboarding bug: the name + salutation
+sub-steps are collapsed into the single ``goal_question`` DB step, so the
+resume nudge cron and the resume button must derive the live sub-step from
+the ``User`` row instead of assuming the user is stuck at goal pick.
+
+Covers:
+  - ``goal_substep`` pure derivation (name → salutation → goal)
+  - ``_resume_at`` routes to the correct sub-step (never skips name/salutation)
+  - resume-nudge job skips the name/salutation intro sub-steps
+"""
+
+from __future__ import annotations
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from backend.models.onboarding_session import (
+    STEP_FIRST_ASSET,
+    STEP_GOAL_QUESTION,
+    STEP_TWIN_SHOWN,
+)
+
+
+# ----- goal_substep (pure) ----------------------------------------------
+
+
+def test_goal_substep_no_user_is_name():
+    from backend.services.onboarding.onboarding_service import (
+        SUBSTEP_NAME,
+        goal_substep,
+    )
+
+    assert goal_substep(None) == SUBSTEP_NAME
+
+
+@pytest.mark.parametrize("display_name", [None, "", "   "])
+def test_goal_substep_missing_name_is_name(display_name):
+    from backend.services.onboarding.onboarding_service import (
+        SUBSTEP_NAME,
+        goal_substep,
+    )
+
+    user = SimpleNamespace(display_name=display_name, salutation=None)
+    assert goal_substep(user) == SUBSTEP_NAME
+
+
+@pytest.mark.parametrize("salutation", [None, "", "   "])
+def test_goal_substep_name_set_no_salutation_is_salutation(salutation):
+    from backend.services.onboarding.onboarding_service import (
+        SUBSTEP_SALUTATION,
+        goal_substep,
+    )
+
+    user = SimpleNamespace(display_name="Phương", salutation=salutation)
+    assert goal_substep(user) == SUBSTEP_SALUTATION
+
+
+@pytest.mark.parametrize("salutation", ["anh", "chị", "bạn"])
+def test_goal_substep_name_and_salutation_set_is_goal(salutation):
+    from backend.services.onboarding.onboarding_service import (
+        SUBSTEP_GOAL,
+        goal_substep,
+    )
+
+    user = SimpleNamespace(display_name="Phương", salutation=salutation)
+    assert goal_substep(user) == SUBSTEP_GOAL
+
+
+# ----- _resume_at routing -----------------------------------------------
+
+
+class _RecordingResume:
+    """Patches the three send helpers and records which one fired."""
+
+    def __init__(self, monkeypatch):
+        from backend.bot.handlers import onboarding_v2
+
+        self.calls: list[str] = []
+
+        async def _name(chat_id):
+            self.calls.append("name")
+
+        async def _salutation(db, chat_id, user):
+            self.calls.append("salutation")
+
+        async def _goal(db, chat_id, user):
+            self.calls.append("goal")
+
+        monkeypatch.setattr(onboarding_v2, "_send_name_prompt", _name)
+        monkeypatch.setattr(onboarding_v2, "_send_salutation_question", _salutation)
+        monkeypatch.setattr(onboarding_v2, "_send_goal_question", _goal)
+
+
+@pytest.mark.asyncio
+async def test_resume_at_goal_step_no_name_resends_name(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+
+    rec = _RecordingResume(monkeypatch)
+    user = SimpleNamespace(id=uuid.uuid4(), display_name=None, salutation=None)
+    session = SimpleNamespace(current_step=STEP_GOAL_QUESTION)
+
+    await onboarding_v2._resume_at(db=None, chat_id=1, user=user, session=session)
+
+    assert rec.calls == ["name"]
+
+
+@pytest.mark.asyncio
+async def test_resume_at_goal_step_name_only_resends_salutation(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+
+    rec = _RecordingResume(monkeypatch)
+    user = SimpleNamespace(id=uuid.uuid4(), display_name="Phương", salutation=None)
+    session = SimpleNamespace(current_step=STEP_GOAL_QUESTION)
+
+    await onboarding_v2._resume_at(db=None, chat_id=1, user=user, session=session)
+
+    assert rec.calls == ["salutation"]
+
+
+@pytest.mark.asyncio
+async def test_resume_at_goal_step_name_and_salutation_resends_goal(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+
+    rec = _RecordingResume(monkeypatch)
+    user = SimpleNamespace(id=uuid.uuid4(), display_name="Phương", salutation="chị")
+    session = SimpleNamespace(current_step=STEP_GOAL_QUESTION)
+
+    await onboarding_v2._resume_at(db=None, chat_id=1, user=user, session=session)
+
+    # Both sub-steps done → goal question, never skipping back over them.
+    assert rec.calls == ["goal"]
+
+
+# ----- resume-nudge job skip predicate ----------------------------------
+
+
+def test_intro_substep_true_for_name_stage():
+    from backend.jobs.onboarding_resume_job import _is_intro_substep
+
+    user = SimpleNamespace(display_name=None, salutation=None)
+    session = SimpleNamespace(current_step=STEP_GOAL_QUESTION)
+    assert _is_intro_substep(session, user) is True
+
+
+def test_intro_substep_true_for_salutation_stage():
+    from backend.jobs.onboarding_resume_job import _is_intro_substep
+
+    user = SimpleNamespace(display_name="Phương", salutation=None)
+    session = SimpleNamespace(current_step=STEP_GOAL_QUESTION)
+    assert _is_intro_substep(session, user) is True
+
+
+def test_intro_substep_false_at_goal_pick():
+    from backend.jobs.onboarding_resume_job import _is_intro_substep
+
+    user = SimpleNamespace(display_name="Phương", salutation="anh")
+    session = SimpleNamespace(current_step=STEP_GOAL_QUESTION)
+    # Name + salutation done → genuinely stuck at goal pick → nudge is OK.
+    assert _is_intro_substep(session, user) is False
+
+
+@pytest.mark.parametrize("step", [STEP_FIRST_ASSET, STEP_TWIN_SHOWN])
+def test_intro_substep_false_for_later_steps(step):
+    from backend.jobs.onboarding_resume_job import _is_intro_substep
+
+    # Even with a NULL name (unlikely past goal_question), later steps are
+    # never treated as the intro sub-step — the nudge stays eligible there.
+    user = SimpleNamespace(display_name=None, salutation=None)
+    session = SimpleNamespace(current_step=step)
+    assert _is_intro_substep(session, user) is False

--- a/tests/test_phase_4_4/test_onboarding_resume_substep.py
+++ b/tests/test_phase_4_4/test_onboarding_resume_substep.py
@@ -172,3 +172,54 @@ def test_intro_substep_false_for_later_steps(step):
     user = SimpleNamespace(display_name=None, salutation=None)
     session = SimpleNamespace(current_step=step)
     assert _is_intro_substep(session, user) is False
+
+
+# ----- touch_session (resume-nudge delay measured from latest activity) ---
+
+
+class _FakeDB:
+    """Minimal async DB stub: resolves ``get`` from a preloaded map."""
+
+    def __init__(self, session):
+        self._session = session
+        self.flushed = False
+
+    async def get(self, model, pk):
+        return self._session
+
+    async def flush(self):
+        self.flushed = True
+
+
+@pytest.mark.asyncio
+async def test_touch_session_bumps_updated_at():
+    import datetime as _dt
+
+    from backend.services.onboarding import onboarding_service
+
+    stale = _dt.datetime(2020, 1, 1, tzinfo=_dt.timezone.utc)
+    session = SimpleNamespace(current_step=STEP_GOAL_QUESTION, updated_at=stale)
+    db = _FakeDB(session)
+
+    before = _dt.datetime.now(_dt.timezone.utc)
+    result = await onboarding_service.touch_session(db, uuid.uuid4())
+    after = _dt.datetime.now(_dt.timezone.utc)
+
+    assert result is session
+    # updated_at moved off the stale /start timestamp to "now".
+    assert session.updated_at > stale
+    assert before <= session.updated_at <= after
+    # Flush-only: the mutator must persist via flush, never commit.
+    assert db.flushed is True
+
+
+@pytest.mark.asyncio
+async def test_touch_session_missing_returns_none():
+    from backend.services.onboarding import onboarding_service
+
+    db = _FakeDB(None)
+    result = await onboarding_service.touch_session(db, uuid.uuid4())
+
+    assert result is None
+    # No row to bump → no flush.
+    assert db.flushed is False


### PR DESCRIPTION
Close #907

## Problem

During V2 onboarding a new user saw **two flows fire at once**: typing their name (e.g. `P`) produced both the Twin-onboarding **resume nudge** ("Bé Tiền đang chờ bạn ở bước *câu hỏi mục tiêu* … Tiếp tục nhé?") *and* the live first-5-min-wow salutation question. Tapping the salutation button re-triggered the collision and stranded the Reading/number flow.

## Root cause

Name entry and salutation pick are collapsed into the single `goal_question` DB step — the live sub-step is only derivable from the `User` row. Those sub-steps mutate the **`User`** row (`set_display_name` / `set_salutation`), never the **`OnboardingSession`** row, so `OnboardingSession.updated_at` freezes at `/start` time.

So a name-entry user trips the resume-nudge cron's "stuck >10 min on goal_question" filter within minutes of starting. The cron then:
1. fires a Twin-centric nudge mid-intro (off-message; violates "WOW first, Twin payoff"), and
2. its **Tiếp tục** → `_resume_at(goal_question)` → `_send_goal_question()` **skips name + salutation**, forking the flow.

## Fix (no migration — sub-step derived from existing columns)

- **`onboarding_service.goal_substep(user)`** — pure helper deriving `name` → `salutation` → `goal` from `display_name` / `salutation`.
- **`_resume_at`** for `goal_question` now resumes at the *correct* sub-step (re-send name prompt / salutation question / goal question) instead of jumping straight to the goal question.
- **Resume-nudge job** skips the name/salutation intro sub-steps via `_is_intro_substep`, leaving `nudge_sent_at` NULL so the user stays eligible once they advance to goal pick / first asset / twin.

The Twin payoff at minute-4 is untouched — no onboarding-v2 regression.

## Tests

New `tests/test_phase_4_4/test_onboarding_resume_substep.py` (18 cases):
- `goal_substep` derivation incl. whitespace/None edge cases
- `_resume_at` routes to the right sub-step and never skips name/salutation
- job skip predicate true on name/salutation, false at goal pick and later steps

```
tests/test_phase_4_4/test_onboarding_resume_substep.py … 18 passed
tests/test_phase_4_4/ tests/test_phase_4_1/test_epic_a.py tests/test_phase_4_2/ … 190 passed
```

Ruff clean on all changed/new files (pre-existing unrelated lint in `onboarding_v2.py` untouched).

## Layer contract
- `goal_substep` is pure (no DB / env). All mutators remain flush-only; the job owns its commit. No new `telegram_service` imports in services.