### PR TITLE
feat(intent): "Theo loại" follow-up opens a category picker

### DIFF
--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -575,6 +575,23 @@ async def _handle_followup_callback(
         )
         return True
 
+    if follow_up.is_category_picker_callback(parsed):
+        time_range = (parsed.parameters or {}).get("time_range")
+        keyboard = follow_up.build_category_picker_keyboard(time_range=time_range)
+        await send_message(
+            chat_id,
+            "Bạn muốn xem chi tiêu loại nào? 🌱",
+            reply_markup=keyboard,
+        )
+        from backend import analytics
+
+        analytics.track(
+            "intent_followup_category_picker_shown",
+            user_id=user.id,
+            properties={"time_range": time_range or ""},
+        )
+        return True
+
     synthesised = IntentResult(
         intent=parsed.intent,
         confidence=0.95,

--- a/backend/intent/follow_up.py
+++ b/backend/intent/follow_up.py
@@ -26,6 +26,7 @@ import logging
 from base64 import urlsafe_b64decode, urlsafe_b64encode
 from dataclasses import dataclass
 
+from backend.config.categories import get_all_categories
 from backend.intent.intents import IntentType
 from backend.wealth.ladder import WealthLevel
 
@@ -57,6 +58,19 @@ _INTENT_TO_CODE: dict[IntentType, str] = {
 _CODE_TO_INTENT: dict[str, IntentType] = {v: k for k, v in _INTENT_TO_CODE.items()}
 
 
+# Parameter-key abbreviations for the callback wire format. Telegram caps
+# callback_data at 64 bytes; long JSON keys like ``"time_range"`` together
+# with a category code blow past that cap once base64-encoded. We shorten
+# only on the wire — handlers see the full key names after parsing.
+_PARAM_KEY_TO_CODE: dict[str, str] = {
+    "category": "c",
+    "time_range": "t",
+    "asset_type": "a",
+    "trend_days": "d",
+}
+_CODE_TO_PARAM_KEY: dict[str, str] = {v: k for k, v in _PARAM_KEY_TO_CODE.items()}
+
+
 @dataclass(frozen=True)
 class FollowUp:
     """One follow-up suggestion — label + the intent it triggers."""
@@ -77,9 +91,12 @@ class FollowUp:
         code = _INTENT_TO_CODE.get(self.intent, self.intent.value[:8])
         if not self.parameters:
             return f"{CALLBACK_PREFIX}{code}"
+        wire_params = {
+            _PARAM_KEY_TO_CODE.get(k, k): v for k, v in self.parameters.items()
+        }
         encoded = (
             urlsafe_b64encode(
-                json.dumps(self.parameters, separators=(",", ":")).encode()
+                json.dumps(wire_params, separators=(",", ":")).encode()
             )
             .decode()
             .rstrip("=")
@@ -110,7 +127,8 @@ _BASE_SUGGESTIONS: dict[IntentType, tuple[FollowUp, ...]] = {
     ),
     IntentType.QUERY_EXPENSES: (
         FollowUp("📅 Tuần này", IntentType.QUERY_EXPENSES, {"time_range": "this_week"}),
-        FollowUp("🍕 Theo loại", IntentType.QUERY_EXPENSES_BY_CATEGORY),
+        # "🍕 Theo loại" is injected dynamically in ``get_follow_ups`` so it
+        # carries the parent report's ``time_range``.
         FollowUp(
             "📊 So sánh tháng trước",
             IntentType.QUERY_EXPENSES,
@@ -122,7 +140,8 @@ _BASE_SUGGESTIONS: dict[IntentType, tuple[FollowUp, ...]] = {
             "📅 Tháng trước", IntentType.QUERY_EXPENSES, {"time_range": "last_month"}
         ),
         FollowUp("📊 Tổng chi tiêu", IntentType.QUERY_EXPENSES),
-        FollowUp("🍕 Loại khác", IntentType.QUERY_EXPENSES_BY_CATEGORY),
+        # "🍕 Loại khác" is injected dynamically in ``get_follow_ups`` so it
+        # preserves the current ``time_range`` into the picker.
     ),
     IntentType.QUERY_INCOME: (
         FollowUp("💸 Cashflow tháng này", IntentType.QUERY_CASHFLOW),
@@ -215,6 +234,34 @@ def get_follow_ups(
         return [FollowUp("🎯 Mục tiêu của tôi", IntentType.QUERY_GOALS)]
 
     pool: list[FollowUp] = []
+    # Inject the "🍕 Theo loại" picker dynamically so it carries the parent
+    # report's ``time_range``. Without this the picker would default back to
+    # "tháng này" even when the user is currently viewing e.g. "tuần này".
+    # "🍕 Loại khác" plays the same role on the category-filtered surface.
+    if intent == IntentType.QUERY_EXPENSES:
+        picker_params: dict | None = None
+        parent_tr = params.get("time_range")
+        if parent_tr:
+            picker_params = {"time_range": parent_tr}
+        pool.append(
+            FollowUp(
+                "🍕 Theo loại",
+                IntentType.QUERY_EXPENSES_BY_CATEGORY,
+                picker_params,
+            )
+        )
+    elif intent == IntentType.QUERY_EXPENSES_BY_CATEGORY:
+        picker_params = None
+        parent_tr = params.get("time_range")
+        if parent_tr:
+            picker_params = {"time_range": parent_tr}
+        pool.append(
+            FollowUp(
+                "🍕 Loại khác",
+                IntentType.QUERY_EXPENSES_BY_CATEGORY,
+                picker_params,
+            )
+        )
     category = str(params.get("category") or "").lower()
     if intent == IntentType.QUERY_MARKET and category in {"stock", "stocks", "crypto", "gold"}:
         asset_type = "stock" if category in {"stock", "stocks"} else category
@@ -303,6 +350,10 @@ def parse_callback_data(callback_data: str) -> FollowUp | None:
             params = json.loads(raw)
             if not isinstance(params, dict):
                 params = None
+            else:
+                params = {
+                    _CODE_TO_PARAM_KEY.get(k, k): v for k, v in params.items()
+                }
         except (ValueError, json.JSONDecodeError, UnicodeDecodeError):
             logger.debug("Bad follow-up params: %r", callback_data)
             return None
@@ -310,11 +361,55 @@ def parse_callback_data(callback_data: str) -> FollowUp | None:
     return FollowUp(label="", intent=intent, parameters=params or None)
 
 
+def build_category_picker_keyboard(time_range: str | None = None) -> dict:
+    """Inline keyboard listing every spending category as a follow-up.
+
+    Tapped when the user selects "🍕 Theo loại" on a spending report — each
+    button re-dispatches ``QUERY_EXPENSES_BY_CATEGORY`` with the chosen
+    ``category`` (and the preserved ``time_range`` so the filter applies to
+    the same period as the original report).
+
+    Two columns to keep the keyboard compact on mobile.
+    """
+    buttons: list[list[dict]] = []
+    row: list[dict] = []
+    for cat in get_all_categories():
+        params: dict = {"category": cat.code}
+        if time_range:
+            params["time_range"] = time_range
+        fu = FollowUp(
+            label=f"{cat.emoji} {cat.name_vi}",
+            intent=IntentType.QUERY_EXPENSES_BY_CATEGORY,
+            parameters=params,
+        )
+        row.append({"text": fu.label, "callback_data": fu.to_callback_data()})
+        if len(row) == 2:
+            buttons.append(row)
+            row = []
+    if row:
+        buttons.append(row)
+    return {"inline_keyboard": buttons}
+
+
+def is_category_picker_callback(parsed: FollowUp | None) -> bool:
+    """True when a parsed follow-up callback should trigger the category
+    picker rather than dispatching the handler — i.e. the user tapped
+    "🍕 Theo loại" without choosing a category yet."""
+    if parsed is None:
+        return False
+    if parsed.intent != IntentType.QUERY_EXPENSES_BY_CATEGORY:
+        return False
+    params = parsed.parameters or {}
+    return not params.get("category")
+
+
 __all__ = [
     "CALLBACK_PREFIX",
     "FollowUp",
     "MAX_SUGGESTIONS",
+    "build_category_picker_keyboard",
     "build_inline_keyboard",
     "get_follow_ups",
+    "is_category_picker_callback",
     "parse_callback_data",
 ]

--- a/backend/tests/test_intent/test_follow_up.py
+++ b/backend/tests/test_intent/test_follow_up.py
@@ -3,12 +3,15 @@ from __future__ import annotations
 
 import pytest
 
+from backend.config.categories import get_all_categories
 from backend.intent.follow_up import (
     CALLBACK_PREFIX,
     MAX_SUGGESTIONS,
     FollowUp,
+    build_category_picker_keyboard,
     build_inline_keyboard,
     get_follow_ups,
+    is_category_picker_callback,
     parse_callback_data,
 )
 from backend.intent.intents import IntentType
@@ -258,6 +261,153 @@ def test_net_worth_view_no_longer_offers_portfolio_analytics_label(level):
     fus = get_follow_ups(IntentType.QUERY_NET_WORTH, wealth_level=level)
     for fu in fus:
         assert "Portfolio analytics" not in fu.label
+
+
+# ---------------------------------------------------------------------------
+# Category picker (Story: "Theo loại" → choose category → filtered report)
+# ---------------------------------------------------------------------------
+
+
+def test_category_picker_keyboard_has_all_13_categories():
+    kb = build_category_picker_keyboard()
+    assert "inline_keyboard" in kb
+    flat = [btn for row in kb["inline_keyboard"] for btn in row]
+    cats = get_all_categories()
+    assert len(flat) == len(cats)
+    # Every category label (emoji + name) appears once.
+    labels = {btn["text"] for btn in flat}
+    for cat in cats:
+        assert f"{cat.emoji} {cat.name_vi}" in labels
+
+
+def test_category_picker_uses_two_column_layout():
+    kb = build_category_picker_keyboard()
+    rows = kb["inline_keyboard"]
+    # All but possibly the last row carry two buttons.
+    for row in rows[:-1]:
+        assert len(row) == 2
+    assert 1 <= len(rows[-1]) <= 2
+
+
+def test_category_picker_preserves_time_range():
+    kb = build_category_picker_keyboard(time_range="this_week")
+    flat = [btn for row in kb["inline_keyboard"] for btn in row]
+    for btn in flat:
+        parsed = parse_callback_data(btn["callback_data"])
+        assert parsed is not None
+        assert parsed.intent == IntentType.QUERY_EXPENSES_BY_CATEGORY
+        assert parsed.parameters is not None
+        assert parsed.parameters.get("time_range") == "this_week"
+        assert "category" in parsed.parameters
+
+
+def test_category_picker_omits_time_range_when_none():
+    kb = build_category_picker_keyboard()
+    flat = [btn for row in kb["inline_keyboard"] for btn in row]
+    for btn in flat:
+        parsed = parse_callback_data(btn["callback_data"])
+        assert parsed is not None
+        params = parsed.parameters or {}
+        assert "time_range" not in params
+        assert "category" in params
+
+
+@pytest.mark.parametrize("time_range", [None, "this_week", "this_month", "last_month"])
+def test_category_picker_button_callback_under_64_bytes(time_range):
+    """Every picker button payload must fit Telegram's 64-byte cap for the
+    time_range values an expense report actually uses."""
+    kb = build_category_picker_keyboard(time_range=time_range)
+    flat = [btn for row in kb["inline_keyboard"] for btn in row]
+    for btn in flat:
+        assert len(btn["callback_data"].encode()) <= 64
+
+
+def test_is_category_picker_callback_true_when_no_category():
+    parsed = FollowUp(label="", intent=IntentType.QUERY_EXPENSES_BY_CATEGORY)
+    assert is_category_picker_callback(parsed) is True
+
+
+def test_is_category_picker_callback_true_when_only_time_range():
+    parsed = FollowUp(
+        label="",
+        intent=IntentType.QUERY_EXPENSES_BY_CATEGORY,
+        parameters={"time_range": "this_week"},
+    )
+    assert is_category_picker_callback(parsed) is True
+
+
+def test_is_category_picker_callback_false_when_category_set():
+    parsed = FollowUp(
+        label="",
+        intent=IntentType.QUERY_EXPENSES_BY_CATEGORY,
+        parameters={"category": "transport"},
+    )
+    assert is_category_picker_callback(parsed) is False
+
+
+def test_is_category_picker_callback_false_for_other_intents():
+    parsed = FollowUp(label="", intent=IntentType.QUERY_EXPENSES)
+    assert is_category_picker_callback(parsed) is False
+    assert is_category_picker_callback(None) is False
+
+
+def test_query_expenses_follow_up_has_theo_loai_button():
+    fus = get_follow_ups(IntentType.QUERY_EXPENSES)
+    labels = [fu.label for fu in fus]
+    assert any("Theo loại" in label for label in labels)
+
+
+def test_query_expenses_follow_up_propagates_time_range_to_picker():
+    """When the parent report is "tuần này", the picker button must carry
+    that time_range so the wizard preserves the period."""
+    fus = get_follow_ups(
+        IntentType.QUERY_EXPENSES, parameters={"time_range": "this_week"}
+    )
+    picker = next(f for f in fus if "Theo loại" in f.label)
+    assert picker.intent == IntentType.QUERY_EXPENSES_BY_CATEGORY
+    assert picker.parameters == {"time_range": "this_week"}
+    # And the picker button itself stays in picker mode (no category).
+    assert is_category_picker_callback(picker) is True
+
+
+def test_query_expenses_picker_has_no_params_when_no_time_range():
+    fus = get_follow_ups(IntentType.QUERY_EXPENSES)
+    picker = next(f for f in fus if "Theo loại" in f.label)
+    assert picker.parameters is None
+
+
+def test_query_expenses_by_category_injects_loai_khac_with_time_range():
+    fus = get_follow_ups(
+        IntentType.QUERY_EXPENSES_BY_CATEGORY,
+        parameters={"time_range": "this_week", "category": "food"},
+    )
+    loai_khac = next(f for f in fus if "Loại khác" in f.label)
+    assert loai_khac.intent == IntentType.QUERY_EXPENSES_BY_CATEGORY
+    assert loai_khac.parameters == {"time_range": "this_week"}
+    # "Loại khác" is itself a picker (no category) so tapping it re-shows
+    # the picker keyboard for the same period.
+    assert is_category_picker_callback(loai_khac) is True
+
+
+@pytest.mark.parametrize(
+    "category_code",
+    [c.code for c in get_all_categories()],
+)
+def test_category_picker_button_round_trip_for_every_category(category_code):
+    """Every category button decodes back to the exact same category +
+    time_range — guards against subtle base64/JSON drift."""
+    kb = build_category_picker_keyboard(time_range="this_month")
+    flat = [btn for row in kb["inline_keyboard"] for btn in row]
+    # Find the button matching this category.
+    match = None
+    for btn in flat:
+        parsed = parse_callback_data(btn["callback_data"])
+        if parsed and (parsed.parameters or {}).get("category") == category_code:
+            match = parsed
+            break
+    assert match is not None, f"Category {category_code} missing from picker"
+    assert match.intent == IntentType.QUERY_EXPENSES_BY_CATEGORY
+    assert match.parameters == {"category": category_code, "time_range": "this_month"}
 
 
 @pytest.mark.parametrize("level", [

--- a/backend/tests/test_intent/test_message_router.py
+++ b/backend/tests/test_intent/test_message_router.py
@@ -172,6 +172,134 @@ async def test_clarify_callback_reroutes_via_classify_and_dispatch():
     assert kwargs["text"] == "tài sản"
 
 
+# ---------------------------------------------------------------------------
+# Follow-up category picker — "🍕 Theo loại" → choose category → filtered
+# ---------------------------------------------------------------------------
+
+
+def _followup_callback(data: str) -> dict:
+    return {
+        "id": "cbq-1",
+        "data": data,
+        "message": {"chat": {"id": 999}},
+        "from": {"id": 12345},
+    }
+
+
+@pytest.mark.asyncio
+async def test_followup_theo_loai_shows_picker_keyboard_and_skips_dispatch():
+    """Tapping "🍕 Theo loại" (no category yet) must show the picker
+    keyboard, NOT dispatch a category-filtered handler."""
+    from backend.intent import follow_up
+
+    user = _user(state=None)
+    db = _fake_db()
+
+    # Picker callback: QUERY_EXPENSES_BY_CATEGORY with no category param.
+    picker_fu = follow_up.FollowUp(
+        label="🍕 Theo loại",
+        intent=IntentType.QUERY_EXPENSES_BY_CATEGORY,
+    )
+    cbq = _followup_callback(picker_fu.to_callback_data())
+
+    dispatcher_mock = MagicMock()
+    dispatcher_mock.dispatch = AsyncMock()
+
+    with patch.object(
+        message, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        message, "send_message", AsyncMock()
+    ) as mock_send, patch(
+        "backend.bot.handlers.free_form_text._dispatcher", dispatcher_mock
+    ):
+        handled = await message.handle_intent_callback(db, cbq)
+
+    assert handled is True
+    dispatcher_mock.dispatch.assert_not_called()
+    mock_send.assert_awaited_once()
+    # The picker reply carries the inline-keyboard payload.
+    kwargs = mock_send.call_args.kwargs
+    assert "reply_markup" in kwargs
+    assert "inline_keyboard" in kwargs["reply_markup"]
+    rows = kwargs["reply_markup"]["inline_keyboard"]
+    flat = [btn for row in rows for btn in row]
+    # All 13 spending categories rendered.
+    from backend.config.categories import get_all_categories
+
+    assert len(flat) == len(get_all_categories())
+
+
+@pytest.mark.asyncio
+async def test_followup_category_button_dispatches_handler_with_filter():
+    """Tapping a specific category (e.g. Di chuyển) DOES dispatch the
+    intent handler — with the chosen category in the parameters."""
+    from backend.intent import follow_up
+
+    user = _user(state=None)
+    db = _fake_db()
+
+    category_fu = follow_up.FollowUp(
+        label="🚗 Di chuyển",
+        intent=IntentType.QUERY_EXPENSES_BY_CATEGORY,
+        parameters={"category": "transport"},
+    )
+    cbq = _followup_callback(category_fu.to_callback_data())
+
+    dispatcher_mock = MagicMock()
+    dispatcher_mock.dispatch = AsyncMock(return_value=MagicMock(spec=DispatchOutcome))
+
+    with patch.object(
+        message, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        message, "send_message", AsyncMock()
+    ), patch(
+        "backend.bot.handlers.free_form_text._dispatcher", dispatcher_mock
+    ), patch(
+        "backend.bot.handlers.free_form_text._send_outcome", AsyncMock()
+    ):
+        handled = await message.handle_intent_callback(db, cbq)
+
+    assert handled is True
+    dispatcher_mock.dispatch.assert_awaited_once()
+    synthesised = dispatcher_mock.dispatch.call_args.args[0]
+    assert synthesised.intent == IntentType.QUERY_EXPENSES_BY_CATEGORY
+    assert synthesised.parameters.get("category") == "transport"
+
+
+@pytest.mark.asyncio
+async def test_followup_theo_loai_preserves_time_range_in_picker_buttons():
+    """The picker shown on tap of "Theo loại" must carry the parent
+    report's time_range into every category button."""
+    from backend.intent import follow_up
+
+    user = _user(state=None)
+    db = _fake_db()
+
+    picker_fu = follow_up.FollowUp(
+        label="🍕 Theo loại",
+        intent=IntentType.QUERY_EXPENSES_BY_CATEGORY,
+        parameters={"time_range": "this_week"},
+    )
+    cbq = _followup_callback(picker_fu.to_callback_data())
+
+    with patch.object(
+        message, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    ), patch.object(
+        message, "send_message", AsyncMock()
+    ) as mock_send:
+        handled = await message.handle_intent_callback(db, cbq)
+
+    assert handled is True
+    kwargs = mock_send.call_args.kwargs
+    rows = kwargs["reply_markup"]["inline_keyboard"]
+    flat = [btn for row in rows for btn in row]
+    for btn in flat:
+        parsed = follow_up.parse_callback_data(btn["callback_data"])
+        assert parsed is not None
+        assert (parsed.parameters or {}).get("time_range") == "this_week"
+        assert "category" in (parsed.parameters or {})
+
+
 @pytest.mark.asyncio
 async def test_pending_action_active_blocks_classification_with_nudge():
     """Free-form text while a confirm is pending should send the


### PR DESCRIPTION
## Summary

Tapping **🍕 Theo loại** on a spending report now opens an inline keyboard of all 13 spending categories. Picking one (e.g. **🚗 Di chuyển**) re-dispatches `QUERY_EXPENSES_BY_CATEGORY` filtered to that category, with the original report's `time_range` preserved end-to-end — so "Tuần này → Theo loại → Di chuyển" stays scoped to the week.

### What changed

- **`backend/intent/follow_up.py`**
  - Inject `🍕 Theo loại` / `🍕 Loại khác` dynamically in `get_follow_ups` so the picker carries the parent report's `time_range` (previously a static button that always reset to "tháng này").
  - New `build_category_picker_keyboard(time_range=None)` — 2-column inline keyboard, one button per category.
  - New `is_category_picker_callback(parsed)` — distinguishes a picker tap (no `category` yet) from a category-filtered re-dispatch.
  - Shortened parameter keys on the callback wire format (`category→c`, `time_range→t`, `asset_type→a`, `trend_days→d`) so picker buttons stay under Telegram's 64-byte `callback_data` cap once both keys are present. Decoding restores full key names — handlers are unaffected.

- **`backend/bot/handlers/message.py`**
  - In `_handle_followup_callback`, detect the picker tap and reply with the category keyboard instead of dispatching a handler. Emits an `intent_followup_category_picker_shown` analytics event.

### Tests

- `test_follow_up.py` (+15 cases): picker keyboard contents, 2-column layout, `time_range` propagation, round-trip for every category, `is_category_picker_callback` cases, dynamic injection of `Theo loại` / `Loại khác` with `time_range`, and Telegram 64-byte cap across all realistic `time_range` values.
- `test_message_router.py` (+3 cases): picker tap shows the keyboard and does **not** invoke the dispatcher; category tap **does** dispatch with the category filter set; `time_range` propagates through the picker → category callback.
- All **470** existing intent tests pass alongside the new ones.

## Test plan

- [x] `pytest backend/tests/test_intent/` — 470 passed
- [ ] Manual smoke on Telegram: "Chi tiêu tháng này" → tap **🍕 Theo loại** → pick **🚗 Di chuyển** → only transport spending shown for the same period
- [ ] Repeat with "Chi tiêu tuần này" → tap **🍕 Theo loại** → confirm the picked category report is also "tuần này"
- [ ] Tap **🍕 Loại khác** from a category-filtered report → picker re-appears with the same period

https://claude.ai/code/session_01REDwVaYgZyTDtMRKHpFwQR