### PR TITLE
feat(intent): "thêm thu nhập" opens add-income wizard (tier1)

### DIFF
--- a/backend/intent/classifier/llm_based.py
+++ b/backend/intent/classifier/llm_based.py
@@ -73,9 +73,10 @@ INTENTS:
 - action_record_saving: Muốn ghi tiết kiệm
 - action_quick_transaction: Ghi giao dịch nhanh (tiền ra/vào). "được cho/thưởng/lì xì/tìm/nhặt X" là tiền vào.
 - action_add_asset: Muốn thêm tài sản mới (BĐS, cổ phiếu, crypto, vàng, tiền mặt). Ví dụ: "thêm bất động sản", "thêm cổ phiếu FPT", "nhập crypto"
-- action_edit_asset: Muốn sửa / cập nhật tài sản đã có. Ví dụ: "sửa đất Ba Tư", "sửa cổ phiếu FPT thành 200 cổ", "cập nhật bất động sản". Khi user nói "thành <giá trị>" / "= <giá trị>" thì capture vào new_value để handler áp dụng update inline.
+- action_edit_asset: Muốn sửa / cập nhật tài sản đã có. Ví dụ: "sửa đất Ba Tư", "sửa FPT thành 200 cổ". Khi user nói "thành/= <giá trị>" thì capture vào new_value.
 - action_delete_asset: Muốn xoá / bỏ tài sản đã có. Ví dụ: "xoá tài sản ACB", "xoá ví zalopay", "xoá cổ phiếu FPT", "huỷ bất động sản"
 - action_add_goal: Muốn thêm mục tiêu tài chính mới. Ví dụ: "thêm mục tiêu", "tạo mục tiêu mới", "đặt goal"
+- action_add_income: Thêm nguồn thu nhập mới, KHÔNG kèm số tiền. Ví dụ: "thêm thu nhập".
 - nav_expense_dashboard: Muốn mở dashboard / bảng điều khiển chi tiêu. Ví dụ: "chi tiêu dashboard", "mở dashboard chi tiêu", "bảng điều khiển chi phí"
 - advisory: Hỏi lời khuyên đầu tư / tài chính
 - planning: Hỏi cách lập kế hoạch

--- a/backend/intent/dispatcher.py
+++ b/backend/intent/dispatcher.py
@@ -60,6 +60,7 @@ WRITE_INTENTS = frozenset(
         IntentType.ACTION_EDIT_ASSET,
         IntentType.ACTION_DELETE_ASSET,
         IntentType.ACTION_ADD_GOAL,
+        IntentType.ACTION_ADD_INCOME,
     }
 )
 
@@ -72,6 +73,7 @@ _WIZARD_LAUNCHING_INTENTS = frozenset(
         IntentType.ACTION_EDIT_ASSET,
         IntentType.ACTION_DELETE_ASSET,
         IntentType.ACTION_ADD_GOAL,
+        IntentType.ACTION_ADD_INCOME,
         IntentType.NAV_EXPENSE_DASHBOARD,
     }
 )
@@ -92,6 +94,7 @@ _SKIP_PERSONALITY_INTENTS = frozenset(
         IntentType.ACTION_EDIT_ASSET,
         IntentType.ACTION_DELETE_ASSET,
         IntentType.ACTION_ADD_GOAL,
+        IntentType.ACTION_ADD_INCOME,
         IntentType.NAV_EXPENSE_DASHBOARD,
     }
 )
@@ -431,6 +434,12 @@ class IntentDispatcher:
             )
 
             return ActionAddGoalHandler()
+        if intent == IntentType.ACTION_ADD_INCOME:
+            from backend.intent.handlers.action_add_income import (
+                ActionAddIncomeHandler,
+            )
+
+            return ActionAddIncomeHandler()
         if intent == IntentType.NAV_EXPENSE_DASHBOARD:
             from backend.intent.handlers.nav_expense_dashboard import (
                 NavExpenseDashboardHandler,

--- a/backend/intent/handlers/action_add_income.py
+++ b/backend/intent/handlers/action_add_income.py
@@ -1,0 +1,24 @@
+"""Handler for ``ACTION_ADD_INCOME`` — open the add-income wizard."""
+
+from __future__ import annotations
+
+import logging
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.bot.handlers import income_entry as income_entry_handlers
+from backend.intent.handlers.base import IntentHandler
+from backend.intent.intents import IntentResult
+from backend.models.user import User
+
+logger = logging.getLogger(__name__)
+
+
+class ActionAddIncomeHandler(IntentHandler):
+    async def handle(
+        self, intent: IntentResult, user: User, db: AsyncSession
+    ) -> str:
+        await income_entry_handlers.start_income_wizard(
+            db, user.telegram_id, user
+        )
+        return ""

--- a/backend/intent/intents.py
+++ b/backend/intent/intents.py
@@ -41,6 +41,7 @@ class IntentType(str, Enum):
     ACTION_EDIT_ASSET = "action_edit_asset"
     ACTION_DELETE_ASSET = "action_delete_asset"
     ACTION_ADD_GOAL = "action_add_goal"
+    ACTION_ADD_INCOME = "action_add_income"
 
     # ----- Navigation intents -----
     NAV_EXPENSE_DASHBOARD = "nav_expense_dashboard"

--- a/backend/tests/test_intent/fixtures/query_examples.yaml
+++ b/backend/tests/test_intent/fixtures/query_examples.yaml
@@ -319,6 +319,22 @@ edge_cases:
     expected_intent: action_add_goal
     notes: "Add-goal wizard alt form (#659)."
 
+  - text: "thêm thu nhập"
+    expected_intent: action_add_income
+    notes: "Add-income wizard — 'thu nhập' product keyword."
+
+  - text: "thêm thu nhập mới"
+    expected_intent: action_add_income
+    notes: "Add-income wizard, matches '+ thêm thu nhập mới' list button."
+
+  - text: "tạo thu nhập mới"
+    expected_intent: action_add_income
+    notes: "Add-income wizard alt form."
+
+  - text: "thêm nguồn thu nhập"
+    expected_intent: action_add_income
+    notes: "Add-income wizard, 'nguồn thu nhập' phrasing."
+
   - text: "chi tiêu dashboard"
     expected_intent: nav_expense_dashboard
     notes: "Expense dashboard miniapp link (#655)."

--- a/backend/tests/test_intent/test_rule_based.py
+++ b/backend/tests/test_intent/test_rule_based.py
@@ -94,6 +94,26 @@ def test_delete_asset_fund_extracts_subtype(classifier):
     assert result.parameters["asset_subtype"] == "fund"
 
 
+@pytest.mark.parametrize(
+    "text",
+    [
+        "thêm thu nhập 20tr",
+        "ghi thu nhập 20tr vào ví momo",
+        "thêm lương 20tr",
+    ],
+)
+def test_amount_bearing_income_does_not_launch_wizard(text, classifier):
+    """Amount-bearing income phrases are money-in logs, not "add a stream"
+    requests. The Tier 1 add-income patterns carry a trailing-digit guard,
+    so these must NOT match action_add_income — they fall through to the
+    transaction/LLM fallback that can see the amount."""
+    result = classifier.classify(text)
+
+    assert result is None or result.intent != IntentType.ACTION_ADD_INCOME, (
+        f"{text!r} wrongly launched the add-income wizard"
+    )
+
+
 # ---------------------- correctness invariants ----------------------
 
 

--- a/content/intent_patterns.yaml
+++ b/content/intent_patterns.yaml
@@ -509,6 +509,26 @@ action_add_goal:
     - pattern: '^(?:muc\s*tieu|goals?)\s+moi\b'
       confidence: 0.92
 
+action_add_income:
+  description: "User wants to add a new income stream (salary, freelance, rental, ...)."
+  # High confidence so it beats query_income when the user is initiating an
+  # add (e.g. "thêm thu nhập"). Opens the income wizard ("+ thêm thu nhập"),
+  # which collects type + schedule + amount. This is NOT a quick income log
+  # — that carries an amount and routes to action_quick_transaction.
+  # "thu nhập" is a product keyword here, mirroring "tài sản" (action_add_asset)
+  # and "mục tiêu" (action_add_goal).
+  patterns:
+    # "thêm thu nhập" / "tạo thu nhập mới" / "thêm nguồn thu nhập"
+    - pattern: '^(?:them|tao|nhap|ghi|moi)\s+(?:moi\s+)?(?:nguon\s+)?thu\s*nhap\b'
+      confidence: 0.95
+    # "thu nhập mới" / "nguồn thu nhập mới"
+    - pattern: '^(?:nguon\s+)?thu\s*nhap\s+moi\b'
+      confidence: 0.92
+    # "thêm lương" — salary is the dominant stream type. Negative lookahead
+    # on a trailing amount keeps "thêm lương 20tr" routed to a quick log.
+    - pattern: '^(?:them|tao|nhap)\s+(?:moi\s+)?luong\b(?!\s*[+\-]?\s*[\d.,]+)'
+      confidence: 0.9
+
 nav_expense_dashboard:
   description: "User wants to open the Expense Dashboard miniapp."
   patterns:

--- a/content/intent_patterns.yaml
+++ b/content/intent_patterns.yaml
@@ -517,16 +517,21 @@ action_add_income:
   # — that carries an amount and routes to action_quick_transaction.
   # "thu nhập" is a product keyword here, mirroring "tài sản" (action_add_asset)
   # and "mục tiêu" (action_add_goal).
+  # Every pattern carries a trailing-digit negative lookahead `(?!.*\d)` so
+  # amount-bearing phrases ("thêm thu nhập 20tr", "ghi thu nhập 20tr vào ví
+  # momo") fall through to action_quick_transaction (a money-in log) instead
+  # of opening the add-stream wizard. Only amountless "add a source" requests
+  # match here.
   patterns:
     # "thêm thu nhập" / "tạo thu nhập mới" / "thêm nguồn thu nhập"
-    - pattern: '^(?:them|tao|nhap|ghi|moi)\s+(?:moi\s+)?(?:nguon\s+)?thu\s*nhap\b'
+    - pattern: '^(?:them|tao|nhap|ghi|moi)\s+(?:moi\s+)?(?:nguon\s+)?thu\s*nhap\b(?!.*\d)'
       confidence: 0.95
     # "thu nhập mới" / "nguồn thu nhập mới"
-    - pattern: '^(?:nguon\s+)?thu\s*nhap\s+moi\b'
+    - pattern: '^(?:nguon\s+)?thu\s*nhap\s+moi\b(?!.*\d)'
       confidence: 0.92
-    # "thêm lương" — salary is the dominant stream type. Negative lookahead
-    # on a trailing amount keeps "thêm lương 20tr" routed to a quick log.
-    - pattern: '^(?:them|tao|nhap)\s+(?:moi\s+)?luong\b(?!\s*[+\-]?\s*[\d.,]+)'
+    # "thêm lương" — salary is the dominant stream type. The trailing-digit
+    # guard keeps "thêm lương 20tr" routed to a quick log.
+    - pattern: '^(?:them|tao|nhap)\s+(?:moi\s+)?luong\b(?!.*\d)'
       confidence: 0.9
 
 nav_expense_dashboard:


### PR DESCRIPTION
## What

Typing **"thêm thu nhập"** (and variants) now opens the add-income wizard, the same way **"thêm tài sản"** and **"thêm mục tiêu"** launch their wizards. `thu nhập` is treated as a product keyword on the Tier 1 rule layer.

> The request also mentioned **"thêm mục tiêu"** → add-goal. That already routed to `action_add_goal`, so no change was needed there. This PR adds the missing income counterpart.

## Changes

- **`backend/intent/intents.py`** — add `ACTION_ADD_INCOME` enum member.
- **`content/intent_patterns.yaml`** — Tier 1 regex patterns (high confidence so an *add* beats `query_income`). Negative lookahead on a trailing amount keeps `"thêm lương 20tr"` routed to a quick transaction log.
- **`backend/intent/handlers/action_add_income.py`** (new) — thin handler calling `income_entry.start_income_wizard(...)`; returns `""` so the dispatcher skips personality-wrap + duplicate send (same contract as the add-goal handler).
- **`backend/intent/dispatcher.py`** — register the intent in the `WRITE` / `WIZARD_LAUNCHING` / `SKIP_PERSONALITY` frozensets + handler-factory mapping.
- **`backend/intent/classifier/llm_based.py`** — Tier 3 prompt coverage for the new intent (required by `test_prompt_includes_all_intents`). Condensed the verbose `action_edit_asset` line — preserving its `new_value` instruction — to keep the prompt under the per-call cost budget (`test_cost_per_call_within_budget`).
- **`backend/tests/test_intent/fixtures/query_examples.yaml`** — canonical fixtures for the new intent.

## Routing safety

`query_income` patterns require `cua toi/minh` or `bao nhieu`; `action_quick_transaction` requires a trailing number — so `"thêm thu nhập"` (no number) won't collide with either.

## Tests

- `backend/tests/test_intent/{test_llm_classifier,test_rule_based,test_canonical_queries,test_dispatcher}.py` — **125 passed**, including the cost-budget guard.
- Pre-existing unrelated failures left untouched: `_parse_quantity('0.5 BTC')` in `test_action_edit_asset_helpers.py` (fails on the base branch too) and the F401 unused import in `llm_based.py` (outside the edited lines).

https://claude.ai/code/session_01Het3rdWi8p8FST6BrT6qMN