### PR TITLE
Tech-debt: i18n hóa 6 chuỗi onboarding + gỡ env-read khỏi service layer

### DIFF
--- a/backend/bot/handlers/onboarding_v2.py
+++ b/backend/bot/handlers/onboarding_v2.py
@@ -142,6 +142,26 @@ def is_screenshot_onboarding_enabled() -> bool:
     )
 
 
+TRUST_CARD_FLAG_ENV = "TRUST_CARD_ENABLED"
+
+
+def is_trust_card_enabled() -> bool:
+    """Trust/privacy card is shown by default; operator can disable via env.
+
+    Read at the handler edge and passed into ``onboarding_service.set_goal``
+    so the service stays env-free (layer contract), same pattern as
+    ``is_v2_enabled`` / ``is_screenshot_onboarding_enabled``.
+    """
+    import os
+
+    return os.environ.get(TRUST_CARD_FLAG_ENV, "true").lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
 # ---------- Entry: /start with optional invite token -----------------
 
 
@@ -305,10 +325,10 @@ async def _send_goal_question(db: AsyncSession, chat_id: int, user: User) -> Non
 
 
 async def _send_name_prompt(chat_id: int) -> None:
+    copy = onboarding_service.load_copy()
     await send_message(
         chat_id,
-        "Trước tiên, Bé Tiền muốn gọi bạn là gì? ✨\n\n"
-        "(Bạn chỉ cần nhắn tên bạn vào đây)",
+        copy["step_name"]["prompt"],
         parse_mode="HTML",
     )
 
@@ -327,9 +347,10 @@ async def handle_name_text_input(
 
     is_valid, name = legacy_onboarding_service.validate_display_name(raw_text)
     if not is_valid:
+        copy = onboarding_service.load_copy()
         await send_message(
             chat_id,
-            "Tên chưa hợp lệ nè 💚 Bạn nhập tên ngắn gọn (tối đa 24 ký tự) nhé.",
+            copy["step_name"]["invalid"],
             parse_mode="HTML",
         )
         return True
@@ -415,7 +436,9 @@ async def _on_goal_picked(
     user: User,
     goal_code: str,
 ) -> None:
-    session = await onboarding_service.set_goal(db, user.id, goal_code)
+    session = await onboarding_service.set_goal(
+        db, user.id, goal_code, trust_card_enabled=is_trust_card_enabled()
+    )
     if session is None:
         await answer_callback(callback_id, text="Lựa chọn không hợp lệ")
         return
@@ -720,9 +743,12 @@ async def handle_asset_text_input(
             },
         }
         await db.flush()
+        copy = onboarding_service.load_copy()
         await send_message(
             chat_id,
-            f"⚠️ <b>Kiểm tra lại số tiền</b>\n\n{warning.message}\n\nBé Tiền hiểu là <b>{format_money_short(value)}</b>. Bạn chọn số đúng nhé:",
+            copy["step_2_asset"]["text_quality_warning"].format(
+                warning=warning.message, amount=format_money_short(value)
+            ),
             parse_mode="HTML",
             reply_markup=_quality_keyboard(value),
         )
@@ -1095,11 +1121,7 @@ async def _on_feedback_signal(
 
     # Persist as a Feedback row too so /feedback_inbox sees it alongside
     # explicit feedback — the operator triages all signals in one place.
-    from backend.feedback.models.feedback import (
-        FEEDBACK_STATUS_NEW,
-        Feedback,
-    )
-
+    # (Feedback / FEEDBACK_STATUS_NEW are imported at module level.)
     fb = Feedback(
         user_id=user.id,
         content=f"[onboarding_signal:{signal}]",
@@ -1279,9 +1301,10 @@ async def handle_next_action_callback(db: AsyncSession, callback_query: dict) ->
 
     from backend.services.dashboard_service import get_user_by_telegram_id
 
+    copy = onboarding_service.load_copy()
     user = await get_user_by_telegram_id(db, telegram_id)
     if user is None:
-        await answer_callback(callback_id, text="Gõ /start để bắt đầu nhé")
+        await answer_callback(callback_id, text=copy["next_action"]["session_expired"])
         return True
 
     action = data.split(":", 1)[1]
@@ -1315,11 +1338,11 @@ async def handle_next_action_callback(db: AsyncSession, callback_query: dict) ->
     elif action == "log_expense":
         await send_message(
             chat_id,
-            "🧾 Gõ khoản chi đầu tiên, ví dụ: <code>ăn trưa 80k</code>",
+            copy["next_action"]["log_expense_prompt"],
             parse_mode="HTML",
         )
     else:
-        await send_message(chat_id, "Gõ /menu để chọn bước tiếp theo nhé.")
+        await send_message(chat_id, copy["next_action"]["default_prompt"])
     return True
 
 

--- a/backend/services/onboarding/onboarding_service.py
+++ b/backend/services/onboarding/onboarding_service.py
@@ -18,7 +18,6 @@ router boundary commits.
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 from datetime import datetime, timezone
 from decimal import Decimal
@@ -79,16 +78,6 @@ MIN_ASSET_VND = Decimal("1_000_000")
 MAX_ASSET_VND = Decimal("100_000_000_000_000")
 
 DEMO_ASSET_VND = Decimal("50_000_000")  # Demo Twin uses 50tr placeholder.
-TRUST_CARD_FLAG_ENV = "TRUST_CARD_ENABLED"
-
-
-def is_trust_card_enabled() -> bool:
-    return os.environ.get(TRUST_CARD_FLAG_ENV, "true").lower() not in {
-        "0",
-        "false",
-        "no",
-        "off",
-    }
 
 
 def parse_asset_amount(raw: str) -> Decimal | None:
@@ -228,15 +217,26 @@ async def set_salutation(
 
 
 async def set_goal(
-    db: AsyncSession, user_id: uuid.UUID, goal_code: str
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    goal_code: str,
+    *,
+    trust_card_enabled: bool,
 ) -> OnboardingSession | None:
+    """Record the goal pick and route to the next step.
+
+    ``trust_card_enabled`` is resolved at the handler edge (feature flag
+    read) and passed in — the service never reads env. When the trust card
+    is enabled and not yet accepted, route through the privacy step; else
+    skip straight to the first-asset step.
+    """
     if goal_code not in ALL_GOALS:
         return None
     session = await get_session(db, user_id)
     if session is None:
         return None
     session.goal_choice = goal_code
-    if is_trust_card_enabled() and session.trust_accepted_at is None:
+    if trust_card_enabled and session.trust_accepted_at is None:
         session.current_step = STEP_TRUST_PRIVACY
     else:
         session.current_step = STEP_FIRST_ASSET

--- a/content/onboarding/welcome_v2.yaml
+++ b/content/onboarding/welcome_v2.yaml
@@ -28,6 +28,16 @@ source_variants:
   direct_msg:
     prefix: "Cảm ơn bạn đã trả lời tin nhắn của Bé Tiền — bắt đầu khám phá nhé!"
 
+# Name prompt — the very first beat of V2 onboarding, asked before the
+# salutation pick. {prompt} is sent as one bubble; keep it warm and short.
+step_name:
+  prompt: |
+    Trước tiên, Bé Tiền muốn gọi bạn là gì? ✨
+
+    (Bạn chỉ cần nhắn tên bạn vào đây)
+  invalid: |
+    Tên chưa hợp lệ nè 💚 Bạn nhập tên ngắn gọn (tối đa 24 ký tự) nhé.
+
 # Salutation pick (Phase 4.4 Epic 0) — asked right after the user gives
 # their name, before the goal question. Lets Bé Tiền address the user
 # warmly (anh/chị) instead of the neutral "bạn". Picking "bạn" is a
@@ -108,6 +118,14 @@ step_2_asset:
     {warning}
 
     Bé Tiền đọc được <b>{amount}</b> từ ảnh. Bạn chọn số đúng nhé:
+  # Same double-check, but for a number the user typed (not from a photo).
+  # {warning} = the data-quality message, {amount} = the parsed figure.
+  text_quality_warning: |
+    ⚠️ <b>Kiểm tra lại số tiền</b>
+
+    {warning}
+
+    Bé Tiền hiểu là <b>{amount}</b>. Bạn chọn số đúng nhé:
 
 # Demo mode banner — explicit framing so user does not mistake the
 # 50tr placeholder for their own Twin (loss-of-trust risk).
@@ -122,6 +140,14 @@ demo_banner:
 # Step 3 — Twin shown ack.
 step_3_twin:
   header: "(3/3) Twin của bạn"
+
+# Next-best-action prompts — shown after onboarding when the user taps a
+# follow-up action button (or when their session has expired).
+next_action:
+  session_expired: "Gõ /start để bắt đầu nhé"
+  log_expense_prompt: |
+    🧾 Gõ khoản chi đầu tiên, ví dụ: <code>ăn trưa 80k</code>
+  default_prompt: "Gõ /menu để chọn bước tiếp theo nhé."
 
 # Resume helpers.
 resume:

--- a/tests/test_phase_4_4/test_onboarding_no_reading.py
+++ b/tests/test_phase_4_4/test_onboarding_no_reading.py
@@ -215,7 +215,7 @@ async def test_goal_pick_routes_to_asset_prompt_no_reading(monkeypatch):
     from backend.bot.handlers import onboarding_v2
     from backend.services.onboarding import onboarding_service
 
-    async def _set_goal(_db, _uid, _goal):
+    async def _set_goal(_db, _uid, _goal, *, trust_card_enabled=True):
         # Not on the trust step → flow goes to the asset prompt.
         return SimpleNamespace(current_step=STEP_FIRST_ASSET_SENTINEL)
 

--- a/tests/test_phase_4_4/test_onboarding_techdebt.py
+++ b/tests/test_phase_4_4/test_onboarding_techdebt.py
@@ -1,0 +1,167 @@
+"""Tech-debt clean-up tests (Phase 4.4 follow-up).
+
+Two pre-existing violations surfaced by the gates are fixed here:
+
+  1. Layer contract — ``onboarding_service.set_goal`` no longer reads the
+     ``TRUST_CARD_ENABLED`` env var. The feature flag is resolved at the
+     handler edge and passed in as ``trust_card_enabled``.
+  2. i18n — six user-facing strings moved out of
+     ``backend/bot/handlers/onboarding_v2.py`` into
+     ``content/onboarding/welcome_v2.yaml``.
+
+These tests are DB-free: ``set_goal`` is exercised with a fake session +
+fake db so we only assert the routing logic.
+"""
+
+from __future__ import annotations
+
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from backend.models.onboarding_session import (
+    ALL_GOALS,
+    STEP_FIRST_ASSET,
+    STEP_TRUST_PRIVACY,
+)
+from backend.services.onboarding import onboarding_service
+
+
+_VALID_GOAL = next(iter(ALL_GOALS))
+
+
+class _FakeDB:
+    async def flush(self):
+        return None
+
+
+def _patch_session(monkeypatch, session):
+    async def _get_session(_db, _uid):
+        return session
+
+    monkeypatch.setattr(onboarding_service, "get_session", _get_session)
+
+
+# ----- B: set_goal is env-free, routes via trust_card_enabled ----------
+
+
+@pytest.mark.asyncio
+async def test_set_goal_routes_to_trust_when_enabled_and_not_accepted(monkeypatch):
+    session = SimpleNamespace(
+        goal_choice=None, trust_accepted_at=None, current_step="goal_question"
+    )
+    _patch_session(monkeypatch, session)
+
+    result = await onboarding_service.set_goal(
+        _FakeDB(), "uid", _VALID_GOAL, trust_card_enabled=True
+    )
+
+    assert result is session
+    assert session.goal_choice == _VALID_GOAL
+    assert session.current_step == STEP_TRUST_PRIVACY
+
+
+@pytest.mark.asyncio
+async def test_set_goal_skips_trust_when_disabled(monkeypatch):
+    session = SimpleNamespace(
+        goal_choice=None, trust_accepted_at=None, current_step="goal_question"
+    )
+    _patch_session(monkeypatch, session)
+
+    await onboarding_service.set_goal(
+        _FakeDB(), "uid", _VALID_GOAL, trust_card_enabled=False
+    )
+
+    assert session.current_step == STEP_FIRST_ASSET
+
+
+@pytest.mark.asyncio
+async def test_set_goal_skips_trust_when_already_accepted(monkeypatch):
+    session = SimpleNamespace(
+        goal_choice=None, trust_accepted_at="2026-05-01", current_step="goal_question"
+    )
+    _patch_session(monkeypatch, session)
+
+    await onboarding_service.set_goal(
+        _FakeDB(), "uid", _VALID_GOAL, trust_card_enabled=True
+    )
+
+    assert session.current_step == STEP_FIRST_ASSET
+
+
+@pytest.mark.asyncio
+async def test_set_goal_invalid_goal_returns_none(monkeypatch):
+    _patch_session(monkeypatch, SimpleNamespace())
+
+    result = await onboarding_service.set_goal(
+        _FakeDB(), "uid", "not_a_real_goal", trust_card_enabled=True
+    )
+
+    assert result is None
+
+
+def test_set_goal_does_not_read_env():
+    # The env-read helper must no longer live on the service (layer contract).
+    assert not hasattr(onboarding_service, "is_trust_card_enabled")
+    assert not hasattr(onboarding_service, "TRUST_CARD_FLAG_ENV")
+
+
+def test_trust_card_flag_lives_at_handler_edge(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+
+    monkeypatch.delenv("TRUST_CARD_ENABLED", raising=False)
+    assert onboarding_v2.is_trust_card_enabled() is True
+
+    monkeypatch.setenv("TRUST_CARD_ENABLED", "off")
+    assert onboarding_v2.is_trust_card_enabled() is False
+
+    monkeypatch.setenv("TRUST_CARD_ENABLED", "true")
+    assert onboarding_v2.is_trust_card_enabled() is True
+
+
+# ----- A: the six moved strings live in the YAML and format cleanly -----
+
+
+def test_copy_has_new_i18n_keys():
+    copy = onboarding_service.load_copy()
+
+    assert copy["step_name"]["prompt"].strip()
+    assert copy["step_name"]["invalid"].strip()
+    assert copy["next_action"]["session_expired"].strip()
+    assert copy["next_action"]["log_expense_prompt"].strip()
+    assert copy["next_action"]["default_prompt"].strip()
+    assert copy["step_2_asset"]["text_quality_warning"].strip()
+
+
+def test_text_quality_warning_formats_placeholders():
+    copy = onboarding_service.load_copy()
+    rendered = copy["step_2_asset"]["text_quality_warning"].format(
+        warning="Số hơi lớn so với thường ngày", amount="200tr"
+    )
+    assert "Số hơi lớn so với thường ngày" in rendered
+    assert "200tr" in rendered
+    # No leftover placeholders.
+    assert "{" not in rendered
+
+
+def test_moved_strings_not_hardcoded_in_handler():
+    handler = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "..",
+        "backend",
+        "bot",
+        "handlers",
+        "onboarding_v2.py",
+    )
+    with open(handler, encoding="utf-8") as fh:
+        src = fh.read()
+    for needle in (
+        "Trước tiên, Bé Tiền muốn gọi bạn là gì",
+        "Tên chưa hợp lệ nè",
+        "Gõ /start để bắt đầu nhé",
+        "Gõ khoản chi đầu tiên",
+        "Gõ /menu để chọn bước tiếp theo",
+    ):
+        assert needle not in src, f"string still hardcoded: {needle!r}"


### PR DESCRIPTION
## Mục tiêu

Dọn 2 khoản tech-debt **có sẵn từ trước** mà các gate phát hiện khi làm PR #911 (gỡ "The Reading"). PR này độc lập, thuần tech-debt, **không đổi hành vi người dùng** (chuỗi giữ nguyên văn).

## A. i18n — 6 chuỗi tiếng Việt hardcode → `welcome_v2.yaml`

Chuyển 6 chuỗi user-facing khỏi `backend/bot/handlers/onboarding_v2.py` vào `content/onboarding/welcome_v2.yaml`:

| Vị trí cũ | Key YAML mới |
|---|---|
| Lời hỏi tên | `step_name.prompt` |
| Tên không hợp lệ | `step_name.invalid` |
| Cảnh báo chất lượng số (gõ tay) | `step_2_asset.text_quality_warning` (`{warning}` + `{amount}`) |
| Session hết hạn | `next_action.session_expired` |
| Gợi ý ghi chi tiêu | `next_action.log_expense_prompt` |
| Prompt mặc định | `next_action.default_prompt` |

## B. Layer contract — service không còn đọc env

`onboarding_service.set_goal()` trước đây gọi `is_trust_card_enabled()` (đọc `os.environ`) — vi phạm "service không đọc env".

- `set_goal(db, user_id, goal_code, *, trust_card_enabled: bool)` — flag truyền vào qua tham số.
- `is_trust_card_enabled()` + `TRUST_CARD_FLAG_ENV` chuyển lên **handler edge** (cùng pattern với `is_v2_enabled` / `is_screenshot_onboarding_enabled`).
- Bỏ `import os` thừa khỏi service.
- Caller `_on_goal_picked` truyền `trust_card_enabled=is_trust_card_enabled()`.

Dọn thêm: gỡ local re-import `Feedback`/`FEEDBACK_STATUS_NEW` bị trùng (đã import ở module level) — xử lý F811/F401 ruff trong file đang sửa.

## Kiểm thử & gate

- ✅ `tests/test_phase_4_4/test_onboarding_techdebt.py` (mới) + toàn bộ suite onboarding: **191 passed**.
- ✅ `ruff check` + `ruff format --check` sạch trên các file đã sửa.
- ✅ `layer-contract-checker`: APPROVE — service env-free, env-read đúng ở handler edge.
- ✅ `vi-localization-checker`: APPROVE — 6 chuỗi chuyển đúng, on-persona "Bé Tiền".

> 2 test pre-existing trong `backend/tests/test_service_boundary.py` (`test_services_do_not_commit`, `test_services_depend_on_ports_not_adapters`) fail trên cả base `main` — không liên quan diff này, để ngoài phạm vi.

Close #912

https://claude.ai/code/session_013k3fCnwYSpjuuxEo7oMSUA