### PR TITLE
fix(intent): drop "Portfolio analytics" shortcut from net-worth view

### DIFF
--- a/backend/intent/follow_up.py
+++ b/backend/intent/follow_up.py
@@ -168,15 +168,17 @@ _LEVEL_OVERRIDES: dict[tuple[IntentType, WealthLevel], tuple[FollowUp, ...]] = {
     # already leads with the YTD button, then "So với tháng trước" and a
     # BĐS filter — the right analytics-first surface for these levels.
     # (The "Portfolio detail" button + flow was removed by request.)
+    # HNW / VIP previously surfaced a dedicated "💼 Portfolio analytics"
+    # button on the net-worth view. It was removed by product request — the
+    # analytics shortcut routed to the same QUERY_PORTFOLIO surface as the
+    # base "💼 Portfolio của tôi" button, so it added a second portfolio
+    # entry-point without adding information. Trend remains as the
+    # HNW-flavored override; portfolio + goals come from the base pool.
     (IntentType.QUERY_NET_WORTH, WealthLevel.HIGH_NET_WORTH): (
         FollowUp("📈 Trend 6 tháng", IntentType.QUERY_NET_WORTH, {"trend_days": 180}),
-        FollowUp("💼 Portfolio analytics", IntentType.QUERY_PORTFOLIO),
     ),
-    # Đỉnh Cao (VIP) gets the same analytics-first surface as HNW —
-    # the persona/copy difference lives in prompts, not in follow-ups.
     (IntentType.QUERY_NET_WORTH, WealthLevel.VIP): (
         FollowUp("📈 Trend 6 tháng", IntentType.QUERY_NET_WORTH, {"trend_days": 180}),
-        FollowUp("💼 Portfolio analytics", IntentType.QUERY_PORTFOLIO),
     ),
 }
 

--- a/backend/tests/test_intent/test_follow_up.py
+++ b/backend/tests/test_intent/test_follow_up.py
@@ -245,3 +245,39 @@ def test_net_worth_follow_ups_unaffected_when_no_time_range():
     the default net-worth view still gets its rich pool."""
     fus = get_follow_ups(IntentType.QUERY_NET_WORTH)
     assert len(fus) > 1
+
+
+@pytest.mark.parametrize("level", [
+    WealthLevel.HIGH_NET_WORTH,
+    WealthLevel.VIP,
+])
+def test_net_worth_view_no_longer_offers_portfolio_analytics_label(level):
+    """The "💼 Portfolio analytics" shortcut was removed across HNW/VIP.
+    It routed to the same QUERY_PORTFOLIO surface as the base
+    "💼 Portfolio của tôi" button, so it duplicated the entry-point."""
+    fus = get_follow_ups(IntentType.QUERY_NET_WORTH, wealth_level=level)
+    for fu in fus:
+        assert "Portfolio analytics" not in fu.label
+
+
+@pytest.mark.parametrize("level", [
+    None,
+    WealthLevel.STARTER,
+    WealthLevel.MASS_AFFLUENT,
+    WealthLevel.HIGH_NET_WORTH,
+    WealthLevel.VIP,
+])
+def test_month_vs_previous_view_excludes_portfolio_analytics(level):
+    """The month_vs_previous comparison surface must not surface any
+    portfolio button (analytics label or otherwise). It's a focused,
+    single-CTA view that hands off to goals."""
+    kwargs = {} if level is None else {"wealth_level": level}
+    fus = get_follow_ups(
+        IntentType.QUERY_NET_WORTH,
+        parameters={"time_range": "month_vs_previous"},
+        avoid_intent=IntentType.QUERY_NET_WORTH,
+        **kwargs,
+    )
+    for fu in fus:
+        assert fu.intent != IntentType.QUERY_PORTFOLIO
+        assert "Portfolio" not in fu.label


### PR DESCRIPTION
## Request

Sau khi merge PR #933, người dùng yêu cầu:
- Báo cáo **"Net worth tổng"**: bỏ button `💼 Portfolio analytics`.
- Báo cáo **"So với tháng trước"**: chỉ giữ `🎯 Mục tiêu của tôi` (đã đúng từ PR #933 — PR này thêm regression test để pin contract).

## Bug

HNW / VIP override cho `QUERY_NET_WORTH` đang surface 2 button cùng route về `QUERY_PORTFOLIO`:
- `💼 Portfolio analytics` (override label)
- `💼 Portfolio của tôi` (base pool, fill phần còn lại)

Hai button, một đích → label "analytics" không thêm thông tin, chỉ chiếm slot trong tối đa 3 button.

## Fix

`backend/intent/follow_up.py`
- Bỏ `💼 Portfolio analytics` khỏi cả 2 override `(QUERY_NET_WORTH, HIGH_NET_WORTH)` và `(QUERY_NET_WORTH, VIP)`.
- `📈 Trend 6 tháng` vẫn là override (signature của HNW/VIP); `Portfolio của tôi` + `Mục tiêu của tôi` đến từ base pool — surface cuối: **Trend / Portfolio / Mục tiêu**.
- Comparison view (`time_range=month_vs_previous`) giữ nguyên early-return single-CTA → `🎯 Mục tiêu của tôi`.

## Tests (`test_follow_up.py`)

- `test_net_worth_view_no_longer_offers_portfolio_analytics_label` — parametrized HNW + VIP, assert không có label chứa "Portfolio analytics".
- `test_month_vs_previous_view_excludes_portfolio_analytics` — parametrized tất cả wealth level, assert không có button route về `QUERY_PORTFOLIO` và không có label chứa "Portfolio".

48 tests passed trong `test_follow_up.py`.

## Layer contract

- Pure dataclass module, không I/O, không state mới.
- Không user-facing string mới ngoài content YAML pattern hiện tại.
- Không đụng services/handlers — dispatcher tiếp tục truyền `parameters` xuống follow-up picker đúng như trước.