### PR TITLE
fix(intent): align asset-list MoM delta with calendar end-of-month

### DIFF
--- a/backend/intent/follow_up.py
+++ b/backend/intent/follow_up.py
@@ -96,7 +96,6 @@ _BASE_SUGGESTIONS: dict[IntentType, tuple[FollowUp, ...]] = {
         FollowUp("📈 YTD - Tài sản từ đầu năm đến nay", IntentType.QUERY_NET_WORTH, {"time_range": "ytd"}),
         FollowUp("📈 So với tháng trước", IntentType.QUERY_NET_WORTH, {"time_range": "month_vs_previous"}),
         FollowUp("🏠 Chỉ BĐS", IntentType.QUERY_ASSETS, {"asset_type": "real_estate"}),
-        FollowUp("💎 Tổng net worth", IntentType.QUERY_NET_WORTH),
         FollowUp("📈 Cổ phiếu", IntentType.QUERY_PORTFOLIO),
     ),
     IntentType.QUERY_NET_WORTH: (
@@ -159,7 +158,7 @@ _LEVEL_OVERRIDES: dict[tuple[IntentType, WealthLevel], tuple[FollowUp, ...]] = {
     (IntentType.QUERY_ASSETS, WealthLevel.STARTER): (
         FollowUp("📈 YTD - Tài sản từ đầu năm đến nay", IntentType.QUERY_NET_WORTH, {"time_range": "ytd"}),
         FollowUp("➕ Thêm tài sản", IntentType.HELP),
-        FollowUp("💎 Net worth tổng", IntentType.QUERY_NET_WORTH),
+        FollowUp("📈 So với tháng trước", IntentType.QUERY_NET_WORTH, {"time_range": "month_vs_previous"}),
     ),
     (IntentType.QUERY_NET_WORTH, WealthLevel.STARTER): (
         FollowUp("➕ Thêm tài sản", IntentType.HELP),
@@ -198,8 +197,23 @@ def get_follow_ups(
     intents such as market queries keep follow-ups context-aware without
     adding another DB roundtrip.
     """
+    params = parameters or {}
+
+    # The "📈 So với tháng trước" comparison view is a focused, single-
+    # purpose surface: the user has just compared this-month vs last-month
+    # net worth. Generic net-worth follow-ups ("Trend 6 tháng",
+    # "Portfolio của tôi", "Portfolio analytics") would either repeat the
+    # same number or dilute the next-step CTA. By design we surface only
+    # the goal-progress hand-off — the natural next question after a
+    # delta is "am I still on track for my goals?".
+    if (
+        intent == IntentType.QUERY_NET_WORTH
+        and params.get("time_range") == "month_vs_previous"
+    ):
+        return [FollowUp("🎯 Mục tiêu của tôi", IntentType.QUERY_GOALS)]
+
     pool: list[FollowUp] = []
-    category = str((parameters or {}).get("category") or "").lower()
+    category = str(params.get("category") or "").lower()
     if intent == IntentType.QUERY_MARKET and category in {"stock", "stocks", "crypto", "gold"}:
         asset_type = "stock" if category in {"stock", "stocks"} else category
         pool.extend(

--- a/backend/intent/handlers/query_net_worth.py
+++ b/backend/intent/handlers/query_net_worth.py
@@ -9,7 +9,7 @@ message as typing "So sánh tài sản của tôi so với tháng trước".
 
 from __future__ import annotations
 
-from datetime import date, timedelta
+from datetime import date
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -47,11 +47,15 @@ class QueryNetWorthHandler(IntentHandler):
         level = detect_level(breakdown.total)
         style = style_for_level(level, breakdown.total)
 
-        change = await net_worth_calculator.calculate_change_from_current(
+        # Anchor the baseline to the end of the previous calendar month so
+        # the standalone "so với tháng trước" delta matches the ⚖️ comparison
+        # view the asset-list follow-up renders. Using a rolling 30-day
+        # window here would drift across month boundaries and produce a
+        # different number than the comparison the user sees one tap later.
+        change = await net_worth_calculator.calculate_change_vs_last_month_end_from_current(
             db,
             user.id,
             breakdown.total,
-            period=net_worth_calculator.PERIOD_MONTH,
         )
 
         name = user.display_name or "bạn"
@@ -131,12 +135,12 @@ class QueryNetWorthHandler(IntentHandler):
             )
             label_a = "Hiện tại"
         else:  # month_vs_previous
-            last_month_end = date.today().replace(day=1) - timedelta(days=1)
-            previous = await net_worth_calculator.calculate_historical(
-                db, user.id, last_month_end
+            change = await net_worth_calculator.calculate_change_vs_last_month_end_from_current(
+                db, user.id, current
             )
-            diff = current - previous
-            diff_pct = float(diff / previous * 100) if previous > 0 else 0.0
+            previous = change.previous
+            diff = change.change_absolute
+            diff_pct = change.change_percentage
             label_a = "Tháng này"
             label_b = "Tháng trước"
 

--- a/backend/tests/test_intent/test_follow_up.py
+++ b/backend/tests/test_intent/test_follow_up.py
@@ -191,3 +191,57 @@ def test_assets_follow_up_has_ytd_button_for_all_wealth_levels(level):
     ytd_button = next(f for f in fus if "YTD - Tài sản từ đầu năm đến nay" in f.label)
     assert ytd_button.intent == IntentType.QUERY_NET_WORTH
     assert ytd_button.parameters == {"time_range": "ytd"}
+
+
+@pytest.mark.parametrize("level", [
+    None,
+    WealthLevel.STARTER,
+    WealthLevel.MASS_AFFLUENT,
+    WealthLevel.HIGH_NET_WORTH,
+    WealthLevel.VIP,
+])
+def test_assets_follow_up_never_offers_plain_total_net_worth(level):
+    """The "Tổng net worth" / "Net worth tổng" plain shortcut was removed —
+    it duplicated the asset-list headline and confused users with a delta
+    computed on a rolling-30-day baseline. The two delta-aware buttons
+    (YTD and So với tháng trước) replace it across every wealth level."""
+    kwargs = {} if level is None else {"wealth_level": level}
+    fus = get_follow_ups(IntentType.QUERY_ASSETS, **kwargs)
+    for fu in fus:
+        # No bare net-worth headline button (i.e. QUERY_NET_WORTH with no
+        # time_range parameter) should appear in the assets follow-ups.
+        if fu.intent == IntentType.QUERY_NET_WORTH:
+            assert fu.parameters and "time_range" in fu.parameters
+
+
+@pytest.mark.parametrize("level", [
+    None,
+    WealthLevel.STARTER,
+    WealthLevel.MASS_AFFLUENT,
+    WealthLevel.HIGH_NET_WORTH,
+    WealthLevel.VIP,
+])
+def test_month_vs_previous_view_shows_only_goals_cta(level):
+    """The ⚖️ comparison surface keeps a single, focused next-step:
+    "🎯 Mục tiêu của tôi". Trend / Portfolio buttons are suppressed so
+    the user isn't pulled back into another net-worth view right after
+    seeing the delta."""
+    kwargs = {} if level is None else {"wealth_level": level}
+    fus = get_follow_ups(
+        IntentType.QUERY_NET_WORTH,
+        parameters={"time_range": "month_vs_previous"},
+        avoid_intent=IntentType.QUERY_NET_WORTH,
+        **kwargs,
+    )
+    assert len(fus) == 1
+    assert fus[0].intent == IntentType.QUERY_GOALS
+    assert "Mục tiêu" in fus[0].label
+    # No Portfolio button — explicit per UX requirement.
+    assert all(f.intent != IntentType.QUERY_PORTFOLIO for f in fus)
+
+
+def test_net_worth_follow_ups_unaffected_when_no_time_range():
+    """Sanity: the override only kicks in for month_vs_previous —
+    the default net-worth view still gets its rich pool."""
+    fus = get_follow_ups(IntentType.QUERY_NET_WORTH)
+    assert len(fus) > 1

--- a/backend/tests/test_intent/test_handlers.py
+++ b/backend/tests/test_intent/test_handlers.py
@@ -372,7 +372,7 @@ async def test_query_net_worth_handler_includes_change_when_baseline_exists():
             calculate_mock,
         ),
         patch(
-            "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_from_current",
+            "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_vs_last_month_end_from_current",
             change_mock,
         ),
     ):
@@ -387,7 +387,7 @@ async def test_query_net_worth_handler_includes_change_when_baseline_exists():
     assert "tháng trước" in response
     assert "📈" in response or "📉" in response
     calculate_mock.assert_awaited_once()
-    change_mock.assert_awaited_once_with(ANY, ANY, Decimal("500000000"), period="month")
+    change_mock.assert_awaited_once_with(ANY, ANY, Decimal("500000000"))
 
 
 @pytest.mark.asyncio
@@ -422,7 +422,7 @@ async def test_query_net_worth_handler_shows_true_ytd_for_hnw():
             AsyncMock(return_value=breakdown),
         ),
         patch(
-            "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_from_current",
+            "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_vs_last_month_end_from_current",
             AsyncMock(return_value=change),
         ),
         patch(
@@ -476,7 +476,7 @@ async def test_query_net_worth_handler_shows_dash_for_zero_ytd_base():
             AsyncMock(return_value=breakdown),
         ),
         patch(
-            "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_from_current",
+            "backend.intent.handlers.query_net_worth.net_worth_calculator.calculate_change_vs_last_month_end_from_current",
             AsyncMock(return_value=change),
         ),
         patch(

--- a/backend/tests/test_net_worth_calculator.py
+++ b/backend/tests/test_net_worth_calculator.py
@@ -294,6 +294,65 @@ class TestCalculateChange:
 
 
 @pytest.mark.asyncio
+async def test_change_vs_last_month_end_uses_calendar_anchor(monkeypatch):
+    """Baseline must be the LAST day of the previous calendar month —
+    not ``today - 30 days``. That alignment is the entire point of the
+    helper: it keeps the headline delta consistent with the ⚖️ comparison
+    surface (which also reads the end-of-month snapshot)."""
+    captured: dict = {}
+
+    async def fake_historical(_db, _uid, target_date):
+        captured["target_date"] = target_date
+        return Decimal("100000000")
+
+    monkeypatch.setattr(nwc, "calculate_historical", fake_historical)
+    db = MagicMock()
+
+    today = date(2026, 6, 4)
+    change = await nwc.calculate_change_vs_last_month_end_from_current(
+        db, uuid.uuid4(), Decimal("110000000"), today=today
+    )
+
+    assert captured["target_date"] == date(2026, 5, 31)
+    assert change.previous == Decimal("100000000")
+    assert change.current == Decimal("110000000")
+    assert change.change_absolute == Decimal("10000000")
+    assert change.change_percentage == 10.0
+    assert change.period_label == "tháng trước"
+
+
+@pytest.mark.asyncio
+async def test_change_vs_last_month_end_handles_zero_baseline(monkeypatch):
+    """No snapshot ⇒ previous=0, pct stays 0 (never divide-by-zero)."""
+    monkeypatch.setattr(
+        nwc, "calculate_historical", AsyncMock(return_value=Decimal(0))
+    )
+    db = MagicMock()
+    change = await nwc.calculate_change_vs_last_month_end_from_current(
+        db, uuid.uuid4(), Decimal("5000000"), today=date(2026, 6, 4)
+    )
+    assert change.previous == Decimal(0)
+    assert change.change_percentage == 0.0
+
+
+@pytest.mark.asyncio
+async def test_change_vs_last_month_end_january_rolls_back_to_december(monkeypatch):
+    """Month boundary at year boundary: Jan 15 ⇒ Dec 31 prev year."""
+    captured: dict = {}
+
+    async def fake_historical(_db, _uid, target_date):
+        captured["target_date"] = target_date
+        return Decimal("0")
+
+    monkeypatch.setattr(nwc, "calculate_historical", fake_historical)
+    db = MagicMock()
+    await nwc.calculate_change_vs_last_month_end_from_current(
+        db, uuid.uuid4(), Decimal("0"), today=date(2026, 1, 15)
+    )
+    assert captured["target_date"] == date(2025, 12, 31)
+
+
+@pytest.mark.asyncio
 async def test_calculate_ytd_return_uses_jan_1_baseline(monkeypatch):
     historical = AsyncMock(return_value=Decimal("100000000"))
     monkeypatch.setattr(nwc, "calculate_historical", historical)

--- a/backend/wealth/services/net_worth_calculator.py
+++ b/backend/wealth/services/net_worth_calculator.py
@@ -255,6 +255,43 @@ async def calculate_change_from_current(
     )
 
 
+async def calculate_change_vs_last_month_end_from_current(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    current: Decimal,
+    *,
+    today: date | None = None,
+) -> NetWorthChange:
+    """Compare current net worth to the snapshot at the **end of last month**.
+
+    Unlike :func:`calculate_change_from_current` with ``period=PERIOD_MONTH``
+    (which uses ``today - 30 days`` — an approximation that drifts across
+    month boundaries), this anchors the baseline to a calendar-aligned
+    point: the last day of the previous calendar month. That matches the
+    semantics users expect when they read "so với tháng trước" and keeps
+    the standalone headline consistent with the ⚖️ comparison view that
+    the asset-list follow-up "📈 So với tháng trước" produces.
+    """
+    today = today or date.today()
+    last_month_end = today.replace(day=1) - timedelta(days=1)
+    current = Decimal(current or 0)
+    previous = await calculate_historical(db, user_id, last_month_end)
+
+    change_absolute = current - previous
+    if previous > 0:
+        change_pct = float(change_absolute / previous * 100)
+    else:
+        change_pct = 0.0
+
+    return NetWorthChange(
+        current=current,
+        previous=previous,
+        change_absolute=change_absolute,
+        change_percentage=change_pct,
+        period_label=_PERIOD_LABELS[PERIOD_MONTH],
+    )
+
+
 async def calculate_ytd_return_from_current(
     db: AsyncSession,
     user_id: uuid.UUID,


### PR DESCRIPTION
## Bug

Asset report ("tài sản của tôi") and the "So với tháng trước" follow-up tap could show contradictory month-over-month deltas one tap apart:

- Headline `QueryNetWorthHandler` used `calculate_change_from_current(period=PERIOD_MONTH)` → rolling `today - 30 days` baseline, but labeled the delta "so với tháng trước".
- The `⚖️ So sánh` comparison surface used calendar end-of-last-month as the baseline.

When a large asset was added within the last 30 days but before the end of last month, the two surfaces disagreed dramatically (e.g. `-3.1 tỷ (-1.3%)` vs `+100.1 tỷ (+76.7%)`).

## Fixes

1. **Service helper** `net_worth_calculator.calculate_change_vs_last_month_end_from_current` — single source of truth, anchored to `today.replace(day=1) - 1 day`. Both the headline handler and the `month_vs_previous` comparison branch now consume it, so the two surfaces agree by construction.
2. **Asset-list follow-ups** — removed the bare "💎 Tổng net worth" / "💎 Net worth tổng" buttons (across base + STARTER override). The two delta-aware buttons (`📈 YTD - Tài sản từ đầu năm đến nay` and `📈 So với tháng trước`) replace it across every wealth level.
3. **Comparison view follow-ups** — `QUERY_NET_WORTH` with `time_range=month_vs_previous` now surfaces a single focused CTA: `🎯 Mục tiêu của tôi`. Portfolio / trend buttons are suppressed so users aren't pulled back into another net-worth view immediately after seeing the delta.

## Tests

- `test_net_worth_calculator.py` — 3 new tests covering calendar anchor (today=2026-06-04 → target=2026-05-31), zero-baseline divide-by-zero safety, and Jan→Dec year boundary.
- `test_follow_up.py` — 3 new parametrized tests: no plain `Tổng net worth` button across all wealth levels, comparison view shows only `Mục tiêu` CTA, and the override does not regress the default net-worth pool.
- `test_handlers.py` — updated patch targets to the new helper.

108 targeted tests pass; `ruff check` clean.

## Layer contract

- New helper lives in `services/` and only flushes (no `db.commit`).
- Handler keeps transport-free; follow-up module stays pure (no I/O).
- No new user-facing strings outside existing patterns.