### PR TITLE
fix(money): round short-form to nearest 1,000đ instead of 100k

### DIFF
--- a/backend/bot/formatters/money.py
+++ b/backend/bot/formatters/money.py
@@ -1,44 +1,83 @@
-"""Format tiền Việt — ngắn gọn (45k / 1.5tr / 1.2 tỷ) và đầy đủ (45,000đ)."""
+"""Format tiền Việt — ngắn gọn (45k / 2tr350 / 1tỷ200) và đầy đủ (45,000đ).
+
+Quy tắc làm tròn: số tiền hiển thị chỉ làm tròn đến đơn vị NGHÌN ĐỒNG, không bao giờ
+mất chính xác ở mức triệu (ví dụ 2,350,000đ → "2tr350", KHÔNG phải "2.4tr").
+Ở thang tỷ, làm tròn đến triệu để giữ chuỗi đủ ngắn cho UI mobile.
+"""
+
+from decimal import ROUND_HALF_UP, Decimal
 
 
-def format_money_short(amount: float) -> str:
-    """Format ngắn gọn kiểu Việt Nam.
+def _round_half_up(value: float, divisor: int) -> int:
+    """Round ``value / divisor`` half-away-from-zero to int.
 
-    Dùng trong progress bar, báo cáo tóm tắt, chỗ không gian hẹp.
+    Python's built-in ``round`` uses banker's rounding (round-half-even), which
+    would turn 2,350,500 into 2,350 (then "2tr350") instead of the user-expected
+    2,351 ("2tr351"). Use Decimal ROUND_HALF_UP for predictable display.
+    """
+    quotient = Decimal(int(value)) / Decimal(divisor) if isinstance(value, int) else Decimal(repr(value)) / Decimal(divisor)
+    return int(quotient.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def format_money_short(amount) -> str:
+    """Format ngắn gọn kiểu Việt Nam, giữ chính xác đến nghìn đồng.
 
     Examples:
-        >>> format_money_short(45000)
+        >>> format_money_short(500)
+        '500đ'
+        >>> format_money_short(45_000)
         '45k'
-        >>> format_money_short(1500000)
-        '1.5tr'
-        >>> format_money_short(25000000)
+        >>> format_money_short(45_500)
+        '46k'
+        >>> format_money_short(2_350_000)
+        '2tr350'
+        >>> format_money_short(2_350_400)
+        '2tr350'
+        >>> format_money_short(2_350_500)
+        '2tr351'
+        >>> format_money_short(25_000_000)
         '25tr'
-        >>> format_money_short(1200000000)
-        '1.2 tỷ'
+        >>> format_money_short(1_500_000)
+        '1tr500'
+        >>> format_money_short(1_200_000_000)
+        '1tỷ200'
+        >>> format_money_short(2_000_000_000)
+        '2 tỷ'
+        >>> format_money_short(0)
+        '0đ'
+        >>> format_money_short(-2_350_000)
+        '-2tr350'
     """
-    amount = float(amount)
-    sign = "-" if amount < 0 else ""
-    amount = abs(amount)
+    value = float(amount) if not isinstance(amount, Decimal) else float(amount)
+    sign = "-" if value < 0 else ""
+    raw = abs(value)
 
-    if amount < 1000:
-        return f"{sign}{int(amount)}đ"
-    if amount < 1_000_000:
-        value = amount / 1000
-        formatted = f"{int(value)}" if value == int(value) else f"{value:.1f}"
-        return f"{sign}{formatted}k"
-    if amount < 1_000_000_000:
-        value = amount / 1_000_000
-        formatted = f"{int(value)}" if value == int(value) else f"{value:.1f}"
-        return f"{sign}{formatted}tr"
-    value = amount / 1_000_000_000
-    formatted = f"{int(value)}" if value == int(value) else f"{value:.1f}"
-    return f"{sign}{formatted} tỷ"
+    if raw < 1:
+        return "0đ"
+    if raw < 1_000:
+        return f"{sign}{_round_half_up(raw, 1)}đ"
+
+    # Round to nearest 1,000đ to preserve thousand precision everywhere.
+    thousands_total = _round_half_up(raw, 1000)
+    if thousands_total < 1_000:
+        return f"{sign}{thousands_total}k"
+
+    if thousands_total < 1_000_000:
+        millions, thousands = divmod(thousands_total, 1000)
+        if thousands == 0:
+            return f"{sign}{millions}tr"
+        return f"{sign}{millions}tr{thousands:03d}"
+
+    # Tỷ range: round to nearest 1tr (sub-tr precision <0.001% — not useful).
+    tr_total = _round_half_up(raw, 1_000_000)
+    billions, millions = divmod(tr_total, 1000)
+    if millions == 0:
+        return f"{sign}{billions} tỷ"
+    return f"{sign}{billions}tỷ{millions:03d}"
 
 
-def format_money_full(amount: float) -> str:
+def format_money_full(amount) -> str:
     """Format đầy đủ với dấu phẩy ngăn cách hàng nghìn.
-
-    Dùng trong tin nhắn xác nhận giao dịch, nơi cần chính xác tuyệt đối.
 
     Examples:
         >>> format_money_full(45000)
@@ -46,4 +85,4 @@ def format_money_full(amount: float) -> str:
         >>> format_money_full(1500000)
         '1,500,000đ'
     """
-    return f"{int(round(amount)):,}đ"
+    return f"{int(round(float(amount))):,}đ"

--- a/backend/bot/formatters/money.py
+++ b/backend/bot/formatters/money.py
@@ -8,14 +8,22 @@ mất chính xác ở mức triệu (ví dụ 2,350,000đ → "2tr350", KHÔNG p
 from decimal import ROUND_HALF_UP, Decimal
 
 
-def _round_half_up(value: float, divisor: int) -> int:
+def _to_decimal(amount) -> Decimal:
+    if isinstance(amount, Decimal):
+        return amount
+    if isinstance(amount, int):
+        return Decimal(amount)
+    return Decimal(repr(amount))
+
+
+def _round_half_up(value: Decimal, divisor: int) -> int:
     """Round ``value / divisor`` half-away-from-zero to int.
 
     Python's built-in ``round`` uses banker's rounding (round-half-even), which
     would turn 2,350,500 into 2,350 (then "2tr350") instead of the user-expected
     2,351 ("2tr351"). Use Decimal ROUND_HALF_UP for predictable display.
     """
-    quotient = Decimal(int(value)) / Decimal(divisor) if isinstance(value, int) else Decimal(repr(value)) / Decimal(divisor)
+    quotient = value / Decimal(divisor)
     return int(quotient.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
 
@@ -48,7 +56,7 @@ def format_money_short(amount) -> str:
         >>> format_money_short(-2_350_000)
         '-2tr350'
     """
-    value = float(amount) if not isinstance(amount, Decimal) else float(amount)
+    value = _to_decimal(amount)
     sign = "-" if value < 0 else ""
     raw = abs(value)
 
@@ -85,4 +93,5 @@ def format_money_full(amount) -> str:
         >>> format_money_full(1500000)
         '1,500,000đ'
     """
-    return f"{int(round(float(amount))):,}đ"
+    rounded = _to_decimal(amount).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    return f"{int(rounded):,}đ"

--- a/backend/miniapp/static/js/cashflow_dashboard.js
+++ b/backend/miniapp/static/js/cashflow_dashboard.js
@@ -276,12 +276,27 @@ async function fetchJSON(url, options = {}) {
     return res.json();
 }
 
+// Round only to nearest 1,000đ — same rule as DashboardCommon.formatMoneyShort.
 function fmtMoney(v) {
     if (isNaN(v)) return "—";
-    if (Math.abs(v) >= 1e9) return `${(v / 1e9).toFixed(1)} tỷ`;
-    if (Math.abs(v) >= 1e6) return `${(v / 1e6).toFixed(1)} tr`;
-    if (Math.abs(v) >= 1e3) return `${(v / 1e3).toFixed(0)}k`;
-    return v.toFixed(0) + " đ";
+    const value = Number(v) || 0;
+    const sign = value < 0 ? '-' : '';
+    const raw = Math.abs(value);
+    if (raw < 1) return '0đ';
+    if (raw < 1_000) return sign + Math.round(raw) + 'đ';
+    const thousandsTotal = Math.round(raw / 1_000);
+    if (thousandsTotal < 1_000) return sign + thousandsTotal + 'k';
+    if (thousandsTotal < 1_000_000) {
+        const millions = Math.floor(thousandsTotal / 1_000);
+        const thousands = thousandsTotal % 1_000;
+        if (thousands === 0) return sign + millions + 'tr';
+        return sign + millions + 'tr' + String(thousands).padStart(3, '0');
+    }
+    const trTotal = Math.round(raw / 1_000_000);
+    const billions = Math.floor(trTotal / 1_000);
+    const millions = trTotal % 1_000;
+    if (millions === 0) return sign + billions + ' tỷ';
+    return sign + billions + 'tỷ' + String(millions).padStart(3, '0');
 }
 
 function escHtml(s) {

--- a/backend/miniapp/static/js/dashboard_common.js
+++ b/backend/miniapp/static/js/dashboard_common.js
@@ -68,19 +68,28 @@
         }
     }
 
-    // Canonical 2-decimal precision for billions ("1.23 tỷ"). The legacy
-    // dashboard.js used 1-decimal; aligning to this is a precision boost,
-    // not a regression — same rounding rule across all dashboards.
+    // Numbers are rounded only to the nearest 1,000đ so a 2,350,000đ
+    // money-in transaction renders as "2tr350" (not "2.4tr"). Tỷ range
+    // rounds to the nearest 1tr to keep the badge short on mobile.
     function formatMoneyShort(amount) {
-        const abs = Math.abs(amount);
-        if (abs >= 1_000_000_000) {
-            return (amount / 1_000_000_000).toFixed(2).replace(/\.?0+$/, '') + ' tỷ';
+        const value = Number(amount) || 0;
+        const sign = value < 0 ? '-' : '';
+        const raw = Math.abs(value);
+        if (raw < 1) return '0đ';
+        if (raw < 1_000) return sign + Math.round(raw) + 'đ';
+        const thousandsTotal = Math.round(raw / 1_000);
+        if (thousandsTotal < 1_000) return sign + thousandsTotal + 'k';
+        if (thousandsTotal < 1_000_000) {
+            const millions = Math.floor(thousandsTotal / 1_000);
+            const thousands = thousandsTotal % 1_000;
+            if (thousands === 0) return sign + millions + 'tr';
+            return sign + millions + 'tr' + String(thousands).padStart(3, '0');
         }
-        if (abs >= 1_000_000) {
-            return (amount / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'tr';
-        }
-        if (abs >= 1_000) return Math.round(amount / 1_000) + 'k';
-        return Math.round(amount) + 'đ';
+        const trTotal = Math.round(raw / 1_000_000);
+        const billions = Math.floor(trTotal / 1_000);
+        const millions = trTotal % 1_000;
+        if (millions === 0) return sign + billions + ' tỷ';
+        return sign + billions + 'tỷ' + String(millions).padStart(3, '0');
     }
 
     function formatMoneyFull(amount) {

--- a/backend/miniapp/static/js/twin_dashboard.js
+++ b/backend/miniapp/static/js/twin_dashboard.js
@@ -496,15 +496,31 @@
         if (theme.button_text_color) root.style.setProperty('--primary-text', theme.button_text_color);
     }
 
-    function formatMoneyShort(value) {
-        if (value >= 1_000_000_000) return `${trim(value / 1_000_000_000)} tỷ`;
-        if (value >= 1_000_000) return `${trim(value / 1_000_000)}tr`;
-        if (value >= 1_000) return `${trim(value / 1_000)}k`;
-        return `${Math.round(value).toLocaleString('en-US')}đ`;
+    // Mirror dashboard_common.js formatMoneyShort exactly — Twin dashboard
+    // keeps a local copy because it's loaded before dashboard_common in
+    // some legacy entry points. Round only to nearest 1,000đ.
+    function formatMoneyShort(amount) {
+        const value = Number(amount) || 0;
+        const sign = value < 0 ? '-' : '';
+        const raw = Math.abs(value);
+        if (raw < 1) return '0đ';
+        if (raw < 1_000) return sign + Math.round(raw) + 'đ';
+        const thousandsTotal = Math.round(raw / 1_000);
+        if (thousandsTotal < 1_000) return sign + thousandsTotal + 'k';
+        if (thousandsTotal < 1_000_000) {
+            const millions = Math.floor(thousandsTotal / 1_000);
+            const thousands = thousandsTotal % 1_000;
+            if (thousands === 0) return sign + millions + 'tr';
+            return sign + millions + 'tr' + String(thousands).padStart(3, '0');
+        }
+        const trTotal = Math.round(raw / 1_000_000);
+        const billions = Math.floor(trTotal / 1_000);
+        const millions = trTotal % 1_000;
+        if (millions === 0) return sign + billions + ' tỷ';
+        return sign + billions + 'tỷ' + String(millions).padStart(3, '0');
     }
 
     function formatMoneyFull(value) { return `${Math.round(value).toLocaleString('en-US')}đ`; }
-    function trim(value) { return value.toFixed(value >= 10 ? 0 : 1).replace('.0', ''); }
 
     const DATE_FORMAT_BY_LANGUAGE = {
         vi: { locale: 'vi-VN', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },

--- a/backend/tests/test_dashboard_common.py
+++ b/backend/tests/test_dashboard_common.py
@@ -116,9 +116,11 @@ def test_dashboard_common_exposes_expected_helpers() -> None:
 
 
 def test_format_money_short_canonical_precision() -> None:
-    """Canonical 2-decimal precision for billions, 1-decimal for millions,
-    rounded thousands, rounded raw đồng. Mirrors the rule the expense and
-    wealth dashboards depended on before extraction.
+    """Rounding rule: only ever round to the nearest 1,000đ in the triệu
+    range — so 2,350,000đ renders as "2tr350" (NOT the legacy "2.4tr").
+    Tỷ range rounds to the nearest 1tr to keep the badge short on mobile.
+    Mirrors backend/bot/formatters/money.py — keep both implementations
+    in sync so server-rendered summaries and dashboard widgets agree.
     """
     cases = _evaluate("""
         return {
@@ -126,19 +128,36 @@ def test_format_money_short_canonical_precision() -> None:
             '500': DC.formatMoneyShort(500),
             '1500': DC.formatMoneyShort(1500),
             '12345': DC.formatMoneyShort(12345),
+            '45500': DC.formatMoneyShort(45500),
+            '2350000': DC.formatMoneyShort(2350000),
+            '2350400': DC.formatMoneyShort(2350400),
+            '2350500': DC.formatMoneyShort(2350500),
+            '1050000': DC.formatMoneyShort(1050000),
             '1500000': DC.formatMoneyShort(1500000),
+            '25000000': DC.formatMoneyShort(25000000),
+            '1200000000': DC.formatMoneyShort(1200000000),
             '1234567890': DC.formatMoneyShort(1234567890),
             '2000000000': DC.formatMoneyShort(2000000000),
+            'neg2350000': DC.formatMoneyShort(-2350000),
             'neg45000': DC.formatMoneyShort(-45000),
         };
     """)
     assert cases["0"] == "0đ"
     assert cases["500"] == "500đ"
-    assert cases["1500"] == "2k"  # round
+    assert cases["1500"] == "2k"
     assert cases["12345"] == "12k"
-    assert cases["1500000"] == "1.5tr"
-    assert cases["1234567890"] == "1.23 tỷ"
-    assert cases["2000000000"] == "2 tỷ"  # trailing zeros stripped
+    assert cases["45500"] == "46k"
+    # User-reported bug: badge showed "2.4tr" for a 2,350,000đ money-in entry.
+    assert cases["2350000"] == "2tr350"
+    assert cases["2350400"] == "2tr350"
+    assert cases["2350500"] == "2tr351"
+    assert cases["1050000"] == "1tr050"
+    assert cases["1500000"] == "1tr500"
+    assert cases["25000000"] == "25tr"
+    assert cases["1200000000"] == "1tỷ200"
+    assert cases["1234567890"] == "1tỷ235"
+    assert cases["2000000000"] == "2 tỷ"
+    assert cases["neg2350000"] == "-2tr350"
     assert cases["neg45000"] == "-45k"
 
 

--- a/backend/tests/test_market_data/test_briefing_full_flow.py
+++ b/backend/tests/test_market_data/test_briefing_full_flow.py
@@ -145,7 +145,7 @@ async def test_briefing_full_flow_provider_cache_wealth_and_sections():
     assert "stock" in result.text
     assert "crypto" in result.text
     assert "gold" in result.text
-    assert "155.5tr" in result.sections["net_worth"]
+    assert "155tr500" in result.sections["net_worth"]
     assert await redis.get("market_data:stock:VNM") is not None
     assert await redis.get("market_data:crypto:BTC") is not None
     assert result.is_stale is False

--- a/backend/tests/test_money.py
+++ b/backend/tests/test_money.py
@@ -89,3 +89,7 @@ class TestFormatMoneyFull:
 
     def test_user_amount_full_precision(self):
         assert format_money_full(2_350_000) == "2,350,000đ"
+
+    def test_large_decimal_preserves_exact_value(self):
+        # float conversion would lose precision past 2**53; Decimal path keeps it.
+        assert format_money_full(Decimal("9007199254740993")) == "9,007,199,254,740,993đ"

--- a/backend/tests/test_money.py
+++ b/backend/tests/test_money.py
@@ -1,31 +1,77 @@
-"""Tests for money formatters (Issue #27)."""
+"""Tests for money formatters.
+
+Rounding rule: short-form numbers are rounded only to the nearest 1,000đ
+so a 2,350,000đ money-in transaction renders as "2tr350", not "2.4tr"
+(see issue: money-in badge rounded down to nearest 100k).
+"""
+from decimal import Decimal
+
 from backend.bot.formatters.money import format_money_full, format_money_short
 
 
 class TestFormatMoneyShort:
+    def test_zero(self):
+        assert format_money_short(0) == "0đ"
+
     def test_below_1k(self):
         assert format_money_short(500) == "500đ"
+
+    def test_sub_dong_rounds_to_zero(self):
+        assert format_money_short(0.4) == "0đ"
 
     def test_exact_k(self):
         assert format_money_short(45_000) == "45k"
 
-    def test_decimal_k(self):
-        assert format_money_short(45_500) == "45.5k"
+    def test_round_to_nearest_k(self):
+        # 45,499 → 45k; 45,500 → 46k (banker's not used — half rounds away)
+        assert format_money_short(45_499) == "45k"
+        assert format_money_short(45_500) == "46k"
 
-    def test_exact_tr(self):
+    def test_exact_tr_no_thousand_portion(self):
         assert format_money_short(25_000_000) == "25tr"
 
-    def test_decimal_tr(self):
-        assert format_money_short(1_500_000) == "1.5tr"
+    def test_million_with_thousand_portion_user_example(self):
+        # User's reported bug: 2,350,000đ must render as "2tr350", not "2.4tr".
+        assert format_money_short(2_350_000) == "2tr350"
 
-    def test_billion(self):
-        assert format_money_short(1_200_000_000) == "1.2 tỷ"
+    def test_million_rounds_down_to_nearest_thousand(self):
+        # 2,350,400 → still rounds to 2tr350
+        assert format_money_short(2_350_400) == "2tr350"
 
-    def test_zero(self):
-        assert format_money_short(0) == "0đ"
+    def test_million_rounds_up_to_nearest_thousand(self):
+        # 2,350,500 → rounds up to 2tr351
+        assert format_money_short(2_350_500) == "2tr351"
 
-    def test_negative(self):
+    def test_million_with_small_thousand_pads_to_three_digits(self):
+        # Avoid ambiguity: "1tr050" reads as 1,050,000 — "1tr50" could be misread.
+        assert format_money_short(1_050_000) == "1tr050"
+        assert format_money_short(1_001_000) == "1tr001"
+
+    def test_decimal_million_legacy_now_preserves_precision(self):
+        # Old behaviour returned "1.5tr"; new rule shows the full thousand portion.
+        assert format_money_short(1_500_000) == "1tr500"
+
+    def test_billion_exact(self):
+        assert format_money_short(2_000_000_000) == "2 tỷ"
+
+    def test_billion_with_million_portion(self):
+        assert format_money_short(1_200_000_000) == "1tỷ200"
+
+    def test_billion_rounds_to_nearest_million(self):
+        # Sub-tr precision in tỷ range is rounded to keep the badge short on mobile.
+        assert format_money_short(1_234_567_890) == "1tỷ235"
+
+    def test_negative_million(self):
+        assert format_money_short(-2_350_000) == "-2tr350"
+
+    def test_negative_k(self):
         assert format_money_short(-45_000) == "-45k"
+
+    def test_decimal_input(self):
+        assert format_money_short(Decimal("2350000")) == "2tr350"
+
+    def test_float_input(self):
+        assert format_money_short(2_350_000.0) == "2tr350"
 
 
 class TestFormatMoneyFull:
@@ -40,3 +86,6 @@ class TestFormatMoneyFull:
 
     def test_float_rounds(self):
         assert format_money_full(12345.6) == "12,346đ"
+
+    def test_user_amount_full_precision(self):
+        assert format_money_full(2_350_000) == "2,350,000đ"

--- a/backend/tests/test_storytelling_handler.py
+++ b/backend/tests/test_storytelling_handler.py
@@ -637,8 +637,8 @@ class TestConfirmationKeyboard:
         )
         assert "Nhà hàng" in body
         assert "2 giao dịch" in body
-        # Total = 2,300,000 → "2.3tr"
-        assert "2.3tr" in body
+        # Total = 2,300,000 → "2tr300" (round to nearest 1,000đ only).
+        assert "2tr300" in body
 
     def test_format_pending_confirmation_html_escapes_merchant(self):
         body = h.format_pending_confirmation(


### PR DESCRIPTION
## Summary

User reported a money-in transaction of **2,350,000đ** rendering as **"+2.4tr"** on the expense dashboard badge — over-rounded to the nearest 100k.

New rule: short-form money is rounded only to the nearest **1,000đ**.

| Input | Before | After |
|---|---|---|
| 2,350,000 | 2.4tr | **2tr350** |
| 2,350,400 | 2.4tr | **2tr350** |
| 2,350,500 | 2.4tr | **2tr351** |
| 1,050,000 | 1.1tr | **1tr050** |
| 1,500,000 | 1.5tr | **1tr500** |

## Implementation

- **`backend/bot/formatters/money.py`** — rewrote `format_money_short` using `Decimal.quantize(ROUND_HALF_UP)` (Python's built-in `round()` does banker's rounding, which would map 2,350,500 → 2350 instead of 2351).
- **JS mirror** — unified three duplicated formatters (`dashboard_common.js`, `twin_dashboard.js`, `cashflow_dashboard.js`) to the same algorithm so server-rendered and miniapp-rendered values match.
- **Tỷ range** still rounds to nearest 1tr to keep the mobile badge compact (sub-tr precision <0.001% at that magnitude).
- **Three-digit zero-padding** on the thousand portion ("1tr050", not "1tr50") to avoid ambiguity.

## Test plan

- [x] `backend/tests/test_money.py` — exhaustive cases: user's exact examples, banker's-rounding edge (2,350,500), negatives, `Decimal`/`float` inputs, padding (1,050,000 → "1tr050"), billion range.
- [x] `backend/tests/test_dashboard_common.py` — JS canonical-precision test updated to assert identical output to Python via Node sandbox.
- [x] `backend/tests/test_storytelling_handler.py` — assertion updated (2,300,000 → "2tr300").
- [x] 36/36 tests pass on the two formatter suites; Python and JS implementations produce bit-identical output across 18 shared cases.

https://claude.ai/code/session_01SL7pWt2cfiiCWrJWoCsDoV

---
_Generated by [Claude Code](https://claude.ai/code/session_01SL7pWt2cfiiCWrJWoCsDoV)_