### PR TITLE
fix(market-data): fall back to secondary when primary batch returns empty/partial

### DIFF
--- a/backend/market_data/providers/base_dispatcher.py
+++ b/backend/market_data/providers/base_dispatcher.py
@@ -13,6 +13,7 @@ from backend.market_data.cache.cache_keys import (
     health_open_until_key,
 )
 from backend.market_data.exceptions import (
+    MarketDataError,
     ParserError,
     ProviderUnavailable,
     RateLimitError,
@@ -137,9 +138,12 @@ class Dispatcher:
             )
         try:
             secondary_quotes = await self._call_secondary_batch(missing)
-        except _RETRYABLE_ERRORS:
-            # Keep whatever the primary gave us; only surface the error when we
-            # have nothing at all (preserves the single-quote raise contract).
+        except MarketDataError:
+            # Keep whatever the primary already gave us; only surface the error
+            # when we have nothing at all (preserves the single-quote raise
+            # contract). This also covers non-retryable errors such as
+            # SymbolNotFound for one missing ticker, which must not discard the
+            # valid quotes the primary returned for the rest of the batch.
             if quotes:
                 return quotes
             raise

--- a/backend/market_data/providers/base_dispatcher.py
+++ b/backend/market_data/providers/base_dispatcher.py
@@ -92,14 +92,23 @@ class Dispatcher:
         ``fetch_quote`` sequentially would multiply provider latency and keep
         hitting an already-open backup circuit. Use provider-native batch calls
         instead and apply the same circuit checks as single-quote fetches.
+
+        Unlike single-quote fetches, a provider batch can *succeed* (no
+        exception) yet return fewer symbols than requested — e.g. a 200 OK with
+        an empty or shape-drifted body. Treat any symbol the primary did not
+        return as missing and ask the secondary provider for it, so a healthy
+        backup (SSI) still serves quotes when the primary (VNDIRECT) answers
+        emptily. Without this guard the empty primary result would be returned
+        as-is and the secondary would never be consulted.
         """
         clean_symbols = [symbol for symbol in symbols if symbol.strip()]
         if not clean_symbols:
             return []
 
+        quotes: list[PriceQuote] = []
         if not await self._is_circuit_open(self.primary):
             try:
-                return await self._call_provider_batch(self.primary, clean_symbols)
+                quotes = await self._call_provider_batch(self.primary, clean_symbols)
             except _RETRYABLE_ERRORS as exc:
                 await self._record_failure(self.primary)
                 logger.warning(
@@ -114,7 +123,33 @@ class Dispatcher:
                 len(clean_symbols),
             )
 
-        return await self._call_secondary_batch(clean_symbols)
+        missing = self._missing_symbols(clean_symbols, quotes)
+        if not missing:
+            return quotes
+
+        if quotes:
+            logger.info(
+                "Primary %s returned %d/%d symbols; asking secondary for the remaining %d",
+                self._provider_name(self.primary),
+                len(quotes),
+                len(clean_symbols),
+                len(missing),
+            )
+        try:
+            secondary_quotes = await self._call_secondary_batch(missing)
+        except _RETRYABLE_ERRORS:
+            # Keep whatever the primary gave us; only surface the error when we
+            # have nothing at all (preserves the single-quote raise contract).
+            if quotes:
+                return quotes
+            raise
+        return quotes + secondary_quotes
+
+    @staticmethod
+    def _missing_symbols(requested: list[str], quotes: list[PriceQuote]) -> list[str]:
+        """Return requested symbols not present in ``quotes`` (case-insensitive)."""
+        have = {quote.symbol.upper() for quote in quotes}
+        return [symbol for symbol in requested if symbol.upper().strip() not in have]
 
     async def _call_secondary(self, symbol: str) -> PriceQuote:
         if await self._is_circuit_open(self.secondary):
@@ -155,7 +190,13 @@ class Dispatcher:
         quotes = await asyncio.wait_for(
             provider.fetch_batch(symbols), timeout=self.timeout
         )
-        await self._record_success(provider)
+        if quotes:
+            await self._record_success(provider)
+        elif symbols:
+            # 200-but-empty for a non-empty request mirrors the single-quote
+            # ParserError-on-empty path: count it as a failure so the circuit
+            # can open instead of silently resetting on a dead-but-OK provider.
+            await self._record_failure(provider)
         return quotes
 
     async def _is_circuit_open(self, provider: BaseProvider) -> bool:

--- a/backend/tests/test_market_data/test_dispatcher.py
+++ b/backend/tests/test_market_data/test_dispatcher.py
@@ -160,6 +160,87 @@ async def test_fetch_batch_uses_provider_batch_once():
     assert secondary.calls == 0
 
 
+class BatchProviderStub(BaseProvider):
+    """Provider returning a configurable subset of requested symbols per batch.
+
+    ``returns`` lists which requested symbols the provider answers with; a
+    missing or empty entry models a 200-but-empty / shape-drifted response
+    that raises no exception.
+    """
+
+    def __init__(self, name: str, returns: set[str] | None) -> None:
+        self.name = name
+        self.returns = returns
+        self.batch_calls = 0
+        self.calls = 0
+
+    @property
+    def asset_type(self) -> str:
+        return "stock"
+
+    async def fetch_quote(self, symbol: str) -> PriceQuote:
+        self.calls += 1
+        return PriceQuote(
+            symbol=symbol,
+            price=Decimal("100"),
+            currency="VND",
+            asset_type="stock",
+            fetched_at=datetime(2026, 5, 8, tzinfo=timezone.utc),
+            source=self.name,
+        )
+
+    async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+        self.batch_calls += 1
+        allowed = self.returns if self.returns is not None else set(symbols)
+        return [
+            await self.fetch_quote(symbol) for symbol in symbols if symbol in allowed
+        ]
+
+
+@pytest.mark.asyncio
+async def test_empty_primary_batch_falls_back_to_secondary():
+    redis = FakeAsyncRedis()
+    primary = BatchProviderStub("vndirect", returns=set())  # 200-but-empty
+    secondary = BatchProviderStub("ssi", returns={"VNM", "FPT"})
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    quotes = await dispatcher.fetch_batch(["VNM", "FPT"])
+
+    assert sorted(quote.symbol for quote in quotes) == ["FPT", "VNM"]
+    assert all(quote.source == "ssi" for quote in quotes)
+    assert secondary.batch_calls == 1
+    # empty-but-OK primary batch must count as a failure, not a success reset
+    assert await redis.get(health_failures_key("vndirect")) == "1"
+
+
+@pytest.mark.asyncio
+async def test_partial_primary_batch_fills_gap_from_secondary():
+    redis = FakeAsyncRedis()
+    primary = BatchProviderStub("vndirect", returns={"VNM"})
+    secondary = BatchProviderStub("ssi", returns={"FPT", "HPG"})
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    quotes = await dispatcher.fetch_batch(["VNM", "FPT", "HPG"])
+
+    by_symbol = {quote.symbol: quote.source for quote in quotes}
+    assert by_symbol == {"VNM": "vndirect", "FPT": "ssi", "HPG": "ssi"}
+    assert primary.batch_calls == 1
+    assert secondary.batch_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_partial_primary_batch_kept_when_secondary_fails():
+    redis = FakeAsyncRedis()
+    primary = BatchProviderStub("vndirect", returns={"VNM"})
+    secondary = ProviderStub("ssi", fail_times=99)
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    quotes = await dispatcher.fetch_batch(["VNM", "FPT"])
+
+    assert [quote.symbol for quote in quotes] == ["VNM"]
+    assert quotes[0].source == "vndirect"
+
+
 @pytest.mark.asyncio
 async def test_fetch_batch_skips_open_secondary_circuit():
     redis = FakeAsyncRedis()

--- a/backend/tests/test_market_data/test_dispatcher.py
+++ b/backend/tests/test_market_data/test_dispatcher.py
@@ -12,7 +12,7 @@ from backend.market_data.cache.cache_keys import (
     health_failures_key,
     health_open_until_key,
 )
-from backend.market_data.exceptions import ProviderUnavailable
+from backend.market_data.exceptions import ProviderUnavailable, SymbolNotFound
 from backend.market_data.normalizer import PriceQuote
 from backend.market_data.providers.base_dispatcher import Dispatcher
 from backend.tests.test_market_data.fakes import FakeAsyncRedis
@@ -239,6 +239,44 @@ async def test_partial_primary_batch_kept_when_secondary_fails():
 
     assert [quote.symbol for quote in quotes] == ["VNM"]
     assert quotes[0].source == "vndirect"
+
+
+@pytest.mark.asyncio
+async def test_partial_primary_batch_kept_when_secondary_raises_symbol_not_found():
+    """A non-retryable secondary error must not discard valid primary quotes."""
+
+    class SymbolNotFoundProvider(BatchProviderStub):
+        async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+            self.batch_calls += 1
+            raise SymbolNotFound(self.name)
+
+    redis = FakeAsyncRedis()
+    primary = BatchProviderStub("vndirect", returns={"VNM"})
+    secondary = SymbolNotFoundProvider("ssi", returns=None)
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    quotes = await dispatcher.fetch_batch(["VNM", "FPT"])
+
+    assert [quote.symbol for quote in quotes] == ["VNM"]
+    assert quotes[0].source == "vndirect"
+
+
+@pytest.mark.asyncio
+async def test_empty_primary_batch_propagates_secondary_symbol_not_found():
+    """With no primary quotes, a non-retryable secondary error still surfaces."""
+
+    class SymbolNotFoundProvider(BatchProviderStub):
+        async def fetch_batch(self, symbols: list[str]) -> list[PriceQuote]:
+            self.batch_calls += 1
+            raise SymbolNotFound(self.name)
+
+    redis = FakeAsyncRedis()
+    primary = BatchProviderStub("vndirect", returns=set())
+    secondary = SymbolNotFoundProvider("ssi", returns=None)
+    dispatcher = Dispatcher(primary, secondary, redis)
+
+    with pytest.raises(SymbolNotFound):
+        await dispatcher.fetch_batch(["VNM", "FPT"])
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Problem

Stock prices silently failed to load even though the SSI provider was healthy and serving quotes.

**Root cause:** the batch fetch path in `Dispatcher.fetch_batch` returned the primary provider's result *as-is* whenever the primary answered without raising — including a **200-but-empty** (or shape-drifted) response. In that case:

1. The healthy **secondary (SSI)** was **never consulted**, so net-worth valuation and `QueryAssetsHandler` got zero prices.
2. The empty-but-OK batch hit `_record_success`, **resetting the circuit breaker** — masking a dead-but-OK provider so the circuit never opened.

This only affected the **batch** path (`value_stock_holdings`, net worth). The single-quote path raised `ParserError` on empty and fell back correctly, which is why the bug was easy to miss — SSI "ran fine" in isolation.

## Fix (`backend/market_data/providers/base_dispatcher.py`)

- **`fetch_batch`** now treats any requested symbol the primary did not return as *missing* and asks the secondary for the remainder:
  - full empty primary → full fallback to secondary
  - partial primary → gap-fill the missing symbols from secondary
  - if the secondary itself fails, keep whatever the primary returned (preserves the raise-only-when-empty contract)
- **`_call_provider_batch`** records a *failure* when a non-empty request returns zero quotes, mirroring the single-quote `ParserError`-on-empty behaviour so the circuit can open instead of resetting.
- Added `_missing_symbols` helper (case-insensitive symbol matching).

The fix lives at the `Dispatcher` level, so it benefits both stock and gold dispatchers.

## Tests (`backend/tests/test_market_data/test_dispatcher.py`)

Added `BatchProviderStub` plus three cases:
- `test_empty_primary_batch_falls_back_to_secondary` — empty primary serves from SSI and records one failure (no circuit reset)
- `test_partial_primary_batch_fills_gap_from_secondary`
- `test_partial_primary_batch_kept_when_secondary_fails`

All 11 dispatcher tests pass; `ruff check` / `ruff format` clean.

https://claude.ai/code/session_01T7MNKW5GMPdY8tpJS8FcXY