### PR TITLE
feat(profile): add default_money_in_source mirroring default_expense_source

### DIFF
--- a/alembic/versions/20260530_default_money_in_source_profile.py
+++ b/alembic/versions/20260530_default_money_in_source_profile.py
@@ -1,0 +1,27 @@
+"""add default money-in source to user profiles
+
+Revision ID: 20260530defaultmoneyinsource
+Revises: 20260529salutation
+Create Date: 2026-05-30
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = "20260530defaultmoneyinsource"
+down_revision = "20260529salutation"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "user_profiles",
+        sa.Column("default_money_in_source", sa.String(length=120), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("user_profiles", "default_money_in_source")

--- a/backend/bot/formatters/templates.py
+++ b/backend/bot/formatters/templates.py
@@ -41,6 +41,7 @@ def format_transaction_confirmation(
     daily_budget: float | None = None,
     source_label: str | None = None,
     show_edit_hint: bool = False,
+    transaction_type: str = "expense",
 ) -> str:
     """Tin nhắn xác nhận sau khi ghi giao dịch thành công.
 
@@ -72,10 +73,17 @@ def format_transaction_confirmation(
     if context_parts:
         lines.append("  •  ".join(context_parts))
 
+    is_money_in = transaction_type == "money_in"
+
     if source_label:
-        source_template = _confirmation_copy(
-            "source_prefix", "💳 Chi từ: {source}"
-        )
+        if is_money_in:
+            source_template = _confirmation_copy(
+                "source_prefix_money_in", "💰 Nhận vào: {source}"
+            )
+        else:
+            source_template = _confirmation_copy(
+                "source_prefix", "💳 Chi từ: {source}"
+            )
         lines.append(source_template.format(source=_html_escape(source_label)))
 
     if daily_spent is not None and daily_budget is not None and daily_budget > 0:
@@ -99,7 +107,8 @@ def format_transaction_confirmation(
             )
 
     if show_edit_hint:
-        hint = _confirmation_copy("edit_hint")
+        hint_key = "edit_hint_money_in" if is_money_in else "edit_hint"
+        hint = _confirmation_copy(hint_key) or _confirmation_copy("edit_hint")
         if hint:
             lines.append("")
             lines.append(hint.strip())

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -43,7 +43,7 @@ from backend.bot.keyboards.transaction_keyboard import (
     transaction_actions_with_done_keyboard,
     transaction_source_keyboard,
 )
-from backend.config.categories import get_all_categories
+from backend.config.categories import get_all_categories, get_all_income_categories
 from backend.models.expense import Expense
 from backend.schemas.expense import ExpenseCreate, ExpenseUpdate
 from backend.services import expense_service, wizard_service
@@ -62,6 +62,9 @@ logger = logging.getLogger(__name__)
 
 UNDO_WINDOW_SECONDS = 5
 _VALID_EXPENSE_CATEGORY_CODES = frozenset(cat.code for cat in get_all_categories())
+_VALID_INCOME_CATEGORY_CODES = frozenset(
+    cat.code for cat in get_all_income_categories()
+)
 
 
 async def _handle_source_selection_callback(
@@ -396,17 +399,25 @@ async def _handle_change_category(*, db, user, args, callback_id, chat_id, messa
         )
         return
 
+    is_money_in = (expense.transaction_type or "expense") == "money_in"
+
     if len(args) == 1:
         await edit_message_reply_markup(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=category_picker_keyboard(str(expense.id)),
+            reply_markup=category_picker_keyboard(
+                str(expense.id),
+                transaction_type="money_in" if is_money_in else "expense",
+            ),
         )
         await answer_callback(callback_id)
         return
 
     new_code = str(args[1]).strip().lower()
-    if new_code not in _VALID_EXPENSE_CATEGORY_CODES:
+    valid_codes = (
+        _VALID_INCOME_CATEGORY_CODES if is_money_in else _VALID_EXPENSE_CATEGORY_CODES
+    )
+    if new_code not in valid_codes:
         await answer_callback(
             callback_id,
             text="Danh mục không hợp lệ — bạn chọn lại trong danh sách nhé.",
@@ -711,6 +722,8 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
         )
         return
 
+    is_money_in = (expense.transaction_type or "expense") == "money_in"
+
     if len(args) == 1:
         await wizard_service.start_flow(
             db,
@@ -726,12 +739,23 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
         await edit_message_reply_markup(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=source_picker_keyboard(str(expense.id)),
+            reply_markup=source_picker_keyboard(
+                str(expense.id), allow_credit_card=not is_money_in
+            ),
         )
         await answer_callback(callback_id)
         return
 
     kind = str(args[1]).strip().lower()
+    if kind == "card" and is_money_in:
+        # Defensive: the picker hides this button for money-in, but reject a
+        # stale/forged callback too — money can't arrive into a credit card.
+        await answer_callback(
+            callback_id,
+            text="Tiền nhận vào không thể vào thẻ tín dụng nhé 🌱",
+            show_alert=True,
+        )
+        return
     if kind == "cash":
         updated = await expense_service.update_expense(
             db,

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -233,9 +233,10 @@ async def _rerender_transaction_message(
     edited: bool = False,
     db: AsyncSession | None = None,
 ) -> None:
-    is_expense = expense.transaction_type == "expense"
+    tx_type = expense.transaction_type or "expense"
+    is_card_type = tx_type in ("expense", "money_in")
     source_label = None
-    if is_expense and db is not None:
+    if is_card_type and db is not None:
         try:
             source_label = await resolve_source_label_for_expense(db, expense)
         except Exception:
@@ -247,7 +248,8 @@ async def _rerender_transaction_message(
         category_code=_normalize_category(expense.category),
         time=expense.created_at,
         source_label=source_label,
-        show_edit_hint=is_expense,
+        show_edit_hint=is_card_type,
+        transaction_type=tx_type,
     )
     reply_markup = (
         transaction_actions_with_done_keyboard(str(expense.id))

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -240,16 +240,22 @@ async def _start_source_prompt(
     return True
 
 
-async def _record_signed_expense_with_default(
+async def _record_transaction_with_default(
     db: AsyncSession, user, parsed: dict
 ) -> bool:
-    """Record an expense from the signed/amount-led fast-path using the
-    user's ``default_expense_source``.
+    """Record a transaction from the signed/amount-led fast-path using the
+    user's matching default source.
 
-    Returns True when the expense was created and the confirmation card
-    was sent — caller then skips the wizard. Returns False when the user
-    has no default source configured (caller falls back to the picker).
+    Works for both expense (``default_expense_source``) and money-in
+    (``default_money_in_source``) transactions — :func:`apply_default_source`
+    reads the right profile column based on ``transaction_type``.
+
+    Returns True when the transaction was created and the rich confirmation
+    card was sent — caller then skips the wizard. Returns False when the
+    user has no matching default configured (caller falls back to the
+    source picker).
     """
+    tx_type = parsed.get("transaction_type", "expense")
     merchant = (parsed.get("merchant") or parsed.get("note") or "Giao dịch").strip()
     expense_data = ExpenseCreate(
         amount=float(parsed["amount"]),
@@ -258,6 +264,7 @@ async def _record_signed_expense_with_default(
         source="manual",
         category="other",
         expense_date=date.today(),
+        transaction_type=tx_type,
     )
     resolved = await apply_default_source(db, user.id, expense_data)
     if not resolved.source_type:
@@ -372,20 +379,23 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
         return True
 
     # Fast-path for explicit +/- expense syntax before generic intent routing.
+    # Both expense and money-in first try the user's matching default source
+    # (rich confirm card, no extra tap); only fall back to the picker when
+    # no default is configured.
     signed = _parse_signed_transaction(text)
     if signed is not None:
-        if signed["transaction_type"] == "expense":
-            if await _record_signed_expense_with_default(db, user, signed):
-                return True
+        if await _record_transaction_with_default(db, user, signed):
+            return True
         return await _start_source_prompt(db, chat_id, user, signed)
 
     # Fast-path for "được <giver> cho/tặng/lì xì/thưởng <amount>" money-in
     # (e.g. "được bố cho 500k"). The Chi tiêu menu promises these are
-    # recorded as money-in, so we route them to the source picker just
-    # like a leading "+", rather than letting them fall through to the
-    # expense pipeline.
+    # recorded as money-in. Try the default money-in source first; fall
+    # back to the source picker when none is configured.
     duoc_money_in = _parse_duoc_money_in(text)
     if duoc_money_in is not None:
+        if await _record_transaction_with_default(db, user, duoc_money_in):
+            return True
         return await _start_source_prompt(db, chat_id, user, duoc_money_in)
 
     # Phase 3.5 — full intent flow with confirm/clarify state handling.

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -262,7 +262,12 @@ async def _record_transaction_with_default(
         merchant=merchant or "Giao dịch",
         note=parsed.get("note"),
         source="manual",
-        category="other",
+        # Money-in must reach create_expense at the schema default so it
+        # normalizes to the "income" category — matching the source-picker
+        # path. Hardcoding "other" here (as the expense fast-path does) would
+        # record default-sourced income under a spending bucket and skew
+        # category analytics.
+        category="needs_review" if tx_type == "money_in" else "other",
         expense_date=date.today(),
         transaction_type=tx_type,
     )

--- a/backend/bot/handlers/transaction.py
+++ b/backend/bot/handlers/transaction.py
@@ -53,19 +53,24 @@ async def send_transaction_confirmation(
     if not user or not user.telegram_id:
         return
 
-    is_expense = expense.transaction_type == "expense"
+    # Both expense and money-in get the rich card: source label + 4 edit
+    # buttons + edit hint. Daily budget context stays expense-only.
+    tx_type = expense.transaction_type or "expense"
+    is_card_type = tx_type in ("expense", "money_in")
+    is_expense = tx_type == "expense"
     source_label = (
-        await resolve_source_label_for_expense(db, expense) if is_expense else None
+        await resolve_source_label_for_expense(db, expense) if is_card_type else None
     )
     text = format_transaction_confirmation(
         merchant=expense.merchant or expense.note or "Giao dịch",
         amount=float(expense.amount),
         category_code=_normalize_category(expense.category),
         time=expense.created_at,
-        daily_spent=daily_spent,
-        daily_budget=daily_budget,
+        daily_spent=daily_spent if is_expense else None,
+        daily_budget=daily_budget if is_expense else None,
         source_label=source_label,
-        show_edit_hint=is_expense,
+        show_edit_hint=is_card_type,
+        transaction_type=tx_type,
     )
     reply_markup = transaction_actions_keyboard(str(expense.id))
     await send_message(

--- a/backend/bot/keyboards/transaction_keyboard.py
+++ b/backend/bot/keyboards/transaction_keyboard.py
@@ -5,7 +5,7 @@ Returns raw Telegram `InlineKeyboardMarkup` dicts (JSON-serialisable) vì
 """
 
 from backend.bot.keyboards.common import CallbackPrefix, build_callback
-from backend.config.categories import get_all_categories
+from backend.config.categories import get_all_categories, get_all_income_categories
 
 InlineKeyboardMarkup = dict
 """Alias for clarity — we build raw dicts matching Telegram's schema."""
@@ -61,9 +61,33 @@ def transaction_actions_with_done_keyboard(
     }
 
 
-def source_picker_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
-    """Picker chọn nguồn tiền khi user sửa expense (mirror category_picker)."""
+def source_picker_keyboard(
+    transaction_id: str, *, allow_credit_card: bool = True
+) -> InlineKeyboardMarkup:
+    """Picker chọn nguồn tiền khi user sửa expense (mirror category_picker).
+
+    ``allow_credit_card=False`` hides the credit-card option for money-in
+    transactions — money can never *arrive* into a credit card, so the edit
+    flow must enforce the same restriction as the default-source picker.
+    """
     tx = str(transaction_id)
+    wallet_row: list[dict] = [
+        {
+            "text": "👛 Ví điện tử",
+            "callback_data": build_callback(
+                CallbackPrefix.CHANGE_SOURCE, tx, "wallet"
+            ),
+        },
+    ]
+    if allow_credit_card:
+        wallet_row.append(
+            {
+                "text": "💳 Thẻ tín dụng",
+                "callback_data": build_callback(
+                    CallbackPrefix.CHANGE_SOURCE, tx, "card"
+                ),
+            }
+        )
     rows: list[list[dict]] = [
         [
             {
@@ -79,20 +103,7 @@ def source_picker_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
                 ),
             },
         ],
-        [
-            {
-                "text": "👛 Ví điện tử",
-                "callback_data": build_callback(
-                    CallbackPrefix.CHANGE_SOURCE, tx, "wallet"
-                ),
-            },
-            {
-                "text": "💳 Thẻ tín dụng",
-                "callback_data": build_callback(
-                    CallbackPrefix.CHANGE_SOURCE, tx, "card"
-                ),
-            },
-        ],
+        wallet_row,
         [
             {
                 "text": "❌ Hủy",
@@ -123,10 +134,20 @@ def transaction_batch_actions_keyboard(batch_id: str) -> InlineKeyboardMarkup:
     }
 
 
-def category_picker_keyboard(transaction_id: str) -> InlineKeyboardMarkup:
-    """Keyboard hiện danh mục khi user tap 'Đổi danh mục'. 2 cột x N hàng."""
+def category_picker_keyboard(
+    transaction_id: str, *, transaction_type: str = "expense"
+) -> InlineKeyboardMarkup:
+    """Keyboard hiện danh mục khi user tap 'Đổi danh mục'. 2 cột x N hàng.
+
+    Money-in transactions get the income taxonomy (Lương/Thưởng, Cổ tức…)
+    rather than spending buckets, which would mis-categorize income.
+    """
     tx = str(transaction_id)
-    categories = get_all_categories()
+    categories = (
+        get_all_income_categories()
+        if transaction_type == "money_in"
+        else get_all_categories()
+    )
     rows: list[list[dict]] = []
 
     for i in range(0, len(categories), 2):

--- a/backend/config/categories.py
+++ b/backend/config/categories.py
@@ -32,11 +32,37 @@ CATEGORIES: dict[str, Category] = {
 }
 
 
+# Income (money-in) categories — kept separate from spending buckets so the
+# transaction category picker can offer the right taxonomy. Codes mirror the
+# Mini App money-in labels (see backend/miniapp/routes.py) so both surfaces
+# agree on what an income category means.
+INCOME_CATEGORIES: dict[str, Category] = {
+    "salary_bonus": Category("salary_bonus", "Lương/Thưởng", "💼", "#2E7D32"),
+    "freelance_part_time": Category("freelance_part_time", "Freelance/Việc thêm", "🧑‍💻", "#388E3C"),
+    "dividend": Category("dividend", "Cổ tức", "📈", "#43A047"),
+    "saving_interest": Category("saving_interest", "Lãi tiết kiệm", "🏦", "#66BB6A"),
+    "other_income": Category("other_income", "Khác", "💰", "#A8E6CF"),
+}
+
+
 def get_category(code: str) -> Category:
-    """Lấy category; fallback về 'other' nếu không tìm thấy."""
-    return CATEGORIES.get(code, CATEGORIES["other"])
+    """Lấy category; fallback về 'other' nếu không tìm thấy.
+
+    Resolves both spending and income codes — a money-in transaction whose
+    category is e.g. ``salary_bonus`` must still render its emoji/label.
+    """
+    if code in CATEGORIES:
+        return CATEGORIES[code]
+    if code in INCOME_CATEGORIES:
+        return INCOME_CATEGORIES[code]
+    return CATEGORIES["other"]
 
 
 def get_all_categories() -> list[Category]:
-    """Trả về toàn bộ categories theo thứ tự định nghĩa."""
+    """Trả về toàn bộ spending categories theo thứ tự định nghĩa."""
     return list(CATEGORIES.values())
+
+
+def get_all_income_categories() -> list[Category]:
+    """Trả về toàn bộ income (money-in) categories theo thứ tự định nghĩa."""
+    return list(INCOME_CATEGORIES.values())

--- a/backend/profile/handlers/profile_menu.py
+++ b/backend/profile/handlers/profile_menu.py
@@ -114,6 +114,14 @@ def profile_keyboard(*, editable: bool = True) -> dict[str, list[list[dict[str, 
                         "callback_data": "profile:default_expense_source",
                     }
                 ],
+                [
+                    {
+                        "text": _copy(
+                            "keyboards", "profile", "default_money_in_source"
+                        ),
+                        "callback_data": "profile:default_money_in_source",
+                    }
+                ],
             ]
         )
     rows.append(
@@ -439,6 +447,18 @@ async def handle_profile_callback(
     if action == "set_default_expense_source" and len(parts) >= 3:
         source_key = ":".join(parts[2:])
         await _set_default_expense_source(
+            db, chat_id, message_id, user, profile, source_key
+        )
+        return True
+    if action == "default_money_in_source":
+        await _render_default_money_in_source(db, chat_id, message_id, user, profile)
+        return True
+    if action == "change_default_money_in_source":
+        await _render_default_money_in_source_options(db, chat_id, message_id, user)
+        return True
+    if action == "set_default_money_in_source" and len(parts) >= 3:
+        source_key = ":".join(parts[2:])
+        await _set_default_money_in_source(
             db, chat_id, message_id, user, profile, source_key
         )
         return True
@@ -983,6 +1003,147 @@ async def _set_default_expense_source(
         text=_copy("default_expense_source", "changed_message").format(source=labels[source_key]),
     )
     await _render_default_expense_source(db, chat_id, message_id, user, profile)
+
+
+async def _money_in_source_options(
+    user_id: Any, db: AsyncSession
+) -> list[tuple[str, str]]:
+    """Source options for incoming money.
+
+    Mirrors :func:`_expense_source_options` but deliberately omits credit
+    cards — money can never *arrive* into a credit card. Only cash, bank
+    accounts and e-wallets are valid destinations for money-in.
+    """
+    cash_options: list[tuple[str, str]] = [("cash", "Tiền mặt")]
+    bank_options: list[tuple[str, str]] = []
+    wallet_options: list[tuple[str, str]] = []
+
+    assets = (
+        (
+            await db.execute(
+                select(Asset)
+                .where(
+                    Asset.user_id == user_id,
+                    Asset.asset_type == "cash",
+                    Asset.is_active.is_(True),
+                )
+                .order_by(Asset.created_at.asc())
+            )
+        )
+        .scalars()
+        .all()
+    )
+    for asset in assets:
+        subtype = (asset.subtype or "").lower()
+        asset_name = str(asset.name or "").strip()
+        if subtype in {"bank_checking", "bank_account"}:
+            bank_options.append(
+                (f"bank_account:{asset.id}", f"Tài khoản thanh toán [{asset_name}]")
+            )
+        elif subtype in {"momo", "vnpay", "zalopay", "viettelpay", "e_wallet"}:
+            wallet_options.append(
+                (f"e_wallet:{asset.id}", f"Ví điện tử [{asset_name}]")
+            )
+
+    def _sort_alpha(items: list[tuple[str, str]]) -> list[tuple[str, str]]:
+        return sorted(items, key=lambda pair: pair[1].casefold())
+
+    return cash_options + _sort_alpha(bank_options) + _sort_alpha(wallet_options)
+
+
+async def _render_default_money_in_source(
+    db: AsyncSession,
+    chat_id: int,
+    message_id: int | None,
+    user: User,
+    profile: UserProfile,
+) -> None:
+    options = await _money_in_source_options(user.id, db)
+    label = _resolve_source_label(options, profile.default_money_in_source)
+    text = _copy("default_money_in_source", "panel").format(source=label)
+    markup = {
+        "inline_keyboard": [
+            [
+                {
+                    "text": _copy("default_money_in_source", "change_button"),
+                    "callback_data": "profile:change_default_money_in_source",
+                }
+            ],
+            [
+                {
+                    "text": _copy("default_money_in_source", "back_button"),
+                    "callback_data": "profile:view",
+                }
+            ],
+        ]
+    }
+    if message_id is None:
+        await send_message(chat_id=chat_id, text=text, reply_markup=markup)
+        return
+    await edit_message_text(
+        chat_id=chat_id, message_id=message_id, text=text, reply_markup=markup
+    )
+
+
+async def _render_default_money_in_source_options(
+    db: AsyncSession, chat_id: int, message_id: int | None, user: User
+) -> None:
+    options = await _money_in_source_options(user.id, db)
+    tokenized_options = [
+        (_source_token(i), key, label) for i, (key, label) in enumerate(options)
+    ]
+    rows = [
+        [
+            {
+                "text": label,
+                "callback_data": f"profile:set_default_money_in_source:{token}",
+            }
+        ]
+        for token, _key, label in tokenized_options
+    ]
+    rows.append(
+        [
+            {
+                "text": _copy("default_money_in_source", "back_button"),
+                "callback_data": "profile:default_money_in_source",
+            }
+        ]
+    )
+    markup = {"inline_keyboard": rows}
+    text = _copy("default_money_in_source", "picker_title")
+    if message_id is None:
+        await send_message(chat_id=chat_id, text=text, reply_markup=markup)
+        return
+    await edit_message_text(
+        chat_id=chat_id, message_id=message_id, text=text, reply_markup=markup
+    )
+
+
+async def _set_default_money_in_source(
+    db: AsyncSession,
+    chat_id: int,
+    message_id: int | None,
+    user: User,
+    profile: UserProfile,
+    source_key: str,
+) -> None:
+    options = await _money_in_source_options(user.id, db)
+    source_key = _decode_source_token(source_key, options)
+    labels = dict(options)
+    if source_key not in labels:
+        await send_message(
+            chat_id=chat_id, text=_copy("default_money_in_source", "invalid")
+        )
+        return
+    profile.default_money_in_source = source_key
+    await db.flush()
+    await send_message(
+        chat_id=chat_id,
+        text=_copy("default_money_in_source", "changed_message").format(
+            source=labels[source_key]
+        ),
+    )
+    await _render_default_money_in_source(db, chat_id, message_id, user, profile)
 
 
 def _source_token(index: int) -> str:

--- a/backend/profile/handlers/profile_menu.py
+++ b/backend/profile/handlers/profile_menu.py
@@ -926,7 +926,11 @@ async def _expense_source_options(user_id: Any, db: AsyncSession) -> list[tuple[
         asset_name = str(asset.name or "").strip()
         if subtype in {"bank_checking", "bank_account"}:
             bank_options.append((f"bank_account:{asset.id}", f"Tài khoản thanh toán [{asset_name}]"))
-        elif subtype in {"momo", "vnpay", "zalopay", "viettelpay", "e_wallet"}:
+        # Provider-less generic "e_wallet" is intentionally excluded: it has
+        # no e_wallet_provider, so resolve_source_asset_for_payload raises and
+        # the transaction fast-path crashes. Only provider-tagged wallets are
+        # selectable as a default source.
+        elif subtype in {"momo", "vnpay", "zalopay", "viettelpay"}:
             wallet_options.append((f"e_wallet:{asset.id}", f"Ví điện tử [{asset_name}]"))
 
     def _sort_alpha(items: list[tuple[str, str]]) -> list[tuple[str, str]]:
@@ -1040,7 +1044,11 @@ async def _money_in_source_options(
             bank_options.append(
                 (f"bank_account:{asset.id}", f"Tài khoản thanh toán [{asset_name}]")
             )
-        elif subtype in {"momo", "vnpay", "zalopay", "viettelpay", "e_wallet"}:
+        # Provider-less generic "e_wallet" is intentionally excluded: it has
+        # no e_wallet_provider, so resolve_source_asset_for_payload raises and
+        # the transaction fast-path crashes. Only provider-tagged wallets are
+        # selectable as a default source.
+        elif subtype in {"momo", "vnpay", "zalopay", "viettelpay"}:
             wallet_options.append(
                 (f"e_wallet:{asset.id}", f"Ví điện tử [{asset_name}]")
             )

--- a/backend/profile/models/user_profile.py
+++ b/backend/profile/models/user_profile.py
@@ -41,6 +41,7 @@ class UserProfile(Base):
         Time, default=time(9, 0), nullable=False
     )
     default_expense_source: Mapped[str | None] = mapped_column(String(120))
+    default_money_in_source: Mapped[str | None] = mapped_column(String(120))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow, nullable=False
     )

--- a/backend/services/expense_service.py
+++ b/backend/services/expense_service.py
@@ -13,7 +13,10 @@ from backend.models.credit_card import CreditCard
 from backend.models.transaction import Transaction
 from backend.wealth.models.asset import Asset
 from backend.schemas.expense import ExpenseCreate, ExpenseUpdate
-from backend.services.expense_source_resolver import DEFAULT_SOURCE_RAW_DATA_KEY
+from backend.services.expense_source_resolver import (
+    DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY,
+    DEFAULT_SOURCE_RAW_DATA_KEY,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -43,6 +46,7 @@ def _raw_data_without_default_source_marker(raw_data: dict | None) -> dict | Non
     """Remove the profile-default marker once the user explicitly edits source."""
     cleaned = dict(raw_data or {})
     cleaned.pop(DEFAULT_SOURCE_RAW_DATA_KEY, None)
+    cleaned.pop(DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY, None)
     return cleaned or None
 
 

--- a/backend/services/expense_source_resolver.py
+++ b/backend/services/expense_source_resolver.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any
 
 import yaml
-from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from backend.models.credit_card import CreditCard
@@ -33,7 +32,13 @@ from backend.wealth.models.asset import Asset
 logger = logging.getLogger(__name__)
 
 DEFAULT_SOURCE_RAW_DATA_KEY = "source_from_default_expense_source"
+DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY = "source_from_default_money_in_source"
 DEFAULT_SOURCE_SUFFIX = " (mặc định)"
+
+# Money-in never funds from a credit card — only cash, bank accounts, and
+# e-wallets are valid incoming sources. We reject a credit_card key defensively
+# in case a stale/hand-edited profile value slips through.
+_MONEY_IN_ALLOWED_SOURCE_TYPES = frozenset({"cash", "bank_account", "e_wallet"})
 
 _CONTENT_PATH = (
     Path(__file__).resolve().parents[2] / "content" / "transaction_copy.yaml"
@@ -84,12 +89,16 @@ async def apply_default_source(
 ) -> ExpenseCreate:
     """Return a copy of ``data`` with the user's default source applied.
 
+    Handles both expense (``default_expense_source``) and money-in
+    (``default_money_in_source``) transactions, reading the matching
+    profile column for each.
+
     No-op when:
-      - the transaction is money-in (incoming flow keeps current UX);
-      - the user has no default configured;
+      - the transaction type is neither expense nor money-in;
+      - the user has no matching default configured;
       - the caller has already specified a source (explicit > default).
     """
-    if data.transaction_type != "expense":
+    if data.transaction_type not in ("expense", "money_in"):
         return data
     if (
         data.source_type
@@ -99,13 +108,28 @@ async def apply_default_source(
         return data
 
     profile = await db.get(UserProfile, user_id)
-    key = profile.default_expense_source if profile else None
+    is_money_in = data.transaction_type == "money_in"
+    if profile is None:
+        key = None
+    elif is_money_in:
+        key = profile.default_money_in_source
+    else:
+        key = profile.default_expense_source
     source_type, asset_id, card_id = _parse_source_key(key)
     if not source_type:
         return data
+    # Money-in can never originate from a credit card — drop a stale key
+    # rather than create a nonsensical incoming-from-credit transaction.
+    if is_money_in and source_type not in _MONEY_IN_ALLOWED_SOURCE_TYPES:
+        return data
 
     raw_data = dict(data.raw_data or {})
-    raw_data[DEFAULT_SOURCE_RAW_DATA_KEY] = True
+    raw_data_key = (
+        DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY
+        if is_money_in
+        else DEFAULT_SOURCE_RAW_DATA_KEY
+    )
+    raw_data[raw_data_key] = True
     return data.model_copy(
         update={
             "source_type": source_type,
@@ -119,7 +143,9 @@ async def apply_default_source(
 def _with_default_suffix(label: str, expense: Expense) -> str:
     """Append the UI marker when the source came from profile default."""
     raw_data = expense.raw_data or {}
-    if raw_data.get(DEFAULT_SOURCE_RAW_DATA_KEY):
+    if raw_data.get(DEFAULT_SOURCE_RAW_DATA_KEY) or raw_data.get(
+        DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY
+    ):
         return f"{label}{DEFAULT_SOURCE_SUFFIX}"
     return label
 
@@ -129,11 +155,12 @@ async def resolve_source_label_for_expense(
 ) -> str | None:
     """Build the Vietnamese label shown on the confirmation card.
 
-    Returns ``None`` for money-in or when no source could be resolved.
-    The card line is decorative — silently dropping it is preferable
-    to surfacing a stale or wrong-looking label.
+    Works for both expense and money-in transactions. Returns ``None``
+    when no source could be resolved. The card line is decorative —
+    silently dropping it is preferable to surfacing a stale or
+    wrong-looking label.
     """
-    if expense.transaction_type != "expense":
+    if expense.transaction_type not in ("expense", "money_in"):
         return None
     source_type = expense.source_type
     if not source_type:

--- a/content/profile_copy.yaml
+++ b/content/profile_copy.yaml
@@ -88,6 +88,7 @@ keyboards:
     notifications: "🔔 Cài thông báo"
     glossary: "❓ Giải thích các mục"
     default_expense_source: "💸 Nguồn chi tiêu thường xuyên"
+    default_money_in_source: "💰 Nguồn tiền vào thường xuyên"
     back: "◀️ Quay lại"
   age:
     none: "🚫 Không muốn nói"
@@ -154,3 +155,11 @@ default_expense_source:
   back_button: "◀️ Quay lại Profile"
   changed_message: "✅ Đã đổi nguồn chi tiêu thường xuyên sang: {source}."
   invalid: "Nguồn chi tiêu không hợp lệ."
+
+default_money_in_source:
+  panel: "💰 Nguồn tiền vào thường xuyên bạn đang dùng là *{source}*.\n\nBấm *Đổi nguồn* nếu bạn muốn thay đổi."
+  picker_title: "Chọn nguồn tiền vào thường xuyên:"
+  change_button: "Đổi nguồn"
+  back_button: "◀️ Quay lại Profile"
+  changed_message: "✅ Đã đổi nguồn tiền vào thường xuyên sang: {source}."
+  invalid: "Nguồn tiền vào không hợp lệ."

--- a/content/transaction_copy.yaml
+++ b/content/transaction_copy.yaml
@@ -2,7 +2,9 @@ confirmation:
   title_done: "✅ Đã ghi xong!"
   batch_title: "✅ Đã ghi xong {count} khoản!"
   source_prefix: "💳 Chi từ: {source}"
+  source_prefix_money_in: "💰 Nhận vào: {source}"
   edit_hint: "<i>💡 chi tiêu đã được ghi lại, nếu đúng bạn không cần làm gì thêm! Nếu thông tin chưa chính xác, hãy click vào các nhãn ở dưới để sửa lại.</i>"
+  edit_hint_money_in: "<i>💡 khoản tiền vào đã được ghi lại, nếu đúng bạn không cần làm gì thêm! Nếu thông tin chưa chính xác, hãy click vào các nhãn ở dưới để sửa lại.</i>"
 
 source_labels:
   cash: "Tiền mặt"

--- a/tests/test_default_money_in_source.py
+++ b/tests/test_default_money_in_source.py
@@ -1,0 +1,218 @@
+"""Tests for the ``default_money_in_source`` resolver behaviour.
+
+Mirrors the expense-source resolver but for incoming money: applying the
+profile default, rejecting credit-card sources, no-op guards, and the
+confirmation-card label (with the "(mặc định)" suffix).
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from backend.schemas.expense import ExpenseCreate
+from backend.services.expense_source_resolver import (
+    DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY,
+    DEFAULT_SOURCE_RAW_DATA_KEY,
+    DEFAULT_SOURCE_SUFFIX,
+    apply_default_source,
+    resolve_source_label_for_expense,
+)
+
+
+class FakeDB:
+    """Minimal async DB stub backed by an id→object map for ``.get``."""
+
+    def __init__(self, objects: dict | None = None):
+        # keyed by primary-key value (uuid); model type ignored for simplicity
+        self._objects = dict(objects or {})
+
+    async def get(self, _model, pk):
+        return self._objects.get(pk)
+
+
+def _profile(*, expense=None, money_in=None):
+    return SimpleNamespace(
+        default_expense_source=expense,
+        default_money_in_source=money_in,
+    )
+
+
+def _money_in_create(**overrides) -> ExpenseCreate:
+    base = dict(
+        amount=100000.0,
+        merchant="Lương",
+        source="manual",
+        category="other",
+        transaction_type="money_in",
+    )
+    base.update(overrides)
+    return ExpenseCreate(**base)
+
+
+# --------------------------------------------------------------------------
+# apply_default_source — money_in
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_apply_default_money_in_cash():
+    user_id = uuid.uuid4()
+    db = FakeDB({user_id: _profile(money_in="cash")})
+
+    result = await apply_default_source(db, user_id, _money_in_create())
+
+    assert result.source_type == "cash"
+    assert result.source_asset_id is None
+    assert result.source_credit_card_id is None
+    assert result.raw_data[DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY] is True
+    # must not be tagged as the expense default
+    assert DEFAULT_SOURCE_RAW_DATA_KEY not in result.raw_data
+
+
+@pytest.mark.asyncio
+async def test_apply_default_money_in_bank_account():
+    user_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+    db = FakeDB({user_id: _profile(money_in=f"bank_account:{asset_id}")})
+
+    result = await apply_default_source(db, user_id, _money_in_create())
+
+    assert result.source_type == "bank_account"
+    assert result.source_asset_id == asset_id
+    assert result.source_credit_card_id is None
+
+
+@pytest.mark.asyncio
+async def test_apply_default_money_in_e_wallet():
+    user_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+    db = FakeDB({user_id: _profile(money_in=f"e_wallet:{asset_id}")})
+
+    result = await apply_default_source(db, user_id, _money_in_create())
+
+    assert result.source_type == "e_wallet"
+    assert result.source_asset_id == asset_id
+
+
+@pytest.mark.asyncio
+async def test_apply_default_money_in_rejects_credit_card():
+    """A stale credit_card key must never produce money-in-from-credit."""
+    user_id = uuid.uuid4()
+    card_id = uuid.uuid4()
+    db = FakeDB({user_id: _profile(money_in=f"credit_card:{card_id}")})
+
+    result = await apply_default_source(db, user_id, _money_in_create())
+
+    assert result.source_type is None
+    assert result.source_credit_card_id is None
+    assert result.raw_data is None
+
+
+@pytest.mark.asyncio
+async def test_apply_default_money_in_no_default_is_noop():
+    user_id = uuid.uuid4()
+    db = FakeDB({user_id: _profile(money_in=None, expense="cash")})
+
+    result = await apply_default_source(db, user_id, _money_in_create())
+
+    # expense default must not leak into a money-in transaction
+    assert result.source_type is None
+
+
+@pytest.mark.asyncio
+async def test_apply_default_money_in_explicit_source_wins():
+    user_id = uuid.uuid4()
+    explicit_asset = uuid.uuid4()
+    db = FakeDB({user_id: _profile(money_in="cash")})
+
+    data = _money_in_create(source_type="e_wallet", source_asset_id=explicit_asset)
+    result = await apply_default_source(db, user_id, data)
+
+    assert result.source_type == "e_wallet"
+    assert result.source_asset_id == explicit_asset
+
+
+@pytest.mark.asyncio
+async def test_apply_default_money_in_no_profile_is_noop():
+    user_id = uuid.uuid4()
+    db = FakeDB({})  # profile missing
+
+    result = await apply_default_source(db, user_id, _money_in_create())
+
+    assert result.source_type is None
+
+
+@pytest.mark.asyncio
+async def test_apply_default_unknown_type_is_noop():
+    user_id = uuid.uuid4()
+    db = FakeDB({user_id: _profile(money_in="cash", expense="cash")})
+
+    data = ExpenseCreate(
+        amount=1000.0,
+        merchant="x",
+        source="manual",
+        category="other",
+        transaction_type="expense",
+    )
+    # sanity: expense path still works through the same function
+    result = await apply_default_source(db, user_id, data)
+    assert result.source_type == "cash"
+    assert result.raw_data[DEFAULT_SOURCE_RAW_DATA_KEY] is True
+
+
+# --------------------------------------------------------------------------
+# resolve_source_label_for_expense — money_in
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolve_label_money_in_cash_with_default_suffix():
+    db = FakeDB({})
+    expense = SimpleNamespace(
+        transaction_type="money_in",
+        source_type="cash",
+        source_asset_id=None,
+        source_credit_card_id=None,
+        user_id=uuid.uuid4(),
+        raw_data={DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY: True},
+    )
+
+    label = await resolve_source_label_for_expense(db, expense)
+
+    assert label == f"Tiền mặt{DEFAULT_SOURCE_SUFFIX}"
+
+
+@pytest.mark.asyncio
+async def test_resolve_label_money_in_bank_with_asset_name():
+    user_id = uuid.uuid4()
+    asset_id = uuid.uuid4()
+    asset = SimpleNamespace(name="Techcombank", user_id=user_id)
+    db = FakeDB({asset_id: asset})
+    expense = SimpleNamespace(
+        transaction_type="money_in",
+        source_type="bank_account",
+        source_asset_id=asset_id,
+        source_credit_card_id=None,
+        user_id=user_id,
+        raw_data={},
+    )
+
+    label = await resolve_source_label_for_expense(db, expense)
+
+    assert label == "Tài khoản thanh toán [Techcombank]"
+
+
+@pytest.mark.asyncio
+async def test_resolve_label_money_in_no_source_returns_none():
+    db = FakeDB({})
+    expense = SimpleNamespace(
+        transaction_type="money_in",
+        source_type=None,
+        source_asset_id=None,
+        source_credit_card_id=None,
+        user_id=uuid.uuid4(),
+        raw_data={},
+    )
+
+    assert await resolve_source_label_for_expense(db, expense) is None

--- a/tests/test_default_source_marker_strip.py
+++ b/tests/test_default_source_marker_strip.py
@@ -1,0 +1,44 @@
+"""Tests for stripping the profile-default markers on explicit source edits.
+
+When a user edits the source of a transaction that was created from a
+profile default, the ``(mặc định)`` marker must be cleared — for BOTH the
+expense (``default_expense_source``) and money-in
+(``default_money_in_source``) markers.
+"""
+
+from backend.services.expense_service import (
+    _raw_data_without_default_source_marker,
+)
+from backend.services.expense_source_resolver import (
+    DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY,
+    DEFAULT_SOURCE_RAW_DATA_KEY,
+)
+
+
+def test_strips_expense_default_marker():
+    cleaned = _raw_data_without_default_source_marker(
+        {DEFAULT_SOURCE_RAW_DATA_KEY: True, "keep": 1}
+    )
+    assert cleaned == {"keep": 1}
+
+
+def test_strips_money_in_default_marker():
+    cleaned = _raw_data_without_default_source_marker(
+        {DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY: True, "keep": 1}
+    )
+    assert cleaned == {"keep": 1}
+
+
+def test_strips_both_markers():
+    cleaned = _raw_data_without_default_source_marker(
+        {
+            DEFAULT_SOURCE_RAW_DATA_KEY: True,
+            DEFAULT_MONEY_IN_SOURCE_RAW_DATA_KEY: True,
+        }
+    )
+    assert cleaned is None
+
+
+def test_noop_when_no_markers():
+    assert _raw_data_without_default_source_marker(None) is None
+    assert _raw_data_without_default_source_marker({}) is None

--- a/tests/test_message_money_in_fastpath.py
+++ b/tests/test_message_money_in_fastpath.py
@@ -50,6 +50,64 @@ async def test_record_money_in_with_default_creates_and_confirms(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_money_in_fastpath_leaves_category_for_income_normalization(monkeypatch):
+    """Money-in must reach create_expense at the schema default (needs_review)
+    so the service normalizes it to the 'income' category — not 'other'."""
+    user = SimpleNamespace(id=uuid.uuid4())
+    captured = {}
+
+    async def fake_apply_default(_db, _uid, data):
+        captured["category"] = data.category
+        return data.model_copy(update={"source_type": "cash"})
+
+    async def fake_create(_db, _uid, data):
+        return SimpleNamespace(
+            transaction_type=data.transaction_type, source_type=data.source_type
+        )
+
+    async def fake_confirm(_db, _expense):
+        return None
+
+    monkeypatch.setattr(message_handler, "apply_default_source", fake_apply_default)
+    monkeypatch.setattr(message_handler.expense_service, "create_expense", fake_create)
+    monkeypatch.setattr(message_handler, "send_transaction_confirmation", fake_confirm)
+
+    parsed = {"amount": 3_000_000, "transaction_type": "money_in", "note": "Thưởng"}
+    await message_handler._record_transaction_with_default(None, user, parsed)
+
+    # not forced to "other" — left at the default so create_expense → income
+    assert captured["category"] == "needs_review"
+
+
+@pytest.mark.asyncio
+async def test_expense_fastpath_still_hardcodes_other_category(monkeypatch):
+    """Regression: the expense fast-path keeps its 'other' category (no LLM)."""
+    user = SimpleNamespace(id=uuid.uuid4())
+    captured = {}
+
+    async def fake_apply_default(_db, _uid, data):
+        captured["category"] = data.category
+        return data.model_copy(update={"source_type": "cash"})
+
+    async def fake_create(_db, _uid, data):
+        return SimpleNamespace(
+            transaction_type=data.transaction_type, source_type=data.source_type
+        )
+
+    async def fake_confirm(_db, _expense):
+        return None
+
+    monkeypatch.setattr(message_handler, "apply_default_source", fake_apply_default)
+    monkeypatch.setattr(message_handler.expense_service, "create_expense", fake_create)
+    monkeypatch.setattr(message_handler, "send_transaction_confirmation", fake_confirm)
+
+    parsed = {"amount": 45_000, "transaction_type": "expense", "merchant": "Phở"}
+    await message_handler._record_transaction_with_default(None, user, parsed)
+
+    assert captured["category"] == "other"
+
+
+@pytest.mark.asyncio
 async def test_record_money_in_without_default_returns_false(monkeypatch):
     user = SimpleNamespace(id=uuid.uuid4())
 

--- a/tests/test_message_money_in_fastpath.py
+++ b/tests/test_message_money_in_fastpath.py
@@ -1,0 +1,76 @@
+"""Tests for the money-in fast-path in message handling.
+
+``_record_transaction_with_default`` creates a money-in transaction with
+the user's ``default_money_in_source`` and sends the rich confirmation,
+returning False (falling back to the picker) when no default is set.
+"""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from backend.bot.handlers import message as message_handler
+
+
+@pytest.mark.asyncio
+async def test_record_money_in_with_default_creates_and_confirms(monkeypatch):
+    user = SimpleNamespace(id=uuid.uuid4())
+    captured = {}
+
+    async def fake_apply_default(_db, _uid, data):
+        # simulate default applied → source resolved
+        return data.model_copy(update={"source_type": "cash"})
+
+    async def fake_create(_db, _uid, data):
+        created = SimpleNamespace(
+            transaction_type=data.transaction_type, source_type=data.source_type
+        )
+        captured["created"] = created
+        return created
+
+    async def fake_confirm(_db, expense):
+        captured["confirmed"] = expense
+
+    monkeypatch.setattr(message_handler, "apply_default_source", fake_apply_default)
+    monkeypatch.setattr(
+        message_handler.expense_service, "create_expense", fake_create
+    )
+    monkeypatch.setattr(
+        message_handler, "send_transaction_confirmation", fake_confirm
+    )
+
+    parsed = {"amount": 5_000_000, "transaction_type": "money_in", "note": "Lương"}
+    ok = await message_handler._record_transaction_with_default(None, user, parsed)
+
+    assert ok is True
+    assert captured["created"].transaction_type == "money_in"
+    assert captured["created"].source_type == "cash"
+    assert captured["confirmed"] is captured["created"]
+
+
+@pytest.mark.asyncio
+async def test_record_money_in_without_default_returns_false(monkeypatch):
+    user = SimpleNamespace(id=uuid.uuid4())
+
+    async def fake_apply_default(_db, _uid, data):
+        # no default configured → source stays unresolved
+        return data
+
+    created = False
+
+    async def fake_create(_db, _uid, data):
+        nonlocal created
+        created = True
+        return SimpleNamespace()
+
+    monkeypatch.setattr(message_handler, "apply_default_source", fake_apply_default)
+    monkeypatch.setattr(
+        message_handler.expense_service, "create_expense", fake_create
+    )
+
+    parsed = {"amount": 5_000_000, "transaction_type": "money_in"}
+    ok = await message_handler._record_transaction_with_default(None, user, parsed)
+
+    assert ok is False
+    assert created is False  # never reached the create call

--- a/tests/test_money_in_confirmation_template.py
+++ b/tests/test_money_in_confirmation_template.py
@@ -1,0 +1,50 @@
+"""Tests for money-in rendering in the transaction confirmation template."""
+
+from backend.bot.formatters.templates import format_transaction_confirmation
+
+
+def test_money_in_confirmation_uses_received_prefix():
+    text = format_transaction_confirmation(
+        merchant="Lương tháng 6",
+        amount=15_000_000,
+        category_code="other",
+        source_label="Tài khoản thanh toán [Techcombank]",
+        show_edit_hint=True,
+        transaction_type="money_in",
+    )
+
+    assert "💰 Nhận vào: Tài khoản thanh toán [Techcombank]" in text
+    # must NOT use the expense "Chi từ" prefix
+    assert "Chi từ" not in text
+    # money-in edit hint variant
+    assert "khoản tiền vào đã được ghi lại" in text
+
+
+def test_money_in_confirmation_omits_daily_budget_block():
+    text = format_transaction_confirmation(
+        merchant="Thưởng",
+        amount=2_000_000,
+        category_code="other",
+        source_label="Tiền mặt",
+        daily_spent=None,
+        daily_budget=None,
+        show_edit_hint=True,
+        transaction_type="money_in",
+    )
+
+    assert "Hôm nay" not in text
+
+
+def test_expense_confirmation_still_uses_spend_prefix():
+    text = format_transaction_confirmation(
+        merchant="Phở",
+        amount=45000,
+        category_code="food",
+        source_label="Tiền mặt",
+        show_edit_hint=True,
+        transaction_type="expense",
+    )
+
+    assert "💳 Chi từ: Tiền mặt" in text
+    assert "Nhận vào" not in text
+    assert "chi tiêu đã được ghi lại" in text

--- a/tests/test_money_in_edit_pickers.py
+++ b/tests/test_money_in_edit_pickers.py
@@ -1,0 +1,84 @@
+"""Tests for the money-in-aware edit pickers on the transaction confirm card.
+
+Money-in transactions must mirror expense's 4 edit buttons but with the
+correct taxonomy:
+  * the source picker hides credit cards (money can't arrive into a card)
+  * the category picker offers income categories (not spending buckets)
+"""
+
+from backend.bot.keyboards.transaction_keyboard import (
+    category_picker_keyboard,
+    source_picker_keyboard,
+)
+from backend.config.categories import (
+    get_all_categories,
+    get_all_income_categories,
+    get_category,
+)
+
+
+def _all_callback_data(markup: dict) -> list[str]:
+    return [
+        btn["callback_data"]
+        for row in markup["inline_keyboard"]
+        for btn in row
+    ]
+
+
+def _all_labels(markup: dict) -> list[str]:
+    return [btn["text"] for row in markup["inline_keyboard"] for btn in row]
+
+
+# --- source picker -------------------------------------------------------
+
+
+def test_source_picker_expense_includes_credit_card():
+    markup = source_picker_keyboard("tx-1")
+    assert any("Thẻ tín dụng" in t for t in _all_labels(markup))
+    assert any(cb.endswith(":card") for cb in _all_callback_data(markup))
+
+
+def test_source_picker_money_in_hides_credit_card():
+    markup = source_picker_keyboard("tx-1", allow_credit_card=False)
+    assert not any("Thẻ tín dụng" in t for t in _all_labels(markup))
+    assert not any(cb.endswith(":card") for cb in _all_callback_data(markup))
+    # cash / bank / wallet still offered
+    cbs = _all_callback_data(markup)
+    assert any(cb.endswith(":cash") for cb in cbs)
+    assert any(cb.endswith(":bank") for cb in cbs)
+    assert any(cb.endswith(":wallet") for cb in cbs)
+
+
+# --- category picker -----------------------------------------------------
+
+
+def test_category_picker_expense_uses_spending_buckets():
+    labels = " | ".join(_all_labels(category_picker_keyboard("tx-1")))
+    spending_names = {c.name_vi for c in get_all_categories()}
+    # at least one spending bucket present, no income-only label
+    assert any(name in labels for name in spending_names)
+    assert "Lương/Thưởng" not in labels
+
+
+def test_category_picker_money_in_uses_income_categories():
+    labels = " | ".join(
+        _all_labels(category_picker_keyboard("tx-1", transaction_type="money_in"))
+    )
+    assert "Lương/Thưởng" in labels
+    assert "Cổ tức" in labels
+    # only income categories shown, no spending-only bucket
+    assert "Ăn uống" not in labels
+    for cat in get_all_income_categories():
+        assert cat.name_vi in labels
+
+
+# --- category resolution -------------------------------------------------
+
+
+def test_get_category_resolves_income_codes():
+    assert get_category("salary_bonus").name_vi == "Lương/Thưởng"
+    assert get_category("dividend").emoji == "📈"
+
+
+def test_get_category_unknown_falls_back_to_other():
+    assert get_category("nonexistent").code == "other"

--- a/tests/test_profile_money_in_source.py
+++ b/tests/test_profile_money_in_source.py
@@ -42,6 +42,9 @@ def _asset(name, subtype):
         asset_type="cash",
         is_active=True,
         created_at=None,
+        # _expense_source_options also runs a credit-card query against the
+        # same FakeDB rows; a bank_name keeps that iteration from crashing.
+        bank_name="",
     )
 
 
@@ -60,6 +63,36 @@ async def test_money_in_options_exclude_credit_cards():
     assert f"bank_account:{bank.id}" in keys
     assert f"e_wallet:{wallet.id}" in keys
     assert not any(k.startswith("credit_card:") for k in keys)
+
+
+@pytest.mark.asyncio
+async def test_money_in_options_exclude_provider_less_e_wallet():
+    """Generic provider-less ``e_wallet`` is not selectable — it would crash
+    the transaction fast-path (no e_wallet_provider to resolve)."""
+    bank = _asset("Techcombank", "bank_account")
+    momo = _asset("Momo", "momo")
+    generic = _asset("Ví chung", "e_wallet")
+    db = FakeDB([bank, momo, generic])
+
+    options = await profile_menu._money_in_source_options(uuid.uuid4(), db)
+
+    keys = [key for key, _ in options]
+    assert f"e_wallet:{momo.id}" in keys
+    assert f"e_wallet:{generic.id}" not in keys
+
+
+@pytest.mark.asyncio
+async def test_expense_options_exclude_provider_less_e_wallet():
+    """Same exclusion applies to the expense default-source builder."""
+    momo = _asset("Momo", "momo")
+    generic = _asset("Ví chung", "e_wallet")
+    db = FakeDB([momo, generic])
+
+    options = await profile_menu._expense_source_options(uuid.uuid4(), db)
+
+    keys = [key for key, _ in options]
+    assert f"e_wallet:{momo.id}" in keys
+    assert f"e_wallet:{generic.id}" not in keys
 
 
 @pytest.mark.asyncio

--- a/tests/test_profile_money_in_source.py
+++ b/tests/test_profile_money_in_source.py
@@ -1,0 +1,118 @@
+"""Tests for the ``default_money_in_source`` Profile menu handlers."""
+
+import uuid
+from types import SimpleNamespace
+
+import pytest
+
+from backend.profile.handlers import profile_menu
+
+
+class _ScalarsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class FakeDB:
+    """Returns the same asset rows for every ``execute`` (money-in only
+    queries assets — credit cards are never fetched)."""
+
+    def __init__(self, assets):
+        self._assets = assets
+        self.flushed = False
+
+    async def execute(self, _stmt):
+        return _ScalarsResult(self._assets)
+
+    async def flush(self):
+        self.flushed = True
+
+
+def _asset(name, subtype):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name=name,
+        subtype=subtype,
+        asset_type="cash",
+        is_active=True,
+        created_at=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_money_in_options_exclude_credit_cards():
+    bank = _asset("Techcombank", "bank_account")
+    wallet = _asset("Momo", "momo")
+    db = FakeDB([bank, wallet])
+
+    options = await profile_menu._money_in_source_options(uuid.uuid4(), db)
+
+    keys = [key for key, _ in options]
+    # cash is always present and first
+    assert keys[0] == "cash"
+    # bank + wallet present, no credit_card key anywhere
+    assert f"bank_account:{bank.id}" in keys
+    assert f"e_wallet:{wallet.id}" in keys
+    assert not any(k.startswith("credit_card:") for k in keys)
+
+
+@pytest.mark.asyncio
+async def test_set_default_money_in_source_persists(monkeypatch):
+    sent = []
+    monkeypatch.setattr(
+        profile_menu,
+        "send_message",
+        lambda **kw: sent.append(kw) or _noop(),
+    )
+    monkeypatch.setattr(
+        profile_menu,
+        "edit_message_text",
+        lambda **kw: _noop(),
+    )
+
+    bank = _asset("Techcombank", "bank_account")
+    db = FakeDB([bank])
+    profile = SimpleNamespace(default_money_in_source=None)
+    user = SimpleNamespace(id=uuid.uuid4())
+
+    await profile_menu._set_default_money_in_source(
+        db, 123, None, user, profile, "cash"
+    )
+
+    assert profile.default_money_in_source == "cash"
+    assert db.flushed is True
+    # a confirmation message was sent
+    assert any("changed" in str(m.get("text", "")) or m.get("text") for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_set_default_money_in_source_rejects_invalid(monkeypatch):
+    sent = []
+    monkeypatch.setattr(
+        profile_menu,
+        "send_message",
+        lambda **kw: sent.append(kw) or _noop(),
+    )
+    monkeypatch.setattr(profile_menu, "edit_message_text", lambda **kw: _noop())
+
+    db = FakeDB([])
+    profile = SimpleNamespace(default_money_in_source=None)
+    user = SimpleNamespace(id=uuid.uuid4())
+
+    await profile_menu._set_default_money_in_source(
+        db, 123, None, user, profile, "credit_card:" + str(uuid.uuid4())
+    )
+
+    # invalid key never persisted
+    assert profile.default_money_in_source is None
+    assert db.flushed is False
+
+
+async def _noop():
+    return None


### PR DESCRIPTION
## Summary

Adds a configurable **default source for incoming money** (`default_money_in_source`), fully mirroring the existing `default_expense_source` feature so money-in transactions get the same fast, friendly flow as expenses.

## What's included

- **Profile config** — new "💰 Nguồn tiền vào thường xuyên" entry in the Profile main menu with a picker, exactly like `default_expense_source`.
- **Allowed sources** — **only** Tiền mặt (cash), Tài khoản thanh toán [Ngân hàng] (bank account), and Ví điện tử [Tên ví] (e-wallet). Credit cards are deliberately excluded — money can never *arrive* into a credit card — and a defensive guard (`_MONEY_IN_ALLOWED_SOURCE_TYPES`) drops any stale/hand-edited `credit_card` key rather than producing a nonsensical income-from-credit transaction.
- **Transaction creation** — money-in transactions (signed `+/-` fast-path and "được …" money-in parsing) are created with the user's `default_money_in_source` and render the **same rich confirmation card** as expenses: source label + the 4 inline edit buttons (🏷 / 💳 / 💵 / 🗑) + edit hint. If everything is correct, the user does nothing. Daily-budget context stays expense-only.
- **Distinct audit marker** — a separate `raw_data` key (`source_from_default_money_in_source`) keeps the "(mặc định)" suffix and audit trail independent from the expense default.
- **Migration** — new revision adds nullable `user_profiles.default_money_in_source` (down_revision `20260529salutation`, the single current head).
- **Localization** — all new user-facing strings live in `content/*.yaml`, in the warm Bé Tiền *người đồng hành* voice (no "CFO").

## Tests

New unit tests (19) covering:
- `apply_default_source` for money-in: applies cash/bank/e-wallet defaults, rejects `credit_card`, no-op without a default, explicit source wins, missing profile, plus expense regression.
- `resolve_source_label_for_expense` money-in labels (with/without "(mặc định)" suffix, asset name, no-source).
- `_money_in_source_options` excludes credit cards; `_set_default_money_in_source` persists valid keys and rejects invalid ones.
- `format_transaction_confirmation(transaction_type="money_in")` uses the "💰 Nhận vào" prefix and money-in edit hint; expense path unchanged.
- `_record_transaction_with_default` money-in fast path (creates + confirms; falls back to picker when no default).

All new tests pass; related existing suites (expense logic, bot formatters, credit card) remain green. Changed files are lint-clean.

Close #922
