### PR TITLE
Asset edit screens: full-width tap-to-edit rows, delete behind a mode toggle

### DIFF
--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -126,6 +126,11 @@ _DASHBOARD_SORT_BY_USER: dict[uuid.UUID, str] = {}
 # (after edit / cancel-delete) land back on the same page instead of jumping
 # to the top. Cleared implicitly on sort change.
 _DASHBOARD_PAGE_BY_USER: dict[uuid.UUID, int] = {}
+# Tracks whether each user's dashboard report is in "edit" (tap an asset to
+# edit) or "delete" (tap an asset to delete) mode. Tapping an asset is the
+# primary action, so the mode decides what that tap does; the 🗑/✏️ footer
+# toggles between them. Defaults to "edit" — the common case.
+_DASHBOARD_MODE_BY_USER: dict[uuid.UUID, str] = {}
 
 
 def _safe_int(value: str | None, default: int = 0) -> int:
@@ -326,14 +331,22 @@ async def show_asset_dashboard_report(
     *,
     sort: str | None = None,
     page: int | None = None,
+    mode: str | None = None,
     message_id: int | None = None,
 ) -> None:
     """Render the asset dashboard report with inline row actions.
+
+    ``mode`` is ``"edit"`` (tap an asset to edit) or ``"delete"`` (tap an asset
+    to delete); when ``None`` we reuse the user's last mode (default ``"edit"``).
 
     Rows are paginated so the keyboard markup stays under Telegram's ~10 KB
     practical reply_markup limit (a user with ~50 assets used to hit it
     and silently get no response — see asset_dashboard_edit_keyboard).
     """
+    mode_key = mode or _DASHBOARD_MODE_BY_USER.get(user.id, "edit")
+    if mode_key not in ("edit", "delete"):
+        mode_key = "edit"
+    _DASHBOARD_MODE_BY_USER[user.id] = mode_key
     sort_key = normalize_sort(sort or _dashboard_sort_for_user(user))
     _DASHBOARD_SORT_BY_USER[user.id] = sort_key
     assets = _sort_assets_for_dashboard(
@@ -341,6 +354,7 @@ async def show_asset_dashboard_report(
     )
     if not assets:
         _DASHBOARD_PAGE_BY_USER.pop(user.id, None)
+        _DASHBOARD_MODE_BY_USER.pop(user.id, None)
         text = (
             "📊 <b>Báo cáo</b>\n\n"
             "Bạn chưa có tài sản nào. Tap /themtaisan để bắt đầu nhé."
@@ -358,14 +372,20 @@ async def show_asset_dashboard_report(
         page = _DASHBOARD_PAGE_BY_USER.get(user.id, 0)
     page = clamp_page(page, len(rows))
     _DASHBOARD_PAGE_BY_USER[user.id] = page
+    if mode_key == "delete":
+        hint = "\n🗑️ Chạm một tài sản để xoá. Đổi ý? Tap ✏️ Quay lại sửa."
+    else:
+        hint = "\n👆 Chạm một tài sản để sửa. Muốn xoá? Tap 🗑 Xoá tài sản."
     text = (
         format_asset_list(assets).replace(
             "📊 <b>Tài sản của bạn</b>", "📊 <b>Báo cáo</b>", 1
         )
         + f"\n\nSắp xếp: <b>{html.escape(_dashboard_sort_label(sort_key))}</b>"
-        + "\n👆 Dùng ✏️ để sửa, 🗑️ để xoá."
+        + hint
     )
-    markup = asset_dashboard_edit_keyboard(rows, current_sort=sort_key, page=page)
+    markup = asset_dashboard_edit_keyboard(
+        rows, current_sort=sort_key, page=page, mode=mode_key
+    )
     if message_id is not None:
         await edit_message_text(
             chat_id=chat_id,
@@ -3359,13 +3379,21 @@ async def handle_dashboard_callback(db: AsyncSession, callback_query: dict) -> b
                 db, chat_id, user, sort=sort_key, page=0, message_id=message_id
             )
             return
-        if action == "page" and arg is not None:
+        if action in ("page", "dpage") and arg is not None:
             try:
                 page_idx = int(arg)
             except ValueError:
                 page_idx = 0
             await show_asset_dashboard_report(
                 db, chat_id, user, page=page_idx, message_id=message_id
+            )
+            return
+        if action == "mode" and arg in ("edit", "delete"):
+            # Toggle tap-to-edit / tap-to-delete. Reset to the first page so the
+            # rows the user is about to tap match what they see.
+            _DASHBOARD_PAGE_BY_USER[user.id] = 0
+            await show_asset_dashboard_report(
+                db, chat_id, user, page=0, mode=arg, message_id=message_id
             )
             return
         if action == "noop":

--- a/backend/bot/handlers/asset_entry.py
+++ b/backend/bot/handlers/asset_entry.py
@@ -3419,6 +3419,10 @@ async def handle_asset_manage_callback(db: AsyncSession, callback_query: dict) -
     arg = parts[1] if len(parts) > 1 else None
 
     async def _act() -> None:
+        if action == "noop":
+            # Content-label tap on an asset card — deliberate no-op; the
+            # ✏️/🗑 buttons below carry the real actions.
+            return
         if action == "menu":
             await show_asset_manage_menu(db, chat_id, user)
             return

--- a/backend/bot/keyboards/asset_keyboard.py
+++ b/backend/bot/keyboards/asset_keyboard.py
@@ -123,6 +123,57 @@ def _pagination_row(
     ]
 
 
+# --- Unified asset "card" rows -------------------------------------------
+# Telegram renders every button *within a row* at equal width, so the old
+# ``[✏️ <label>] [🗑]`` single-row layout forced the trash icon to claim ~50%
+# of the row — squeezing long asset labels (e.g. "🏛️ VCB — 100 tỷ") until they
+# were unreadable. Splitting each asset into a full-width content label row plus
+# a dedicated ✏️/🗑 action row gives the label the whole width back while keeping
+# both actions one tap away. Every card-style edit screen shares this helper so
+# the layout stays consistent.
+
+CARD_EDIT_LABEL = "✏️ Sửa"
+CARD_DELETE_LABEL = "🗑 Xoá"
+# Content sits on its own full-width row now, but we still trim pathological
+# labels so the serialized markup stays small and the row never wraps oddly.
+_CARD_LABEL_MAX = 48
+
+
+def _clean_card_label(label: str) -> str:
+    """Collapse whitespace and trim over-long labels with an ellipsis."""
+    clean = " ".join(str(label).split())
+    if len(clean) > _CARD_LABEL_MAX:
+        clean = clean[: _CARD_LABEL_MAX - 3].rstrip() + "…"
+    return clean
+
+
+def _asset_card_rows(
+    items,
+    *,
+    edit_cb,
+    delete_cb,
+    noop_cb: str = "asset:noop",
+) -> list[list[dict]]:
+    """Two rows per asset: a full-width content label then ``✏️ Sửa`` / ``🗑 Xoá``.
+
+    ``edit_cb`` / ``delete_cb`` are callables mapping an asset id to the
+    callback_data string for that action, so each screen keeps its own routing
+    prefix while sharing one visual layout. ``noop_cb`` backs the content label
+    (a tap is a deliberate no-op — the explicit action buttons live below it).
+    """
+    rows: list[list[dict]] = []
+    for item in items:
+        asset_id, label = item[0], item[1]
+        rows.append([{"text": _clean_card_label(label), "callback_data": noop_cb}])
+        rows.append(
+            [
+                {"text": CARD_EDIT_LABEL, "callback_data": edit_cb(asset_id)},
+                {"text": CARD_DELETE_LABEL, "callback_data": delete_cb(asset_id)},
+            ]
+        )
+    return rows
+
+
 def asset_type_picker_keyboard() -> InlineKeyboardMarkup:
     """Layout asset types for thumb-friendly tapping."""
     return {
@@ -712,19 +763,18 @@ def asset_edit_list_keyboard(
     asset_type: str,
     page: int = 0,
 ) -> InlineKeyboardMarkup:
-    """Render filtered edit rows plus navigation for market portfolio context."""
+    """Render filtered edit/delete cards plus navigation for portfolio context."""
     page_items, page, total_pages = _page_slice(candidates, page)
-    rows = [
-        [
-            {
-                "text": f"✏️ {label}"[:60],
-                "callback_data": build_callback(
-                    CB_ASSET_MANAGE, "edit", str(asset_id), asset_type
-                ),
-            }
-        ]
-        for asset_id, label in page_items
-    ]
+    rows = _asset_card_rows(
+        page_items,
+        edit_cb=lambda aid: build_callback(
+            CB_ASSET_MANAGE, "edit", str(aid), asset_type
+        ),
+        delete_cb=lambda aid: build_callback(
+            CB_ASSET_MANAGE, "delete_confirm", str(aid)
+        ),
+        noop_cb=build_callback(CB_ASSET_MANAGE, "noop"),
+    )
     nav = _pagination_row(
         page,
         total_pages,
@@ -921,24 +971,13 @@ def asset_dashboard_edit_keyboard(
             sort_button("alpha", "A-Z 🔤"),
         ],
     ]
-    for asset_id, label in page_items:
-        clean = " ".join(str(label).split())
-        # Keep delete CTA as a single icon so the edit button can claim
-        # most of the row width in Telegram (roughly 9:1 visual split).
-        if len(clean) > 48:
-            clean = clean[:45].rstrip() + "…"
-        keyboard.append(
-            [
-                {
-                    "text": f"✏️ {clean}",
-                    "callback_data": build_callback(CB_ASSET_ROW, "edit", asset_id),
-                },
-                {
-                    "text": "🗑",
-                    "callback_data": build_callback(CB_ASSET_ROW, "delete", asset_id),
-                },
-            ]
+    keyboard.extend(
+        _asset_card_rows(
+            page_items,
+            edit_cb=lambda aid: build_callback(CB_ASSET_ROW, "edit", aid),
+            delete_cb=lambda aid: build_callback(CB_ASSET_ROW, "delete", aid),
         )
+    )
     nav = _pagination_row(
         page,
         total_pages,

--- a/backend/bot/keyboards/asset_keyboard.py
+++ b/backend/bot/keyboards/asset_keyboard.py
@@ -34,6 +34,8 @@ Callback prefix convention (see ``backend/bot/keyboards/common.py``):
 
     asset:sort:<sort_key>                 — sort dashboard rows (default is value_desc)
     asset:page:<page>                     — switch dashboard page (current sort kept server-side)
+    asset:mode:<edit|delete>              — toggle dashboard between edit-tap and delete-tap
+    asset:dpage:<page>                    — switch dashboard page while in delete-mode
     asset:edit:<asset_uuid>               — edit one asset from dashboard report
     asset:delete:<asset_uuid>             — show inline delete confirmation
     asset:delete_yes:<asset_uuid>         — confirm inline soft delete
@@ -123,25 +125,19 @@ def _pagination_row(
     ]
 
 
-# --- Unified asset "card" rows -------------------------------------------
-# Telegram renders every button *within a row* at equal width, so the old
-# ``[✏️ <label>] [🗑]`` layout forced the trash icon to claim ~50% of the row.
-# We keep each asset on a single line — ``[✏️] [🗑] [<content>]`` — to maximise
-# list density (see more assets without scrolling). With three buttons the
-# content gets ~1/3 of the width and Telegram truncates the visible text on its
-# own; that's an accepted product trade-off ("see more assets" over showing the
-# full name). Every card-style edit screen shares this helper so the layout
-# stays consistent.
+# --- Unified asset picker rows -------------------------------------------
+# Telegram renders every button *within a row* at equal width regardless of its
+# text, so any second button on a row halves the space the asset name can use.
+# To keep each asset name on one line *and* give it the full row width we render
+# exactly **one** button per asset — tapping it is the primary action (edit, or
+# delete while in delete-mode). Secondary actions live behind a mode toggle /
+# separate screen instead of stealing row width. Every card-style edit screen
+# shares this helper so the layout stays consistent.
 
-CARD_EDIT_LABEL = "✏️"
-CARD_DELETE_LABEL = "🗑"
-# One row per asset: ``✏️``  ``🗑``  ``<content>``. Telegram splits a row's
-# width equally across its buttons regardless of text, so with three buttons
-# the content gets ~1/3 of the row and Telegram truncates the visible text on
-# its own. We still cap the label so the serialized markup stays small; the cap
-# is tight because the content button is narrow by design (denser list, one line
-# per asset — the product trade-off is "see more assets" over "full name").
-_CARD_LABEL_MAX = 24
+# Telegram caps button labels at 64 bytes. A full-width row comfortably shows
+# ~56 characters before the client truncates, so we cap there: the markup stays
+# small while the name gets room to breathe (no premature ``…``).
+_CARD_LABEL_MAX = 56
 
 
 def _clean_card_label(label: str) -> str:
@@ -152,28 +148,30 @@ def _clean_card_label(label: str) -> str:
     return clean
 
 
-def _asset_card_rows(
+def _asset_picker_rows(
     items,
     *,
-    edit_cb,
-    delete_cb,
-    noop_cb: str = "asset:noop",
+    row_cb,
+    label_prefix: str = "",
 ) -> list[list[dict]]:
-    """One row per asset: ``✏️`` / ``🗑`` action icons then the content label.
+    """One full-width button per asset; tapping it triggers ``row_cb``.
 
-    ``edit_cb`` / ``delete_cb`` are callables mapping an asset id to the
-    callback_data string for that action, so each screen keeps its own routing
-    prefix while sharing one visual layout. The content button is backed by
-    ``noop_cb`` (a tap is a deliberate no-op — the actions are the two icons).
+    ``row_cb`` is a callable mapping an asset id to the callback_data string for
+    the row's primary action (edit, or delete in delete-mode), so each screen
+    keeps its own routing prefix while sharing one visual layout. Giving the
+    asset its own full-width button keeps the name on a single line without the
+    width loss a second in-row action button would cost. ``label_prefix`` (e.g.
+    ``"🗑 "``) marks the active mode.
     """
     rows: list[list[dict]] = []
     for item in items:
         asset_id, label = item[0], item[1]
         rows.append(
             [
-                {"text": CARD_EDIT_LABEL, "callback_data": edit_cb(asset_id)},
-                {"text": CARD_DELETE_LABEL, "callback_data": delete_cb(asset_id)},
-                {"text": _clean_card_label(label), "callback_data": noop_cb},
+                {
+                    "text": label_prefix + _clean_card_label(label),
+                    "callback_data": row_cb(asset_id),
+                }
             ]
         )
     return rows
@@ -768,17 +766,19 @@ def asset_edit_list_keyboard(
     asset_type: str,
     page: int = 0,
 ) -> InlineKeyboardMarkup:
-    """Render filtered edit/delete cards plus navigation for portfolio context."""
+    """Render a full-width edit picker plus navigation for portfolio context.
+
+    Tapping an asset opens its edit wizard (then returns to the market
+    portfolio). Delete lives behind the ``🗑 Xoá tài sản`` footer, which reuses
+    the existing delete-list flow (``asset_manage:delete_type:<type>``) so the
+    asset name keeps the whole row width.
+    """
     page_items, page, total_pages = _page_slice(candidates, page)
-    rows = _asset_card_rows(
+    rows = _asset_picker_rows(
         page_items,
-        edit_cb=lambda aid: build_callback(
+        row_cb=lambda aid: build_callback(
             CB_ASSET_MANAGE, "edit", str(aid), asset_type
         ),
-        delete_cb=lambda aid: build_callback(
-            CB_ASSET_MANAGE, "delete_confirm", str(aid)
-        ),
-        noop_cb=build_callback(CB_ASSET_MANAGE, "noop"),
     )
     nav = _pagination_row(
         page,
@@ -788,6 +788,16 @@ def asset_edit_list_keyboard(
     )
     if nav is not None:
         rows.append(nav)
+    rows.append(
+        [
+            {
+                "text": "🗑 Xoá tài sản",
+                "callback_data": build_callback(
+                    CB_ASSET_MANAGE, "delete_type", asset_type
+                ),
+            }
+        ]
+    )
     rows.append(
         [
             {
@@ -951,8 +961,18 @@ def asset_dashboard_edit_keyboard(
     *,
     current_sort: str = "value_desc",
     page: int = 0,
+    mode: str = "edit",
 ) -> InlineKeyboardMarkup | None:
-    """Sort controls plus compact edit/delete buttons per dashboard row.
+    """Full-width asset picker for the dashboard report.
+
+    Each asset is its own full-width button so the name gets the whole row (one
+    line, no width halving) — the product trade-off resolved in favour of
+    readable names over an always-visible per-row delete icon.
+
+    ``mode="edit"`` (default): sort controls on top; tapping an asset opens its
+    edit wizard; a ``🗑 Xoá tài sản`` footer toggles to delete-mode.
+    ``mode="delete"``: tapping an asset opens its delete confirmation; an
+    ``✏️ Quay lại sửa`` footer toggles back.
 
     Rows are paginated at :data:`ASSET_LIST_PAGE_SIZE` per page so the
     serialized markup stays under Telegram's ~10 KB practical limit.
@@ -961,6 +981,33 @@ def asset_dashboard_edit_keyboard(
         return None
 
     page_items, page, total_pages = _page_slice(rows, page)
+
+    if mode == "delete":
+        keyboard = list(
+            _asset_picker_rows(
+                page_items,
+                row_cb=lambda aid: build_callback(CB_ASSET_ROW, "delete", aid),
+                label_prefix="🗑 ",
+            )
+        )
+        nav = _pagination_row(
+            page,
+            total_pages,
+            prev_cb=build_callback(CB_ASSET_ROW, "dpage", page - 1),
+            next_cb=build_callback(CB_ASSET_ROW, "dpage", page + 1),
+        )
+        if nav is not None:
+            keyboard.append(nav)
+        keyboard.append(
+            [
+                {
+                    "text": "✏️ Quay lại sửa",
+                    "callback_data": build_callback(CB_ASSET_ROW, "mode", "edit"),
+                }
+            ]
+        )
+        keyboard.append([{"text": "◀️ Quay về", "callback_data": "menu:assets"}])
+        return {"inline_keyboard": keyboard}
 
     def sort_button(key: str, label: str) -> dict:
         prefix = "✅ " if key == current_sort else ""
@@ -977,10 +1024,9 @@ def asset_dashboard_edit_keyboard(
         ],
     ]
     keyboard.extend(
-        _asset_card_rows(
+        _asset_picker_rows(
             page_items,
-            edit_cb=lambda aid: build_callback(CB_ASSET_ROW, "edit", aid),
-            delete_cb=lambda aid: build_callback(CB_ASSET_ROW, "delete", aid),
+            row_cb=lambda aid: build_callback(CB_ASSET_ROW, "edit", aid),
         )
     )
     nav = _pagination_row(
@@ -991,6 +1037,14 @@ def asset_dashboard_edit_keyboard(
     )
     if nav is not None:
         keyboard.append(nav)
+    keyboard.append(
+        [
+            {
+                "text": "🗑 Xoá tài sản",
+                "callback_data": build_callback(CB_ASSET_ROW, "mode", "delete"),
+            }
+        ]
+    )
     keyboard.append([{"text": "◀️ Quay về", "callback_data": "menu:assets"}])
     return {"inline_keyboard": keyboard}
 

--- a/backend/bot/keyboards/asset_keyboard.py
+++ b/backend/bot/keyboards/asset_keyboard.py
@@ -125,25 +125,30 @@ def _pagination_row(
 
 # --- Unified asset "card" rows -------------------------------------------
 # Telegram renders every button *within a row* at equal width, so the old
-# ``[✏️ <label>] [🗑]`` single-row layout forced the trash icon to claim ~50%
-# of the row — squeezing long asset labels (e.g. "🏛️ VCB — 100 tỷ") until they
-# were unreadable. Splitting each asset into a full-width content label row plus
-# a dedicated ✏️/🗑 action row gives the label the whole width back while keeping
-# both actions one tap away. Every card-style edit screen shares this helper so
-# the layout stays consistent.
+# ``[✏️ <label>] [🗑]`` layout forced the trash icon to claim ~50% of the row.
+# We keep each asset on a single line — ``[✏️] [🗑] [<content>]`` — to maximise
+# list density (see more assets without scrolling). With three buttons the
+# content gets ~1/3 of the width and Telegram truncates the visible text on its
+# own; that's an accepted product trade-off ("see more assets" over showing the
+# full name). Every card-style edit screen shares this helper so the layout
+# stays consistent.
 
-CARD_EDIT_LABEL = "✏️ Sửa"
-CARD_DELETE_LABEL = "🗑 Xoá"
-# Content sits on its own full-width row now, but we still trim pathological
-# labels so the serialized markup stays small and the row never wraps oddly.
-_CARD_LABEL_MAX = 48
+CARD_EDIT_LABEL = "✏️"
+CARD_DELETE_LABEL = "🗑"
+# One row per asset: ``✏️``  ``🗑``  ``<content>``. Telegram splits a row's
+# width equally across its buttons regardless of text, so with three buttons
+# the content gets ~1/3 of the row and Telegram truncates the visible text on
+# its own. We still cap the label so the serialized markup stays small; the cap
+# is tight because the content button is narrow by design (denser list, one line
+# per asset — the product trade-off is "see more assets" over "full name").
+_CARD_LABEL_MAX = 24
 
 
 def _clean_card_label(label: str) -> str:
     """Collapse whitespace and trim over-long labels with an ellipsis."""
     clean = " ".join(str(label).split())
     if len(clean) > _CARD_LABEL_MAX:
-        clean = clean[: _CARD_LABEL_MAX - 3].rstrip() + "…"
+        clean = clean[: _CARD_LABEL_MAX - 1].rstrip() + "…"
     return clean
 
 
@@ -154,21 +159,21 @@ def _asset_card_rows(
     delete_cb,
     noop_cb: str = "asset:noop",
 ) -> list[list[dict]]:
-    """Two rows per asset: a full-width content label then ``✏️ Sửa`` / ``🗑 Xoá``.
+    """One row per asset: ``✏️`` / ``🗑`` action icons then the content label.
 
     ``edit_cb`` / ``delete_cb`` are callables mapping an asset id to the
     callback_data string for that action, so each screen keeps its own routing
-    prefix while sharing one visual layout. ``noop_cb`` backs the content label
-    (a tap is a deliberate no-op — the explicit action buttons live below it).
+    prefix while sharing one visual layout. The content button is backed by
+    ``noop_cb`` (a tap is a deliberate no-op — the actions are the two icons).
     """
     rows: list[list[dict]] = []
     for item in items:
         asset_id, label = item[0], item[1]
-        rows.append([{"text": _clean_card_label(label), "callback_data": noop_cb}])
         rows.append(
             [
                 {"text": CARD_EDIT_LABEL, "callback_data": edit_cb(asset_id)},
                 {"text": CARD_DELETE_LABEL, "callback_data": delete_cb(asset_id)},
+                {"text": _clean_card_label(label), "callback_data": noop_cb},
             ]
         )
     return rows

--- a/backend/tests/test_asset_entry_edit_list.py
+++ b/backend/tests/test_asset_entry_edit_list.py
@@ -39,24 +39,17 @@ async def test_show_asset_edit_list_filters_by_subtype():
         await asset_entry.show_asset_edit_list(db, chat_id, user, "stock", subtype="fund")
 
     markup = send_message.await_args.kwargs["reply_markup"]
-    # Each asset renders as a single row: ✏️ / 🗑 action icons then the content
-    # label (asset_manage:noop), so read the label off the no-op button.
-    labels = [
-        b["text"]
-        for row in markup["inline_keyboard"]
-        for b in row
-        if b.get("callback_data") == "asset_manage:noop"
-    ]
-    assert len(labels) == 1
-    assert "TCEF" in labels[0]
-    # The subtype filter must keep the edit action wired to the fund only.
-    edit_cbs = [
-        b["callback_data"]
+    # Each asset renders as a single full-width button; tapping it edits, so the
+    # label and the edit callback live on the same button.
+    edit_buttons = [
+        b
         for row in markup["inline_keyboard"]
         for b in row
         if b.get("callback_data", "").startswith("asset_manage:edit:")
     ]
-    assert len(edit_cbs) == 1
+    # The subtype filter must keep exactly the fund row.
+    assert len(edit_buttons) == 1
+    assert "TCEF" in edit_buttons[0]["text"]
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_asset_entry_edit_list.py
+++ b/backend/tests/test_asset_entry_edit_list.py
@@ -39,9 +39,23 @@ async def test_show_asset_edit_list_filters_by_subtype():
         await asset_entry.show_asset_edit_list(db, chat_id, user, "stock", subtype="fund")
 
     markup = send_message.await_args.kwargs["reply_markup"]
-    labels = [row[0]["text"] for row in markup["inline_keyboard"] if row and row[0].get("callback_data", "").startswith("asset_manage:edit:")]
+    # Each asset renders as a full-width content label row (asset_manage:noop)
+    # followed by an ✏️/🗑 action row, so read the label off the content row.
+    labels = [
+        row[0]["text"]
+        for row in markup["inline_keyboard"]
+        if row and row[0].get("callback_data") == "asset_manage:noop"
+    ]
     assert len(labels) == 1
     assert "TCEF" in labels[0]
+    # The subtype filter must keep the edit action wired to the fund only.
+    edit_cbs = [
+        b["callback_data"]
+        for row in markup["inline_keyboard"]
+        for b in row
+        if b.get("callback_data", "").startswith("asset_manage:edit:")
+    ]
+    assert len(edit_cbs) == 1
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_asset_entry_edit_list.py
+++ b/backend/tests/test_asset_entry_edit_list.py
@@ -39,12 +39,13 @@ async def test_show_asset_edit_list_filters_by_subtype():
         await asset_entry.show_asset_edit_list(db, chat_id, user, "stock", subtype="fund")
 
     markup = send_message.await_args.kwargs["reply_markup"]
-    # Each asset renders as a full-width content label row (asset_manage:noop)
-    # followed by an ✏️/🗑 action row, so read the label off the content row.
+    # Each asset renders as a single row: ✏️ / 🗑 action icons then the content
+    # label (asset_manage:noop), so read the label off the no-op button.
     labels = [
-        row[0]["text"]
+        b["text"]
         for row in markup["inline_keyboard"]
-        if row and row[0].get("callback_data") == "asset_manage:noop"
+        for b in row
+        if b.get("callback_data") == "asset_manage:noop"
     ]
     assert len(labels) == 1
     assert "TCEF" in labels[0]

--- a/backend/tests/test_asset_keyboard_pagination.py
+++ b/backend/tests/test_asset_keyboard_pagination.py
@@ -53,9 +53,9 @@ class TestPageSlice:
 class TestDashboardKeyboardSize:
     def test_single_page_when_under_page_size(self):
         kb = asset_dashboard_edit_keyboard(_rows(5))
-        # 1 sort row + 5 assets × (label row + action row) + back row = 12 rows
+        # 1 sort row + 5 assets × 1 combined row + back row = 7 rows
         # (no pagination row when everything fits on one page).
-        assert len(kb["inline_keyboard"]) == 12
+        assert len(kb["inline_keyboard"]) == 7
 
     def test_paginates_at_page_size(self):
         kb = asset_dashboard_edit_keyboard(_rows(ASSET_LIST_PAGE_SIZE * 3))
@@ -110,42 +110,41 @@ class TestDashboardKeyboardSize:
             cbs = [b["callback_data"] for b in first_row]
             assert all(cb.startswith("asset:sort:") for cb in cbs)
 
-    def test_card_layout_label_row_then_action_row(self):
+    def test_card_layout_single_row_actions_then_content(self):
         asset_id = uuid.uuid4()
-        kb = asset_dashboard_edit_keyboard([(asset_id, "🏛️ VCB — 100 tỷ")])
-        # Row 0 = sort controls, row 1 = full-width content label,
-        # row 2 = ✏️ Sửa / 🗑 Xoá action buttons.
-        label_row = kb["inline_keyboard"][1]
-        action_row = kb["inline_keyboard"][2]
-        assert len(label_row) == 1
-        assert label_row[0]["text"] == "🏛️ VCB — 100 tỷ"
-        assert label_row[0]["callback_data"] == "asset:noop"
-        assert [b["text"] for b in action_row] == ["✏️ Sửa", "🗑 Xoá"]
-        assert action_row[0]["callback_data"] == f"asset:edit:{asset_id}"
-        assert action_row[1]["callback_data"] == f"asset:delete:{asset_id}"
+        kb = asset_dashboard_edit_keyboard([(asset_id, "🏛️ VCB")])
+        # Row 0 = sort controls, row 1 = ✏️ / 🗑 action icons then content.
+        card_row = kb["inline_keyboard"][1]
+        assert [b["text"] for b in card_row] == ["✏️", "🗑", "🏛️ VCB"]
+        assert card_row[0]["callback_data"] == f"asset:edit:{asset_id}"
+        assert card_row[1]["callback_data"] == f"asset:delete:{asset_id}"
+        assert card_row[2]["callback_data"] == "asset:noop"
 
-    def test_content_label_full_width_no_trailing_trash_icon(self):
-        # Regression: trash icon must not share the label's row (it claimed
-        # ~half the width and truncated the asset name).
+    def test_actions_precede_content_on_same_row(self):
+        # The two action icons lead the row; the content (no-op) trails it so
+        # the whole asset fits on a single line.
         kb = asset_dashboard_edit_keyboard(_rows(1))
-        label_row = kb["inline_keyboard"][1]
-        assert len(label_row) == 1
-        assert "🗑" not in label_row[0]["text"]
+        card_row = kb["inline_keyboard"][1]
+        assert len(card_row) == 3
+        action_cbs = [card_row[0]["callback_data"], card_row[1]["callback_data"]]
+        assert any(cb.startswith("asset:edit:") for cb in action_cbs)
+        assert any(cb.startswith("asset:delete:") for cb in action_cbs)
+        assert card_row[2]["callback_data"] == "asset:noop"
 
     def test_returns_none_for_empty(self):
         assert asset_dashboard_edit_keyboard([]) is None
 
-    def test_label_not_truncated_when_length_is_48(self):
-        label = "A" * 48
+    def test_label_not_truncated_when_length_is_24(self):
+        label = "A" * 24
         kb = asset_dashboard_edit_keyboard([(uuid.uuid4(), label)])
-        label_btn = kb["inline_keyboard"][1][0]
+        label_btn = kb["inline_keyboard"][1][2]
         assert label_btn["text"] == label
 
-    def test_label_truncates_at_49_with_ellipsis(self):
-        label = "B" * 49
+    def test_label_truncates_at_25_with_ellipsis(self):
+        label = "B" * 25
         kb = asset_dashboard_edit_keyboard([(uuid.uuid4(), label)])
-        label_btn = kb["inline_keyboard"][1][0]
-        assert label_btn["text"] == f"{'B' * 45}…"
+        label_btn = kb["inline_keyboard"][1][2]
+        assert label_btn["text"] == f"{'B' * 23}…"
 
 
 class TestManageListKeyboards:
@@ -198,18 +197,16 @@ class TestManageListKeyboards:
     def test_edit_list_card_has_edit_and_delete_actions(self):
         asset_id = uuid.uuid4()
         kb = asset_edit_list_keyboard(
-            [(asset_id, "📈 FPT — 6.2 tỷ")], asset_type="stock"
+            [(asset_id, "📈 FPT")], asset_type="stock"
         )
-        label_row = kb["inline_keyboard"][0]
-        action_row = kb["inline_keyboard"][1]
-        assert label_row[0]["text"] == "📈 FPT — 6.2 tỷ"
-        assert label_row[0]["callback_data"] == "asset_manage:noop"
-        assert [b["text"] for b in action_row] == ["✏️ Sửa", "🗑 Xoá"]
+        card_row = kb["inline_keyboard"][0]
+        assert [b["text"] for b in card_row] == ["✏️", "🗑", "📈 FPT"]
+        assert card_row[2]["callback_data"] == "asset_manage:noop"
         # Edit keeps the return-to-portfolio asset_type suffix; delete routes
         # through the existing confirmation guard.
-        assert action_row[0]["callback_data"] == f"asset_manage:edit:{asset_id}:stock"
+        assert card_row[0]["callback_data"] == f"asset_manage:edit:{asset_id}:stock"
         assert (
-            action_row[1]["callback_data"]
+            card_row[1]["callback_data"]
             == f"asset_manage:delete_confirm:{asset_id}"
         )
 

--- a/backend/tests/test_asset_keyboard_pagination.py
+++ b/backend/tests/test_asset_keyboard_pagination.py
@@ -53,8 +53,9 @@ class TestPageSlice:
 class TestDashboardKeyboardSize:
     def test_single_page_when_under_page_size(self):
         kb = asset_dashboard_edit_keyboard(_rows(5))
-        # 1 sort row + 5 asset rows + back row = 7 rows (no pagination row)
-        assert len(kb["inline_keyboard"]) == 7
+        # 1 sort row + 5 assets × (label row + action row) + back row = 12 rows
+        # (no pagination row when everything fits on one page).
+        assert len(kb["inline_keyboard"]) == 12
 
     def test_paginates_at_page_size(self):
         kb = asset_dashboard_edit_keyboard(_rows(ASSET_LIST_PAGE_SIZE * 3))
@@ -109,25 +110,42 @@ class TestDashboardKeyboardSize:
             cbs = [b["callback_data"] for b in first_row]
             assert all(cb.startswith("asset:sort:") for cb in cbs)
 
-    def test_delete_button_uses_compact_icon_for_more_edit_label_space(self):
+    def test_card_layout_label_row_then_action_row(self):
+        asset_id = uuid.uuid4()
+        kb = asset_dashboard_edit_keyboard([(asset_id, "🏛️ VCB — 100 tỷ")])
+        # Row 0 = sort controls, row 1 = full-width content label,
+        # row 2 = ✏️ Sửa / 🗑 Xoá action buttons.
+        label_row = kb["inline_keyboard"][1]
+        action_row = kb["inline_keyboard"][2]
+        assert len(label_row) == 1
+        assert label_row[0]["text"] == "🏛️ VCB — 100 tỷ"
+        assert label_row[0]["callback_data"] == "asset:noop"
+        assert [b["text"] for b in action_row] == ["✏️ Sửa", "🗑 Xoá"]
+        assert action_row[0]["callback_data"] == f"asset:edit:{asset_id}"
+        assert action_row[1]["callback_data"] == f"asset:delete:{asset_id}"
+
+    def test_content_label_full_width_no_trailing_trash_icon(self):
+        # Regression: trash icon must not share the label's row (it claimed
+        # ~half the width and truncated the asset name).
         kb = asset_dashboard_edit_keyboard(_rows(1))
-        delete_btn = kb["inline_keyboard"][1][1]
-        assert delete_btn["text"] == "🗑"
+        label_row = kb["inline_keyboard"][1]
+        assert len(label_row) == 1
+        assert "🗑" not in label_row[0]["text"]
 
     def test_returns_none_for_empty(self):
         assert asset_dashboard_edit_keyboard([]) is None
 
-    def test_edit_label_not_truncated_when_length_is_48(self):
+    def test_label_not_truncated_when_length_is_48(self):
         label = "A" * 48
         kb = asset_dashboard_edit_keyboard([(uuid.uuid4(), label)])
-        edit_btn = kb["inline_keyboard"][1][0]
-        assert edit_btn["text"] == f"✏️ {label}"
+        label_btn = kb["inline_keyboard"][1][0]
+        assert label_btn["text"] == label
 
-    def test_edit_label_truncates_at_49_with_ellipsis(self):
+    def test_label_truncates_at_49_with_ellipsis(self):
         label = "B" * 49
         kb = asset_dashboard_edit_keyboard([(uuid.uuid4(), label)])
-        edit_btn = kb["inline_keyboard"][1][0]
-        assert edit_btn["text"] == f"✏️ {'B' * 45}…"
+        label_btn = kb["inline_keyboard"][1][0]
+        assert label_btn["text"] == f"{'B' * 45}…"
 
 
 class TestManageListKeyboards:
@@ -176,3 +194,30 @@ class TestManageListKeyboards:
             if "edit_page" in b.get("callback_data", "")
         ]
         assert not page_cbs
+
+    def test_edit_list_card_has_edit_and_delete_actions(self):
+        asset_id = uuid.uuid4()
+        kb = asset_edit_list_keyboard(
+            [(asset_id, "📈 FPT — 6.2 tỷ")], asset_type="stock"
+        )
+        label_row = kb["inline_keyboard"][0]
+        action_row = kb["inline_keyboard"][1]
+        assert label_row[0]["text"] == "📈 FPT — 6.2 tỷ"
+        assert label_row[0]["callback_data"] == "asset_manage:noop"
+        assert [b["text"] for b in action_row] == ["✏️ Sửa", "🗑 Xoá"]
+        # Edit keeps the return-to-portfolio asset_type suffix; delete routes
+        # through the existing confirmation guard.
+        assert action_row[0]["callback_data"] == f"asset_manage:edit:{asset_id}:stock"
+        assert (
+            action_row[1]["callback_data"]
+            == f"asset_manage:delete_confirm:{asset_id}"
+        )
+
+    def test_edit_list_callbacks_within_telegram_cap(self):
+        # Market edit list is rendered for market asset types (stock/crypto/
+        # gold); the edit callback carries the asset_type as a return hint.
+        candidates = _rows(20)
+        kb = asset_edit_list_keyboard(candidates, asset_type="stock")
+        for row in kb["inline_keyboard"]:
+            for b in row:
+                assert len(b["callback_data"].encode("utf-8")) <= 64

--- a/backend/tests/test_asset_keyboard_pagination.py
+++ b/backend/tests/test_asset_keyboard_pagination.py
@@ -53,9 +53,9 @@ class TestPageSlice:
 class TestDashboardKeyboardSize:
     def test_single_page_when_under_page_size(self):
         kb = asset_dashboard_edit_keyboard(_rows(5))
-        # 1 sort row + 5 assets × 1 combined row + back row = 7 rows
-        # (no pagination row when everything fits on one page).
-        assert len(kb["inline_keyboard"]) == 7
+        # 1 sort row + 5 full-width asset rows + "🗑 Xoá tài sản" toggle row
+        # + back row = 8 rows (no pagination row when everything fits).
+        assert len(kb["inline_keyboard"]) == 8
 
     def test_paginates_at_page_size(self):
         kb = asset_dashboard_edit_keyboard(_rows(ASSET_LIST_PAGE_SIZE * 3))
@@ -110,41 +110,55 @@ class TestDashboardKeyboardSize:
             cbs = [b["callback_data"] for b in first_row]
             assert all(cb.startswith("asset:sort:") for cb in cbs)
 
-    def test_card_layout_single_row_actions_then_content(self):
+    def test_edit_mode_row_is_full_width_tap_to_edit(self):
         asset_id = uuid.uuid4()
         kb = asset_dashboard_edit_keyboard([(asset_id, "🏛️ VCB")])
-        # Row 0 = sort controls, row 1 = ✏️ / 🗑 action icons then content.
+        # Row 0 = sort controls, row 1 = the asset as a single full-width
+        # button (the whole row width goes to the name; tapping it edits).
         card_row = kb["inline_keyboard"][1]
-        assert [b["text"] for b in card_row] == ["✏️", "🗑", "🏛️ VCB"]
+        assert len(card_row) == 1
+        assert card_row[0]["text"] == "🏛️ VCB"
         assert card_row[0]["callback_data"] == f"asset:edit:{asset_id}"
-        assert card_row[1]["callback_data"] == f"asset:delete:{asset_id}"
-        assert card_row[2]["callback_data"] == "asset:noop"
 
-    def test_actions_precede_content_on_same_row(self):
-        # The two action icons lead the row; the content (no-op) trails it so
-        # the whole asset fits on a single line.
+    def test_edit_mode_has_delete_toggle_footer(self):
         kb = asset_dashboard_edit_keyboard(_rows(1))
-        card_row = kb["inline_keyboard"][1]
-        assert len(card_row) == 3
-        action_cbs = [card_row[0]["callback_data"], card_row[1]["callback_data"]]
-        assert any(cb.startswith("asset:edit:") for cb in action_cbs)
-        assert any(cb.startswith("asset:delete:") for cb in action_cbs)
-        assert card_row[2]["callback_data"] == "asset:noop"
+        cbs = {b.get("callback_data") for row in kb["inline_keyboard"] for b in row}
+        assert "asset:mode:delete" in cbs
+
+    def test_delete_mode_row_is_full_width_tap_to_delete(self):
+        asset_id = uuid.uuid4()
+        kb = asset_dashboard_edit_keyboard([(asset_id, "🏛️ VCB")], mode="delete")
+        # Delete-mode drops the sort row, so the first row is the asset itself.
+        card_row = kb["inline_keyboard"][0]
+        assert len(card_row) == 1
+        assert card_row[0]["text"] == "🗑 🏛️ VCB"
+        assert card_row[0]["callback_data"] == f"asset:delete:{asset_id}"
+        cbs = {b.get("callback_data") for row in kb["inline_keyboard"] for b in row}
+        # Toggle back to edit-mode is offered.
+        assert "asset:mode:edit" in cbs
+
+    def test_delete_mode_pagination_uses_dpage(self):
+        single = asset_dashboard_edit_keyboard(_rows(3), mode="delete")
+        multi = asset_dashboard_edit_keyboard(_rows(20), mode="delete")
+        single_cbs = {b.get("callback_data") for row in single["inline_keyboard"] for b in row}
+        multi_cbs = {b.get("callback_data") for row in multi["inline_keyboard"] for b in row}
+        assert not any(cb and cb.startswith("asset:dpage:") for cb in single_cbs)
+        assert any(cb and cb.startswith("asset:dpage:") for cb in multi_cbs)
 
     def test_returns_none_for_empty(self):
         assert asset_dashboard_edit_keyboard([]) is None
 
-    def test_label_not_truncated_when_length_is_24(self):
-        label = "A" * 24
+    def test_label_not_truncated_when_length_is_56(self):
+        label = "A" * 56
         kb = asset_dashboard_edit_keyboard([(uuid.uuid4(), label)])
-        label_btn = kb["inline_keyboard"][1][2]
+        label_btn = kb["inline_keyboard"][1][0]
         assert label_btn["text"] == label
 
-    def test_label_truncates_at_25_with_ellipsis(self):
-        label = "B" * 25
+    def test_label_truncates_at_57_with_ellipsis(self):
+        label = "B" * 57
         kb = asset_dashboard_edit_keyboard([(uuid.uuid4(), label)])
-        label_btn = kb["inline_keyboard"][1][2]
-        assert label_btn["text"] == f"{'B' * 23}…"
+        label_btn = kb["inline_keyboard"][1][0]
+        assert label_btn["text"] == f"{'B' * 55}…"
 
 
 class TestManageListKeyboards:
@@ -194,21 +208,24 @@ class TestManageListKeyboards:
         ]
         assert not page_cbs
 
-    def test_edit_list_card_has_edit_and_delete_actions(self):
+    def test_edit_list_row_is_full_width_tap_to_edit(self):
         asset_id = uuid.uuid4()
         kb = asset_edit_list_keyboard(
             [(asset_id, "📈 FPT")], asset_type="stock"
         )
+        # The asset is a single full-width button; tapping it edits and keeps
+        # the return-to-portfolio asset_type suffix.
         card_row = kb["inline_keyboard"][0]
-        assert [b["text"] for b in card_row] == ["✏️", "🗑", "📈 FPT"]
-        assert card_row[2]["callback_data"] == "asset_manage:noop"
-        # Edit keeps the return-to-portfolio asset_type suffix; delete routes
-        # through the existing confirmation guard.
+        assert len(card_row) == 1
+        assert card_row[0]["text"] == "📈 FPT"
         assert card_row[0]["callback_data"] == f"asset_manage:edit:{asset_id}:stock"
-        assert (
-            card_row[1]["callback_data"]
-            == f"asset_manage:delete_confirm:{asset_id}"
-        )
+
+    def test_edit_list_has_delete_footer_reusing_delete_flow(self):
+        kb = asset_edit_list_keyboard([(uuid.uuid4(), "📈 FPT")], asset_type="stock")
+        cbs = {b.get("callback_data") for row in kb["inline_keyboard"] for b in row}
+        # Delete lives behind a footer that reuses the existing delete-list
+        # flow rather than stealing per-row width.
+        assert "asset_manage:delete_type:stock" in cbs
 
     def test_edit_list_callbacks_within_telegram_cap(self):
         # Market edit list is rendered for market asset types (stock/crypto/


### PR DESCRIPTION
## Problem

On the "sửa tài sản" screens, Telegram renders every button **within a row at equal width** regardless of its text. The previous `[✏️][🗑][content]` card therefore gave the asset name only ~1/3 of the row, so the client truncated real asset names.

## Solution — "Chạm = Sửa luôn"

Each asset becomes a **single full-width button**; tapping it is the primary action (edit). Delete moves off every row into a separate flow, so the name keeps the whole row width (one line, no halving).

- **Dashboard report (`asset:*`)** and **filtered market edit list (`asset_manage:*`)** now render one full-width button per asset → tap opens the edit wizard. Label cap raised 24→56 chars so real names rarely truncate.
- **Delete is no longer an always-visible per-row icon:**
  - Dashboard gains an edit/delete **mode toggle**. `🗑 Xoá tài sản` switches to delete-mode (tap an asset = delete confirmation; `asset:dpage` pagination); `✏️ Quay lại sửa` switches back. Mode is tracked per user (`_DASHBOARD_MODE_BY_USER`) and reset on empty portfolio.
  - Market edit list gains a `🗑 Xoá tài sản` footer that **reuses the existing** `asset_manage:delete_type` delete-list flow.
- Hint text adapts to the active mode.

New callbacks: `asset:mode:<edit|delete>`, `asset:dpage:<page>`.

## Consistency / quality

- One shared `_asset_picker_rows` helper backs every card-style edit screen, so the layout stays consistent (dashboard, market edit list, filtered edit list).
- `noop` handler branches retained — still used by the pagination page indicator.
- Money/`Decimal` and layer-contract conventions untouched; keyboards remain pure view builders.

## Tests

- `test_asset_keyboard_pagination.py`: full-width edit-mode row, delete-mode row + `dpage` pagination, mode toggle footers, 56/57-char truncation boundary, market edit list full-width row + delete footer.
- `test_asset_entry_edit_list.py`: reads label + edit callback off the single full-width button.
- Target suites green (28 passed). Pre-existing unrelated failures in `test_action_delete_asset.py` / `TestParseQuantity` confirmed present on the baseline before this change.

Close #924

https://claude.ai/code/session_0156vqxNLRKq1x8U5tBJa6aT