### PR TITLE
feat(nlu): extract transaction date from free-text in Tier-1/1.5/2

### DIFF
--- a/backend/bot/formatters/templates.py
+++ b/backend/bot/formatters/templates.py
@@ -42,6 +42,7 @@ def format_transaction_confirmation(
     source_label: str | None = None,
     show_edit_hint: bool = False,
     transaction_type: str = "expense",
+    expense_date: date | None = None,
 ) -> str:
     """Tin nhắn xác nhận sau khi ghi giao dịch thành công.
 
@@ -72,6 +73,15 @@ def format_transaction_confirmation(
         context_parts.append(time_vn.strftime("%H:%M"))
     if context_parts:
         lines.append("  •  ".join(context_parts))
+
+    # Only surface the date line when the user pinned a different day —
+    # showing "📅 Ngày giao dịch: <today>" on every confirmation is noise
+    # that buries the actually useful merchant/amount/source rows.
+    if expense_date is not None and expense_date != date.today():
+        date_template = _confirmation_copy(
+            "transaction_date", "📅 Ngày giao dịch: {date}"
+        )
+        lines.append(date_template.format(date=expense_date.strftime("%d/%m/%Y")))
 
     is_money_in = transaction_type == "money_in"
 
@@ -178,6 +188,7 @@ def format_transaction_batch_confirmation(
     time: datetime | None = None,
     source_label: str | None = None,
     show_edit_hint: bool = False,
+    expense_date: date | None = None,
 ) -> str:
     """Tin nhắn xác nhận sau khi ghi nhiều giao dịch cùng lúc."""
     total = sum(amount for _, amount, _ in items)
@@ -197,6 +208,12 @@ def format_transaction_batch_confirmation(
     time_vn = _as_vn_time(time)
     if time_vn:
         lines.append(time_vn.strftime("%H:%M"))
+
+    if expense_date is not None and expense_date != date.today():
+        date_template = _confirmation_copy(
+            "transaction_date", "📅 Ngày giao dịch: {date}"
+        )
+        lines.append(date_template.format(date=expense_date.strftime("%d/%m/%Y")))
 
     if source_label:
         source_template = _confirmation_copy(

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -18,7 +18,7 @@ and edit the triggering message in place.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
 
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -162,6 +162,22 @@ async def _handle_source_selection_callback(
         if chosen != "skip":
             source_type = chosen
 
+    # Wizard JSONB can't store ``date`` natively, so the Tier-1 fast-path
+    # stashes the parsed transaction date as an ISO string. Pull it back
+    # here so a user who walked through the source picker keeps the
+    # ``ngày dd/mm/yyyy`` they typed instead of silently falling back to
+    # today.
+    expense_date_iso = draft.get("expense_date")
+    expense_date_value = date.today()
+    if expense_date_iso:
+        try:
+            expense_date_value = date.fromisoformat(expense_date_iso)
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid expense_date in wizard draft for user %s: %r",
+                user.id,
+                expense_date_iso,
+            )
     expense_data = ExpenseCreate(
         amount=float(draft.get("amount", 0)),
         transaction_type=draft.get("transaction_type", "expense"),
@@ -172,6 +188,7 @@ async def _handle_source_selection_callback(
         e_wallet_provider=wallet_provider,
         source_credit_card_id=source_credit_card_id,
         source_asset_id=source_asset_id,
+        expense_date=expense_date_value,
     )
     expense = await expense_service.create_expense(db, user.id, expense_data)
     from backend.services import wizard_service
@@ -253,6 +270,7 @@ async def _rerender_transaction_message(
         source_label=source_label,
         show_edit_hint=is_card_type,
         transaction_type=tx_type,
+        expense_date=expense.expense_date,
     )
     reply_markup = (
         transaction_actions_with_done_keyboard(str(expense.id))

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -27,6 +27,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.bot.handlers import free_form_text as intent_layer
 from backend.bot.handlers.transaction import send_transaction_confirmation
 from backend.bot.keyboards.transaction_keyboard import transaction_source_keyboard
+from backend.bot.utils.transaction_date_extractor import (
+    extract_transaction_date,
+    strip_span,
+)
 from backend.intent import pending_action
 from backend.intent.income_semantics import is_duoc_money_in
 from backend.intent.dispatcher import (
@@ -148,6 +152,12 @@ def _parse_signed_transaction(text: str) -> dict | None:
         sign = None
         body = (amount_led.group("body") or "").strip()
 
+    # Strip any "ngày dd/mm[/yyyy]" phrase BEFORE searching for the
+    # amount so the date digits don't get mistaken for a price.
+    extracted_date = extract_transaction_date(body)
+    if extracted_date is not None:
+        body = strip_span(body, extracted_date.span)
+
     amount_match = _AMOUNT_TOKEN_RE.search(body)
     if not amount_match:
         return None
@@ -163,12 +173,16 @@ def _parse_signed_transaction(text: str) -> dict | None:
     merchant = f"{body[:amount_match.start()]} {body[amount_match.end():]}"
     merchant = re.sub(r"\s+", " ", merchant).strip(" ,-+;:")[:500]
 
-    return {
+    parsed = {
         "amount": float(amount_decimal),
         "merchant": merchant,
         "note": text[:1000],
         "transaction_type": "money_in" if sign == "+" else "expense",
     }
+    if extracted_date is not None:
+        # ISO string so the wizard draft stays JSONB-safe.
+        parsed["expense_date"] = extracted_date.value.isoformat()
+    return parsed
 
 
 def _parse_duoc_money_in(text: str) -> dict | None:
@@ -189,10 +203,16 @@ def _parse_duoc_money_in(text: str) -> dict | None:
     if not is_duoc_money_in(text):
         return None
 
+    # Strip the date phrase first so its digits don't shadow the amount.
+    working = text
+    extracted_date = extract_transaction_date(working)
+    if extracted_date is not None:
+        working = strip_span(working, extracted_date.span)
+
     # Require a currency-denominated amount (see ``_DUOC_AMOUNT_RE``) so
     # non-cash gifts like "được mẹ cho 2 quả cam" fall through to the
     # intent pipeline instead of being booked as a 2đ money-in.
-    amount_match = _DUOC_AMOUNT_RE.search(text)
+    amount_match = _DUOC_AMOUNT_RE.search(working)
     if not amount_match:
         return None
     amount_token = amount_match.group("amt").strip()
@@ -200,18 +220,21 @@ def _parse_duoc_money_in(text: str) -> dict | None:
     if amount_decimal is None or amount_decimal <= 0:
         return None
 
-    merchant = f"{text[:amount_match.start()]} {text[amount_match.end():]}"
+    merchant = f"{working[:amount_match.start()]} {working[amount_match.end():]}"
     merchant = re.sub(r"\s+", " ", merchant).strip(" ,-+;:")
     # Drop the leading "được" so the source label reads "bố cho" /
     # "thưởng" / "lì xì" rather than "được bố cho".
     merchant = re.sub(r"(?i)^được\s+", "", merchant)[:500]
 
-    return {
+    parsed = {
         "amount": float(amount_decimal),
         "merchant": merchant,
         "note": text[:1000],
         "transaction_type": "money_in",
     }
+    if extracted_date is not None:
+        parsed["expense_date"] = extracted_date.value.isoformat()
+    return parsed
 
 
 async def _start_source_prompt(
@@ -232,6 +255,16 @@ async def _start_source_prompt(
     sign = "+" if tx_type == "money_in" else "-"
     amount_line = f"{sign}{parsed['amount']:,.0f}đ"
     detail = f"{merchant} · {amount_line}" if merchant else amount_line
+    # Show the back-dated day in the prompt so the user can spot a mis-parse
+    # before choosing a source.
+    expense_date_iso = parsed.get("expense_date")
+    if expense_date_iso:
+        try:
+            picked = date.fromisoformat(expense_date_iso)
+            if picked != date.today():
+                detail = f"{detail}\n📅 {picked.strftime('%d/%m/%Y')}"
+        except ValueError:
+            pass
     await send_message(
         chat_id,
         f"{prompt}\n{detail}",
@@ -257,6 +290,13 @@ async def _record_transaction_with_default(
     """
     tx_type = parsed.get("transaction_type", "expense")
     merchant = (parsed.get("merchant") or parsed.get("note") or "Giao dịch").strip()
+    expense_date_iso = parsed.get("expense_date")
+    expense_date = date.today()
+    if expense_date_iso:
+        try:
+            expense_date = date.fromisoformat(expense_date_iso)
+        except ValueError:
+            pass
     expense_data = ExpenseCreate(
         amount=float(parsed["amount"]),
         merchant=merchant or "Giao dịch",
@@ -268,7 +308,7 @@ async def _record_transaction_with_default(
         # record default-sourced income under a spending bucket and skew
         # category analytics.
         category="needs_review" if tx_type == "money_in" else "other",
-        expense_date=date.today(),
+        expense_date=expense_date,
         transaction_type=tx_type,
     )
     resolved = await apply_default_source(db, user.id, expense_data)
@@ -438,12 +478,19 @@ async def handle_text_message(db: AsyncSession, message: dict) -> bool:
 
     if parsed and parsed.get("is_expense") and float(parsed.get("amount", 0)) > 0:
         source_type, source_card_id = await _extract_credit_card_source(db, user.id, text)
+        # Tier-1.5: even though the LLM JSON omits dates, recover any
+        # ``ngày dd/mm`` hint the user typed so the fallback path matches
+        # the fast-path behaviour.
+        extracted_date = extract_transaction_date(text)
+        expense_date_value = (
+            extracted_date.value if extracted_date is not None else date.today()
+        )
         expense_data = ExpenseCreate(
             amount=float(parsed["amount"]),
             merchant=parsed.get("merchant") or text,
             note=text,
             source="manual",
-            expense_date=date.today(),
+            expense_date=expense_date_value,
             source_type=source_type,
             source_credit_card_id=source_card_id,
         )

--- a/backend/bot/handlers/transaction.py
+++ b/backend/bot/handlers/transaction.py
@@ -71,6 +71,7 @@ async def send_transaction_confirmation(
         source_label=source_label,
         show_edit_hint=is_card_type,
         transaction_type=tx_type,
+        expense_date=expense.expense_date,
     )
     reply_markup = transaction_actions_keyboard(str(expense.id))
     await send_message(
@@ -125,6 +126,12 @@ async def send_transaction_batch_confirmation(
         if len(unique) == 1 and len(labels) == len(expenses):
             source_label = next(iter(unique))
 
+    # Batch items can technically be on different days (rare — usually a
+    # single ``ngày dd/mm`` covers the whole message); only surface the
+    # date row when every item agrees AND it isn't today.
+    batch_dates = {expense.expense_date for expense in expenses}
+    batch_date = batch_dates.pop() if len(batch_dates) == 1 else None
+
     text = format_transaction_batch_confirmation(
         items=[
             (
@@ -137,6 +144,7 @@ async def send_transaction_batch_confirmation(
         time=max((expense.created_at for expense in expenses), default=None),
         source_label=source_label,
         show_edit_hint=all_expense,
+        expense_date=batch_date,
     )
     reply_markup = (
         None if all_expense else transaction_batch_actions_keyboard(batch_id)

--- a/backend/bot/utils/date_parser.py
+++ b/backend/bot/utils/date_parser.py
@@ -2,7 +2,16 @@
 
 from __future__ import annotations
 
+import re
 from datetime import date, datetime
+
+# Vietnamese day-month-year token: ``16/05/2026``, ``16-05-2026``, ``16/05/26``
+# (2-digit year) or year-less ``16/05`` / ``16-5``. We accept 1-2 digit
+# day/month so ``5/3`` parses without forcing the user to zero-pad.
+_DAY_MONTH = r"(?P<d>\d{1,2})[/\-.](?P<m>\d{1,2})"
+_OPTIONAL_YEAR = r"(?:[/\-.](?P<y>\d{2}|\d{4}))?"
+
+_VN_DATE_TOKEN_RE = re.compile(rf"^{_DAY_MONTH}{_OPTIONAL_YEAR}$")
 
 
 def parse_vietnamese_date(value: str) -> date | None:
@@ -18,5 +27,40 @@ def parse_vietnamese_date(value: str) -> date | None:
             pass
     try:
         return date.fromisoformat(cleaned)
+    except ValueError:
+        return None
+
+
+def parse_vietnamese_date_token(
+    value: str, *, today: date | None = None
+) -> date | None:
+    """Parse a Vietnamese-style date token with optional year fallback.
+
+    Accepts ``dd/mm/yyyy``, ``dd-mm-yyyy``, ``dd.mm.yyyy``, ``dd/mm/yy``
+    (2-digit year → 2000+yy) and the year-less forms ``dd/mm`` / ``dd-mm``
+    (year defaults to ``today.year``).
+
+    Returns ``None`` for any malformed or out-of-range token (e.g.
+    ``31/02``, ``00/05``) — callers fall back to ``date.today()``.
+    """
+    if not value:
+        return None
+    today = today or date.today()
+    match = _VN_DATE_TOKEN_RE.match(value.strip())
+    if not match:
+        return None
+
+    day = int(match.group("d"))
+    month = int(match.group("m"))
+    raw_year = match.group("y")
+    if raw_year is None:
+        year = today.year
+    else:
+        year = int(raw_year)
+        if year < 100:  # ``26`` → 2026
+            year += 2000
+
+    try:
+        return date(year, month, day)
     except ValueError:
         return None

--- a/backend/bot/utils/transaction_date_extractor.py
+++ b/backend/bot/utils/transaction_date_extractor.py
@@ -1,0 +1,75 @@
+"""Extract a transaction date from free-text user input.
+
+Used by the Tier-1 NLU fast-paths so a message like
+``"-1tr ăn tối ngày 16/05/2026"`` records the expense on 16/05/2026 instead
+of today. Matching is anchored on Vietnamese date keywords (``ngày``, ``hôm``,
+``vào ngày``) to avoid false positives — a phrase like ``"mua 12/3 phần
+pizza"`` MUST NOT be re-interpreted as a date.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from datetime import date
+
+from backend.bot.utils.date_parser import parse_vietnamese_date_token
+
+# Inner day/month[/year] token. Mirrors ``_VN_DATE_TOKEN_RE`` in
+# date_parser.py but stays unanchored so we can embed it in a larger
+# phrase regex.
+_DATE_TOKEN = r"\d{1,2}[/\-.]\d{1,2}(?:[/\-.](?:\d{2}|\d{4}))?"
+
+# Keyword-anchored phrases. ``ngày`` is the canonical one; ``vào ngày`` and
+# ``hôm`` cover natural phrasings. We intentionally do NOT match bare
+# ``16/05`` without a keyword — that risks parsing ratios/portions
+# ("ăn 12/3 phần") as dates.
+_DATE_PHRASE_RE = re.compile(
+    rf"(?P<prefix>\b(?:vào\s+ngày|ngày|hôm))\s+(?P<token>{_DATE_TOKEN})\b",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class ExtractedDate:
+    """Result of date extraction.
+
+    ``span`` is the half-open ``(start, end)`` slice in the input text
+    covering BOTH the keyword and the token, so the caller can strip the
+    whole phrase from the merchant/note without leaving a dangling
+    ``"ngày"``.
+    """
+
+    value: date
+    span: tuple[int, int]
+
+
+def extract_transaction_date(
+    text: str, *, today: date | None = None
+) -> ExtractedDate | None:
+    """Find the first ``ngày <dd/mm[/yyyy]>``-style phrase in ``text``.
+
+    Returns ``None`` when no recognisable date phrase is present, or when
+    the captured token is malformed (e.g. ``ngày 31/02`` → invalid). The
+    caller then keeps ``date.today()``.
+    """
+    if not text:
+        return None
+    match = _DATE_PHRASE_RE.search(text)
+    if not match:
+        return None
+    parsed = parse_vietnamese_date_token(match.group("token"), today=today)
+    if parsed is None:
+        return None
+    return ExtractedDate(value=parsed, span=match.span())
+
+
+def strip_span(text: str, span: tuple[int, int]) -> str:
+    """Remove the matched date phrase from ``text`` and tidy whitespace."""
+    if not text or not span:
+        return text
+    start, end = span
+    cleaned = f"{text[:start]} {text[end:]}"
+    # Tidy whitespace and dangling punctuation, but preserve leading
+    # ``+``/``-`` because they carry sign semantics for the amount.
+    return re.sub(r"\s+", " ", cleaned).strip(" ,.;:")

--- a/backend/intent/handlers/action_quick_transaction.py
+++ b/backend/intent/handlers/action_quick_transaction.py
@@ -30,6 +30,10 @@ from backend.bot.handlers.transaction import (
     send_transaction_batch_confirmation,
     send_transaction_confirmation,
 )
+from backend.bot.utils.transaction_date_extractor import (
+    extract_transaction_date,
+    strip_span,
+)
 from backend.intent.clarifier import build_message_from_key
 from backend.intent.handlers.base import IntentHandler
 # Income vs. expense semantics live in ONE place —
@@ -158,7 +162,21 @@ class ActionQuickTransactionHandler(IntentHandler):
                 "income_detected_in_expense_flow", user
             )
 
-        items = await self._extract_items(text, params, db, user)
+        # Tier-2 must mirror the Tier-1 fast-path: pull any
+        # ``ngày dd/mm[/yyyy]`` hint out before item-parsing so the
+        # date digits don't get re-interpreted as a second amount, and
+        # so the recorded ``expense_date`` matches what the user typed.
+        extracted_date = extract_transaction_date(text)
+        expense_date_value = (
+            extracted_date.value if extracted_date is not None else date.today()
+        )
+        parse_text = (
+            strip_span(text, extracted_date.span)
+            if extracted_date is not None
+            else text
+        )
+
+        items = await self._extract_items(parse_text, params, db, user)
         if not items:
             return _FALLBACK_REPLY
 
@@ -166,11 +184,11 @@ class ActionQuickTransactionHandler(IntentHandler):
             item = items[0]
             expense_data = ExpenseCreate(
                 amount=float(item.amount),
-                merchant=item.merchant or text,
+                merchant=item.merchant or parse_text,
                 category=item.category_hint,
                 note=text,
                 source="manual",
-                expense_date=date.today(),
+                expense_date=expense_date_value,
             )
             expense_data = await apply_default_source(db, user.id, expense_data)
             expense = await expense_service.create_expense(db, user.id, expense_data)
@@ -181,11 +199,11 @@ class ActionQuickTransactionHandler(IntentHandler):
             for index, item in enumerate(items, start=1):
                 expense_data = ExpenseCreate(
                     amount=float(item.amount),
-                    merchant=item.merchant or text,
+                    merchant=item.merchant or parse_text,
                     category=item.category_hint,
                     note=text,
                     source="manual",
-                    expense_date=date.today(),
+                    expense_date=expense_date_value,
                     raw_data={
                         "batch_id": batch_id,
                         "batch_size": len(items),

--- a/backend/tests/test_date_parser.py
+++ b/backend/tests/test_date_parser.py
@@ -1,6 +1,9 @@
 from datetime import date
 
-from backend.bot.utils.date_parser import parse_vietnamese_date
+from backend.bot.utils.date_parser import (
+    parse_vietnamese_date,
+    parse_vietnamese_date_token,
+)
 
 
 def test_parse_vietnamese_date_accepts_slash_format() -> None:
@@ -23,3 +26,54 @@ def test_parse_vietnamese_date_returns_none_on_invalid() -> None:
     assert parse_vietnamese_date("31/31/2028") is None
     assert parse_vietnamese_date("not-a-date") is None
     assert parse_vietnamese_date("") is None
+
+
+# ---------------------------------------------------------------------------
+# parse_vietnamese_date_token — used by the NLU date extractor. Must accept
+# year-less forms and 2-digit years; must reject malformed/out-of-range dates.
+# ---------------------------------------------------------------------------
+
+
+def test_token_parses_full_year() -> None:
+    assert parse_vietnamese_date_token(
+        "16/05/2026", today=date(2026, 6, 3)
+    ) == date(2026, 5, 16)
+
+
+def test_token_parses_year_less_form_defaults_to_today_year() -> None:
+    assert parse_vietnamese_date_token(
+        "16/05", today=date(2026, 6, 3)
+    ) == date(2026, 5, 16)
+
+
+def test_token_parses_two_digit_year_as_2000_offset() -> None:
+    assert parse_vietnamese_date_token(
+        "16/05/26", today=date(2026, 6, 3)
+    ) == date(2026, 5, 16)
+
+
+def test_token_accepts_dash_and_dot_separators() -> None:
+    assert parse_vietnamese_date_token(
+        "16-05-2026", today=date(2026, 6, 3)
+    ) == date(2026, 5, 16)
+    assert parse_vietnamese_date_token(
+        "16.05.2026", today=date(2026, 6, 3)
+    ) == date(2026, 5, 16)
+
+
+def test_token_accepts_single_digit_day_and_month() -> None:
+    assert parse_vietnamese_date_token(
+        "5/3", today=date(2026, 6, 3)
+    ) == date(2026, 3, 5)
+
+
+def test_token_rejects_invalid_day_or_month() -> None:
+    assert parse_vietnamese_date_token("31/02", today=date(2026, 6, 3)) is None
+    assert parse_vietnamese_date_token("00/05", today=date(2026, 6, 3)) is None
+    assert parse_vietnamese_date_token("16/13", today=date(2026, 6, 3)) is None
+
+
+def test_token_rejects_empty_and_malformed() -> None:
+    assert parse_vietnamese_date_token("", today=date(2026, 6, 3)) is None
+    assert parse_vietnamese_date_token("hôm nay", today=date(2026, 6, 3)) is None
+    assert parse_vietnamese_date_token("16", today=date(2026, 6, 3)) is None

--- a/backend/tests/test_signed_transaction_parser.py
+++ b/backend/tests/test_signed_transaction_parser.py
@@ -117,3 +117,68 @@ def test_parse_duoc_money_in_accepts(
 )
 def test_parse_duoc_money_in_rejects(text: str) -> None:
     assert _parse_duoc_money_in(text) is None
+
+
+# ---------------------------------------------------------------------------
+# Date extraction wiring — the Tier-1 fast-paths must surface the
+# ``ngày dd/mm[/yyyy]`` hint in the parsed dict as ISO string so the
+# wizard draft stays JSONB-safe, and the date phrase must NOT bleed into
+# the merchant slot.
+# ---------------------------------------------------------------------------
+
+
+def test_signed_expense_extracts_date_with_year() -> None:
+    parsed = _parse_signed_transaction("-1tr ăn tối ngày 16/05/2026")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 1_000_000
+    assert parsed["expense_date"] == "2026-05-16"
+    # Date phrase stripped from merchant.
+    assert "ngày" not in parsed["merchant"]
+    assert "16/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "ăn tối"
+
+
+def test_signed_expense_extracts_year_less_date() -> None:
+    parsed = _parse_signed_transaction("-50k cà phê ngày 02/06")
+    assert parsed is not None
+    assert parsed["expense_date"] is not None
+    # Defaults to current year — exact value depends on test run date,
+    # but format and month/day must be right.
+    assert parsed["expense_date"].endswith("-06-02")
+    assert parsed["merchant"] == "cà phê"
+
+
+def test_signed_money_in_extracts_date() -> None:
+    parsed = _parse_signed_transaction("+5tr thưởng tết ngày 15/01/2026")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "money_in"
+    assert parsed["amount"] == 5_000_000
+    assert parsed["expense_date"] == "2026-01-15"
+    assert parsed["merchant"] == "thưởng tết"
+
+
+def test_signed_expense_without_date_omits_expense_date() -> None:
+    parsed = _parse_signed_transaction("-50k cà phê")
+    assert parsed is not None
+    # No date in input → key must be absent so the handler defaults to today.
+    assert "expense_date" not in parsed
+
+
+def test_duoc_money_in_extracts_date() -> None:
+    parsed = _parse_duoc_money_in("được bố cho 500k ngày 15/05/2026")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "money_in"
+    assert parsed["amount"] == 500_000
+    assert parsed["expense_date"] == "2026-05-15"
+    assert "ngày" not in parsed["merchant"]
+    assert parsed["merchant"] == "bố cho"
+
+
+def test_duoc_money_in_invalid_date_falls_back_silently() -> None:
+    """``ngày 31/02`` is invalid — parser must drop the date hint but still
+    record the money-in (don't refuse a good transaction over a bad date)."""
+    parsed = _parse_duoc_money_in("được bố cho 500k ngày 31/02")
+    assert parsed is not None
+    assert parsed["amount"] == 500_000
+    assert "expense_date" not in parsed

--- a/backend/tests/test_templates.py
+++ b/backend/tests/test_templates.py
@@ -1,6 +1,6 @@
 """Tests for message templates (Issue #27)."""
 
-from datetime import datetime
+from datetime import date, datetime, timedelta
 from zoneinfo import ZoneInfo
 
 from backend.bot.formatters.templates import (
@@ -94,6 +94,33 @@ class TestTransactionConfirmation:
         )
         assert "📌" in result  # 'other' emoji
 
+    def test_back_dated_expense_renders_date_line(self):
+        result = format_transaction_confirmation(
+            merchant="ăn tối",
+            amount=1_000_000,
+            category_code="food",
+            expense_date=date(2026, 5, 16),
+        )
+        assert "📅 Ngày giao dịch: 16/05/2026" in result
+
+    def test_today_expense_omits_date_line(self):
+        result = format_transaction_confirmation(
+            merchant="cà phê",
+            amount=50_000,
+            category_code="food",
+            expense_date=date.today(),
+        )
+        assert "Ngày giao dịch" not in result
+
+    def test_none_expense_date_omits_date_line(self):
+        result = format_transaction_confirmation(
+            merchant="cà phê",
+            amount=50_000,
+            category_code="food",
+            expense_date=None,
+        )
+        assert "Ngày giao dịch" not in result
+
 
 class TestTransactionBatchConfirmation:
     def test_contains_each_item_and_total(self):
@@ -119,6 +146,29 @@ class TestTransactionBatchConfirmation:
         assert "click vào các nhãn ở dưới để sửa lại" in result
         assert "<i>" in result and "</i>" in result
         assert "💡" in result
+
+    def test_batch_back_dated_renders_date_line(self):
+        yesterday = date.today() - timedelta(days=1)
+        result = format_transaction_batch_confirmation(
+            items=[("tiền xăng", 50_000, "transport"), ("ăn trưa", 50_000, "food")],
+            expense_date=yesterday,
+        )
+        assert "Ngày giao dịch" in result
+        assert yesterday.strftime("%d/%m/%Y") in result
+
+    def test_batch_today_omits_date_line(self):
+        result = format_transaction_batch_confirmation(
+            items=[("tiền xăng", 50_000, "transport"), ("ăn trưa", 50_000, "food")],
+            expense_date=date.today(),
+        )
+        assert "Ngày giao dịch" not in result
+
+    def test_batch_none_expense_date_omits_date_line(self):
+        result = format_transaction_batch_confirmation(
+            items=[("tiền xăng", 50_000, "transport"), ("ăn trưa", 50_000, "food")],
+            expense_date=None,
+        )
+        assert "Ngày giao dịch" not in result
 
 
 class TestDailySummary:

--- a/backend/tests/test_transaction_date_extractor.py
+++ b/backend/tests/test_transaction_date_extractor.py
@@ -1,0 +1,89 @@
+"""Tests for the Tier-1 transaction-date extractor.
+
+Anchored on Vietnamese date keywords (``ngày``, ``vào ngày``, ``hôm``) so
+bare ratios like ``"ăn 12/3 phần pizza"`` MUST NOT be parsed as dates.
+"""
+
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+from backend.bot.utils.transaction_date_extractor import (
+    extract_transaction_date,
+    strip_span,
+)
+
+_TODAY = date(2026, 6, 3)
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("-1tr ăn tối ngày 16/05/2026", date(2026, 5, 16)),
+        ("-1tr ăn tối ngày 16/05", date(2026, 5, 16)),
+        ("100k cà phê vào ngày 01/05", date(2026, 5, 1)),
+        ("ăn trưa 50k hôm 02/06", date(2026, 6, 2)),
+        ("NGÀY 16/05/2026 ăn tối 1tr", date(2026, 5, 16)),  # case-insensitive
+        ("được bố cho 500k ngày 15/05", date(2026, 5, 15)),
+    ],
+)
+def test_extract_with_keyword_anchor(text: str, expected: date) -> None:
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None, f"expected a date in {text!r}"
+    assert result.value == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "",
+        "ăn 12/3 phần pizza",  # ratio — NOT a date phrase
+        "mua 2/3 ổ bánh mì",  # portion
+        "hôm nay đẹp trời",  # 'hôm' without a token
+        "-1tr ăn tối",  # no date
+        "100k cà phê",
+        "ngày",  # keyword without token
+    ],
+)
+def test_extract_returns_none_for_non_date(text: str) -> None:
+    assert extract_transaction_date(text, today=_TODAY) is None
+
+
+def test_extract_returns_none_for_invalid_token() -> None:
+    # Keyword is present but the token is invalid → None (caller falls
+    # back to date.today()).
+    assert extract_transaction_date("ăn tối ngày 31/02", today=_TODAY) is None
+
+
+def test_extract_span_covers_keyword_and_token() -> None:
+    text = "-1tr ăn tối ngày 16/05/2026"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    start, end = result.span
+    assert text[start:end] == "ngày 16/05/2026"
+
+
+def test_strip_span_removes_phrase_and_tidies_whitespace() -> None:
+    text = "-1tr ăn tối ngày 16/05/2026"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    # Date phrase gone, no double spaces, no dangling punctuation.
+    assert "ngày" not in stripped
+    assert "16/05" not in stripped
+    assert "  " not in stripped
+    assert stripped == "-1tr ăn tối"
+
+
+def test_strip_span_handles_mid_text_phrase() -> None:
+    text = "ăn trưa ngày 02/06 ở quán cũ"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    assert stripped == "ăn trưa ở quán cũ"
+
+
+def test_strip_span_empty_input() -> None:
+    assert strip_span("", (0, 0)) == ""

--- a/content/transaction_copy.yaml
+++ b/content/transaction_copy.yaml
@@ -3,8 +3,12 @@ confirmation:
   batch_title: "✅ Đã ghi xong {count} khoản!"
   source_prefix: "💳 Chi từ: {source}"
   source_prefix_money_in: "💰 Nhận vào: {source}"
+  transaction_date: "📅 Ngày giao dịch: {date}"
   edit_hint: "<i>💡 chi tiêu đã được ghi lại, nếu đúng bạn không cần làm gì thêm! Nếu thông tin chưa chính xác, hãy click vào các nhãn ở dưới để sửa lại.</i>"
   edit_hint_money_in: "<i>💡 khoản tiền vào đã được ghi lại, nếu đúng bạn không cần làm gì thêm! Nếu thông tin chưa chính xác, hãy click vào các nhãn ở dưới để sửa lại.</i>"
+
+prompt:
+  date_line: "📅 Ngày giao dịch: {date}"
 
 source_labels:
   cash: "Tiền mặt"


### PR DESCRIPTION
## Summary

Lets users back-date a transaction by typing a Vietnamese date phrase ("-1tr ăn tối **ngày 16/05/2026**") so Bé Tiền records the expense on the intended date instead of today.

The same extractor is wired across all three NLU entry points so behaviour is consistent regardless of which tier handles the message:

- **Tier 1 fast-path** — `_parse_signed_transaction`, `_parse_duoc_money_in` in `bot/handlers/message.py`
- **Tier 1.5 LLM-JSON fallback** — inside `handle_text_message`
- **Tier 2 LLM-classified path** — `intent/handlers/action_quick_transaction.py`

## Design choices

| Concern | Decision |
|---|---|
| **Consistency** | One extractor (`extract_transaction_date`) used by all three NLU tiers + the LLM-JSON fallback → same behaviour everywhere |
| **Performance** | Pure regex + `datetime.date(...)` validation; no LLM round-trip, no DB hit. Stays inside the Tier-1 ≤200ms budget |
| **UX** | Confirmation card shows the date line ONLY when `expense_date != today` — same-day flows stay clean. Batch confirmations show the date only when ALL items agree, never a misleading single date |
| **Security / robustness** | Keyword-anchored regex (`ngày`, `vào ngày`, `hôm`) → ratios like "ăn 12/3 phần pizza" are NOT misread as dates. Invalid dates (`ngày 31/02`) silently fall back to today rather than refusing the transaction. Wizard JSONB serialises the date as ISO-8601 string; deserialise is wrapped in try/except so a corrupt draft can't crash the source-picker |
| **Localization** | New copy keys in `content/transaction_copy.yaml` (`confirmation.transaction_date`, `prompt.date_line`) — no hardcoded Vietnamese strings |

## Supported formats

- `dd/mm/yyyy`, `dd-mm-yyyy`, `dd.mm.yyyy`
- `dd/mm/yy` → 2000 + yy
- `dd/mm` → defaults to current year
- Single-digit day/month accepted (`5/3`)
- Case-insensitive keyword (`NGÀY 16/05/2026` ok)

## Test plan

- [x] `pytest backend/tests/test_date_parser.py backend/tests/test_transaction_date_extractor.py backend/tests/test_signed_transaction_parser.py backend/tests/test_templates.py` → **91 passed**
- [x] Full backend suite vs pristine baseline → **+37 net-new passes, 0 new failures**
- [x] `ruff check` on touched files → clean (only one E741 in `message.py` is pre-existing)
- [ ] Manual smoke test on Telegram:
  - Type `-1tr ăn tối ngày 16/05/2026` → confirmation shows "📅 Ngày giao dịch: 16/05/2026"
  - Type `45k phở` (today) → no date line
  - Type `ăn 12/3 phần pizza` → NOT parsed as date
  - Type `được bố cho 500k ngày 15/05` → money-in recorded on 15/05/current-year

https://claude.ai/code/session_017WyTn4EmVj2vfYV5LK6eEx