### PR TITLE
fix(intent): separate money_in from expense queries & cashflow math

### DIFF
--- a/backend/intent/classifier/llm_based.py
+++ b/backend/intent/classifier/llm_based.py
@@ -66,6 +66,7 @@ INTENTS:
 - query_expenses_by_category: Hỏi chi tiêu theo loại (ăn uống, sức khỏe...)
 - query_income: Hỏi thu nhập / lương
 - query_cashflow: Hỏi dòng tiền / dư cuối tháng
+- query_money_in: Hỏi các khoản tiền vào (quà, được cho, hoàn tiền) — KHÔNG phải lương/thu nhập định kỳ
 - query_market: Hỏi giá thị trường (cổ phiếu VNM, crypto BTC, vàng SJC, VN-Index). Bao gồm cả câu hỏi tổng quát kiểu "giá vàng", "giá crypto", "giá cổ phiếu".
 - query_goals: Hỏi mục tiêu của user
 - query_goal_progress: Hỏi tiến độ mục tiêu cụ thể

--- a/backend/intent/dispatcher.py
+++ b/backend/intent/dispatcher.py
@@ -383,6 +383,12 @@ class IntentDispatcher:
             )
 
             return QueryIncomeHandler()
+        if intent == IntentType.QUERY_MONEY_IN:
+            from backend.intent.handlers.query_expenses import (
+                QueryMoneyInHandler,
+            )
+
+            return QueryMoneyInHandler()
         if intent == IntentType.QUERY_CASHFLOW:
             from backend.intent.handlers.query_cashflow import (
                 QueryCashflowHandler,

--- a/backend/intent/handlers/query_cashflow.py
+++ b/backend/intent/handlers/query_cashflow.py
@@ -61,8 +61,10 @@ class CashflowPeriod:
     spend_current: Decimal
     spend_recurring: Decimal
     spend_total: Decimal
+    money_in: Decimal
     net: Decimal
     expenses: list[Expense]
+    money_in_txs: list[Expense]
 
 
 class QueryCashflowHandler(IntentHandler):
@@ -100,13 +102,17 @@ class QueryCashflowHandler(IntentHandler):
     ) -> str:
         name = user.display_name or "bạn"
         label_vi = _cashflow_period_label(time_range)
-        if current.income <= 0 and current.spend_total <= 0:
+        if (
+            current.income <= 0
+            and current.spend_total <= 0
+            and current.money_in <= 0
+        ):
             return (
                 f"{name} chưa có dữ liệu thu / chi {label_vi} 🌱\n"
                 "Mình cần ít nhất một nguồn thu và vài giao dịch để tính dòng tiền."
             )
 
-        saving_rate = _safe_rate(current.net, current.income)
+        saving_rate = _safe_rate(current.net, current.income + current.money_in)
         arrow = "💚" if current.net >= 0 else "🟥"
         sign = "+" if current.net >= 0 else "−"
         net_word = "dư" if current.net >= 0 else "vượt thu"
@@ -116,6 +122,8 @@ class QueryCashflowHandler(IntentHandler):
             self._income_card(current, previous, streams, time_range),
             "",
             self._expense_card(current, previous),
+            "",
+            self._money_in_card(current, previous),
             "",
             "💎 *Tỷ lệ tiết kiệm*",
             f"{_format_percent(saving_rate) if saving_rate is not None else '—'}",
@@ -152,6 +160,17 @@ class QueryCashflowHandler(IntentHandler):
         ]
         return "\n".join(lines)
 
+    def _money_in_card(
+        self, current: CashflowPeriod, previous: CashflowPeriod
+    ) -> str:
+        money_in_delta = _delta_text(current.money_in, previous.money_in)
+        lines = [
+            "💰 *Tiền vào tháng*",
+            f"Tổng: *{format_money_full(current.money_in)}* "
+            f"({money_in_delta} vs tháng trước)",
+        ]
+        return "\n".join(lines)
+
     def _format_monthly_detail(
         self,
         user: User,
@@ -168,6 +187,7 @@ class QueryCashflowHandler(IntentHandler):
             f"Chi: *{format_money_full(period.spend_total)}*",
             f"• Chi tiêu hiện tại: {format_money_full(period.spend_current)}",
             f"• Chi phí định kì: {format_money_full(period.spend_recurring)}",
+            f"Tiền vào: *{format_money_full(period.money_in)}*",
             f"Dư / thiếu: *{sign}{format_money_full(abs(period.net))}*",
             "",
             "💼 *Top nguồn thu*",
@@ -232,17 +252,29 @@ async def _build_period(
     expenses = await _fetch_expenses(
         db, user, start=time_range.start, end=time_range.end
     )
+    money_in_txs = await _fetch_expenses(
+        db,
+        user,
+        start=time_range.start,
+        end=time_range.end,
+        transaction_type="money_in",
+    )
     spend_current = sum(Decimal(tx.amount or 0) for tx in expenses)
     spend_recurring = await _recurring_expense_for_period(db, user, time_range)
     spend_total = spend_current + spend_recurring
-    net = income - spend_total
+    money_in = sum(
+        (Decimal(tx.amount or 0) for tx in money_in_txs), Decimal(0)
+    )
+    net = income + money_in - spend_total
     return CashflowPeriod(
         income=income,
         spend_current=spend_current,
         spend_recurring=spend_recurring,
         spend_total=spend_total,
+        money_in=money_in,
         net=net,
         expenses=expenses,
+        money_in_txs=money_in_txs,
     )
 
 

--- a/backend/intent/handlers/query_expenses.py
+++ b/backend/intent/handlers/query_expenses.py
@@ -80,6 +80,7 @@ async def _fetch_expenses(
     start: date,
     end: date,
     category: str | None = None,
+    transaction_type: str | None = "expense",
 ) -> list[Expense]:
     stmt = select(Expense).where(
         Expense.user_id == user.id,
@@ -87,6 +88,8 @@ async def _fetch_expenses(
         Expense.expense_date >= start,
         Expense.expense_date <= end,
     )
+    if transaction_type is not None:
+        stmt = stmt.where(Expense.transaction_type == transaction_type)
     if category:
         stmt = stmt.where(Expense.category == category)
     stmt = stmt.order_by(Expense.amount.desc())
@@ -158,6 +161,55 @@ class QueryExpensesHandler(IntentHandler):
         return _format_listing(
             expenses, time_range=time_range, user=user
         )
+
+
+def _format_money_in_listing(
+    rows: list[Expense],
+    *,
+    time_range: TimeRange,
+    user: User,
+) -> str:
+    total = sum(Decimal(tx.amount or 0) for tx in rows)
+    count = len(rows)
+    label_vi = _TIME_LABELS_VI.get(time_range.label, time_range.label)
+    lines = [
+        f"💰 Tiền vào {label_vi}:",
+        f"Tổng: *{format_money_full(total)}* ({count} giao dịch)",
+        "",
+    ]
+    top = sorted(rows, key=lambda x: Decimal(x.amount or 0), reverse=True)[
+        :_TOP_N_TRANSACTIONS
+    ]
+    for tx in top:
+        merchant = tx.merchant or tx.note or "Tiền vào"
+        lines.append(f"💰 {merchant} — {format_money_short(tx.amount)}")
+    if count > _TOP_N_TRANSACTIONS:
+        lines.append("")
+        lines.append(f"_...và {count - _TOP_N_TRANSACTIONS} giao dịch nhỏ hơn_")
+    return "\n".join(lines)
+
+
+def _empty_money_in_message(*, time_range: TimeRange, user: User) -> str:
+    name = user.display_name or "bạn"
+    label_vi = _TIME_LABELS_VI.get(time_range.label, time_range.label)
+    return f"{name} chưa có khoản tiền vào nào {label_vi} 🌱"
+
+
+class QueryMoneyInHandler(IntentHandler):
+    async def handle(
+        self, intent: IntentResult, user: User, db: AsyncSession
+    ) -> str:
+        time_range = _resolve_time_range(intent)
+        rows = await _fetch_expenses(
+            db,
+            user,
+            start=time_range.start,
+            end=time_range.end,
+            transaction_type="money_in",
+        )
+        if not rows:
+            return _empty_money_in_message(time_range=time_range, user=user)
+        return _format_money_in_listing(rows, time_range=time_range, user=user)
 
 
 class QueryExpensesByCategoryHandler(IntentHandler):

--- a/backend/intent/intents.py
+++ b/backend/intent/intents.py
@@ -28,6 +28,7 @@ class IntentType(str, Enum):
     QUERY_EXPENSES = "query_expenses"
     QUERY_EXPENSES_BY_CATEGORY = "query_expenses_by_category"
     QUERY_INCOME = "query_income"
+    QUERY_MONEY_IN = "query_money_in"
     QUERY_CASHFLOW = "query_cashflow"
     QUERY_MARKET = "query_market"
     QUERY_GOALS = "query_goals"

--- a/backend/tests/test_intent/test_query_cashflow.py
+++ b/backend/tests/test_intent/test_query_cashflow.py
@@ -29,6 +29,20 @@ _THIRTY_DAYS = TimeRange(
 )
 
 
+def _fetch_expenses_side_effect(expenses=None, money_in=None):
+    """Return a side_effect for ``_fetch_expenses`` that routes by
+    ``transaction_type`` so tests don't need to know call order."""
+    expenses = expenses or []
+    money_in = money_in or []
+
+    async def _impl(db, user, *, start, end, category=None, transaction_type="expense"):
+        if transaction_type == "money_in":
+            return money_in
+        return expenses
+
+    return _impl
+
+
 def _user(name: str = "An") -> MagicMock:
     user = MagicMock()
     user.id = uuid.uuid4()
@@ -85,7 +99,7 @@ async def test_starter_gets_simple_message_no_jargon():
 
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[expense]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=[expense])),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("0")),
@@ -117,7 +131,7 @@ async def test_mass_affluent_gets_savings_rate_breakdown():
     expenses = [MagicMock(amount=Decimal("20000000"))]
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=expenses),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=expenses)),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("0")),
@@ -147,7 +161,7 @@ async def test_no_data_message():
 
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect()),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("0")),
@@ -179,7 +193,7 @@ async def test_cashflow_overview_splits_income_and_expense_cards():
     shopping = MagicMock(amount=Decimal("1000000"), category="shopping")
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[food, shopping]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=[food, shopping])),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("500000")),
@@ -230,7 +244,7 @@ async def test_cashflow_current_month_detail_report():
     )
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[tx1, tx2]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=[tx1, tx2])),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("3000000")),
@@ -253,6 +267,92 @@ async def test_cashflow_current_month_detail_report():
     assert "Chi tiêu hiện tại" in response
     assert "Chi phí định kì" in response
     assert "Tiền nhà" in response
+
+
+@pytest.mark.asyncio
+async def test_cashflow_overview_includes_money_in_card_and_correct_net():
+    """Bug fix: money_in must show as a separate card AND be added to net
+    (net = income + money_in - spend_total), not folded into expenses."""
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_CASHFLOW,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="[menu:cashflow:overview]",
+    )
+    salary = _stream(Decimal("30000000"))
+    salary.stream_type = "salary"
+    salary.name = "Lương"
+    db = _fake_db_with_streams([salary])
+    style = style_for_level(WealthLevel.MASS_AFFLUENT, Decimal("500000000"))
+
+    expense = MagicMock(amount=Decimal("10000000"), category="food")
+    gift = MagicMock(amount=Decimal("2000000"), category="other", merchant="Bố cho")
+    with patch(
+        "backend.intent.handlers.query_cashflow._fetch_expenses",
+        new=AsyncMock(
+            side_effect=_fetch_expenses_side_effect(
+                expenses=[expense], money_in=[gift]
+            )
+        ),
+    ), patch(
+        "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
+        AsyncMock(return_value=Decimal("0")),
+    ), patch(
+        "backend.intent.handlers.query_cashflow.resolve_style",
+        AsyncMock(return_value=style),
+    ):
+        response = await QueryCashflowHandler().handle(intent, user, db)
+
+    assert "💰 *Tiền vào tháng*" in response
+    # Net = 30M income + 2M money_in - 10M spend = 22M dư
+    assert "dư 22tr" in response.lower() or "22.000.000" in response
+
+
+@pytest.mark.asyncio
+async def test_cashflow_monthly_detail_shows_money_in_line():
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_CASHFLOW,
+        confidence=1.0,
+        parameters={"focus": "current_month_detail", "time_range": "this_month"},
+        raw_text="[menu:cashflow:monthly_report]",
+    )
+    salary = _stream(Decimal("20000000"))
+    salary.stream_type = "salary"
+    salary.name = "Lương"
+    db = _fake_db_with_streams([salary])
+    style = style_for_level(WealthLevel.MASS_AFFLUENT, Decimal("500000000"))
+
+    expense = MagicMock(
+        amount=Decimal("5000000"),
+        category="food",
+        merchant="Nhà hàng",
+        expense_date=date.today().replace(day=3),
+    )
+    gift = MagicMock(
+        amount=Decimal("1000000"),
+        category="other",
+        merchant="Tìm trong ngăn bàn",
+        expense_date=date.today().replace(day=2),
+    )
+    with patch(
+        "backend.intent.handlers.query_cashflow._fetch_expenses",
+        new=AsyncMock(
+            side_effect=_fetch_expenses_side_effect(
+                expenses=[expense], money_in=[gift]
+            )
+        ),
+    ), patch(
+        "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
+        AsyncMock(return_value=Decimal("0")),
+    ), patch(
+        "backend.intent.handlers.query_cashflow.resolve_style",
+        AsyncMock(return_value=style),
+    ):
+        response = await QueryCashflowHandler().handle(intent, user, db)
+
+    assert "Tiền vào:" in response
 
 
 class TestIncomeForPeriodFromStreams:

--- a/backend/tests/test_intent/test_query_expenses.py
+++ b/backend/tests/test_intent/test_query_expenses.py
@@ -1,0 +1,168 @@
+"""Tests for ``_fetch_expenses`` transaction_type filter and the new
+``QueryMoneyInHandler``."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.intent.handlers.query_expenses import (
+    QueryExpensesHandler,
+    QueryMoneyInHandler,
+    _fetch_expenses,
+)
+from backend.intent.intents import IntentResult, IntentType
+
+
+def _user(name: str = "An") -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.display_name = name
+    return user
+
+
+def _capture_db():
+    """Return (db, captured_stmts) — capturing the SQL each call sees so
+    tests can assert ``transaction_type`` was filtered."""
+    captured: list = []
+
+    async def _execute(stmt):
+        captured.append(stmt)
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all.return_value = []
+        result.scalars.return_value = scalars
+        return result
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db, captured
+
+
+@pytest.mark.asyncio
+async def test_fetch_expenses_defaults_to_expense_type():
+    db, captured = _capture_db()
+    user = _user()
+    await _fetch_expenses(
+        db, user, start=date(2026, 5, 1), end=date(2026, 5, 31)
+    )
+    assert len(captured) == 1
+    sql = str(captured[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "transaction_type" in sql
+    assert "'expense'" in sql
+
+
+@pytest.mark.asyncio
+async def test_fetch_expenses_money_in_filters_correctly():
+    db, captured = _capture_db()
+    user = _user()
+    await _fetch_expenses(
+        db,
+        user,
+        start=date(2026, 5, 1),
+        end=date(2026, 5, 31),
+        transaction_type="money_in",
+    )
+    sql = str(captured[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "'money_in'" in sql
+
+
+@pytest.mark.asyncio
+async def test_fetch_expenses_none_type_returns_all():
+    db, captured = _capture_db()
+    user = _user()
+    await _fetch_expenses(
+        db,
+        user,
+        start=date(2026, 5, 1),
+        end=date(2026, 5, 31),
+        transaction_type=None,
+    )
+    sql = str(captured[0].compile(compile_kwargs={"literal_binds": True}))
+    where_clause = sql.split("WHERE", 1)[1] if "WHERE" in sql else ""
+    assert "transaction_type" not in where_clause
+
+
+@pytest.mark.asyncio
+async def test_query_expenses_handler_filters_to_expense_type():
+    """Regression: chi tiêu listing must NOT include money_in rows."""
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_EXPENSES,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="chi tiêu tháng này",
+    )
+    db = MagicMock()
+    captured_kwargs: dict = {}
+
+    async def fake_fetch(db_, user_, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    with patch(
+        "backend.intent.handlers.query_expenses._fetch_expenses",
+        new=AsyncMock(side_effect=fake_fetch),
+    ):
+        await QueryExpensesHandler().handle(intent, user, db)
+
+    # Handler doesn't explicitly pass transaction_type — relies on default.
+    # The important contract is that the default is "expense".
+    # (Verified by test_fetch_expenses_defaults_to_expense_type.)
+    assert "transaction_type" not in captured_kwargs or captured_kwargs.get(
+        "transaction_type"
+    ) in (None, "expense")
+
+
+@pytest.mark.asyncio
+async def test_query_money_in_handler_fetches_money_in_only():
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_MONEY_IN,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="tiền vào tháng này",
+    )
+    db = MagicMock()
+    gift = MagicMock(
+        amount=Decimal("2000000"),
+        merchant="Bố cho",
+        note=None,
+    )
+    captured_kwargs: dict = {}
+
+    async def fake_fetch(db_, user_, **kwargs):
+        captured_kwargs.update(kwargs)
+        return [gift]
+
+    with patch(
+        "backend.intent.handlers.query_expenses._fetch_expenses",
+        new=AsyncMock(side_effect=fake_fetch),
+    ):
+        response = await QueryMoneyInHandler().handle(intent, user, db)
+
+    assert captured_kwargs.get("transaction_type") == "money_in"
+    assert "Tiền vào" in response
+    assert "Bố cho" in response
+
+
+@pytest.mark.asyncio
+async def test_query_money_in_handler_empty_message():
+    user = _user("Minh")
+    intent = IntentResult(
+        intent=IntentType.QUERY_MONEY_IN,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="tiền vào tháng này",
+    )
+    db = MagicMock()
+    with patch(
+        "backend.intent.handlers.query_expenses._fetch_expenses",
+        new=AsyncMock(return_value=[]),
+    ):
+        response = await QueryMoneyInHandler().handle(intent, user, db)
+    assert "chưa có khoản tiền vào" in response.lower()

--- a/content/intent_patterns.yaml
+++ b/content/intent_patterns.yaml
@@ -165,6 +165,21 @@ query_income:
     - pattern: 'tong\s+thu\s*nhap\s+(?:thang|nam)'
       confidence: 0.9
 
+query_money_in:
+  description: "User asks about money-in transactions (gifts, refunds, found cash) for a period."
+  patterns:
+    - pattern: 'tien\s+vao.*(?:thang|tuan|nam|hom)'
+      confidence: 0.95
+    - pattern: '^(?:liet\s*ke|list|xem)\s+tien\s+vao'
+      confidence: 0.9
+    - pattern: 'tien\s+vao\s+(?:cua\s+)?(?:toi|minh)?'
+      confidence: 0.85
+    - pattern: 'khoan\s+thu\s+khac.*(?:thang|tuan)'
+      confidence: 0.85
+  parameter_extractors:
+    time_range:
+      use_extractor: time_range
+
 query_cashflow:
   description: "User asks net cashflow / savings for a period."
   patterns:


### PR DESCRIPTION
## Summary

Fixes two bugs reported via screenshots:

1. **Bug 1** — "chi tiêu tháng này" listing was including money_in rows ("+5000k", "bố cho", etc.). Now expense-only.
2. **Bug 2** — Cashflow report rolled money_in into "Chi tiêu tháng", inflating spend and breaking saving rate.

### Root cause
`_fetch_expenses` had no `transaction_type` filter, so both the expense listing handler and the cashflow handler pulled every row from the unified `expenses` table.

### Changes
- `_fetch_expenses(transaction_type="expense")` — default keeps existing behavior safe; `None` returns all rows; cashflow now does a two-pass fetch (expense + money_in).
- New `QueryMoneyInHandler` + `IntentType.QUERY_MONEY_IN` with `content/intent_patterns.yaml` patterns and LLM-classifier prompt entry, so "tiền vào tháng này" routes to a dedicated listing.
- `CashflowPeriod` carries `money_in` separately. Net formula: `net = income + money_in − spend`. Saving-rate denominator becomes `income + money_in`.
- Overview gains a 3rd card "💰 *Tiền vào tháng*"; monthly detail gains a "Tiền vào:" line.

### Tests
- 6 new tests in `test_query_expenses.py` covering the `transaction_type` filter behavior on `_fetch_expenses`, the existing `QueryExpensesHandler` default, and the new `QueryMoneyInHandler` (populated + empty).
- 2 new cashflow tests asserting the 3-card overview rendering and the monthly-detail "Tiền vào" line.
- Existing cashflow tests updated to route `_fetch_expenses` mocks by `transaction_type` kwarg.

## Test plan
- [x] `pytest backend/tests/test_intent/test_query_cashflow.py backend/tests/test_intent/test_query_expenses.py backend/tests/test_intent/test_llm_classifier.py` — 35 passed
- [ ] Manual: send "chi tiêu tháng này" — listing shows only expenses
- [ ] Manual: send "tiền vào tháng này" — listing shows only money_in
- [ ] Manual: send "dòng tiền tháng này" — 3 cards (Thu nhập / Chi tiêu / Tiền vào), net and saving rate use new formula

---
_Generated by [Claude Code](https://claude.ai/code/session_01NCFjbTpC3kxC6uQV2z6fmu)_