### PR TITLE
Release 1.4.4.11 — merge main into prod (10th release)

### DIFF
--- a/backend/bot/formatters/money.py
+++ b/backend/bot/formatters/money.py
@@ -1,44 +1,83 @@
-"""Format tiền Việt — ngắn gọn (45k / 1.5tr / 1.2 tỷ) và đầy đủ (45,000đ)."""
+"""Format tiền Việt — ngắn gọn (45k / 2tr350 / 1tỷ200) và đầy đủ (45,000đ).
+
+Quy tắc làm tròn: số tiền hiển thị chỉ làm tròn đến đơn vị NGHÌN ĐỒNG, không bao giờ
+mất chính xác ở mức triệu (ví dụ 2,350,000đ → "2tr350", KHÔNG phải "2.4tr").
+Ở thang tỷ, làm tròn đến triệu để giữ chuỗi đủ ngắn cho UI mobile.
+"""
+
+from decimal import ROUND_HALF_UP, Decimal
 
 
-def format_money_short(amount: float) -> str:
-    """Format ngắn gọn kiểu Việt Nam.
+def _round_half_up(value: float, divisor: int) -> int:
+    """Round ``value / divisor`` half-away-from-zero to int.
 
-    Dùng trong progress bar, báo cáo tóm tắt, chỗ không gian hẹp.
+    Python's built-in ``round`` uses banker's rounding (round-half-even), which
+    would turn 2,350,500 into 2,350 (then "2tr350") instead of the user-expected
+    2,351 ("2tr351"). Use Decimal ROUND_HALF_UP for predictable display.
+    """
+    quotient = Decimal(int(value)) / Decimal(divisor) if isinstance(value, int) else Decimal(repr(value)) / Decimal(divisor)
+    return int(quotient.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+
+
+def format_money_short(amount) -> str:
+    """Format ngắn gọn kiểu Việt Nam, giữ chính xác đến nghìn đồng.
 
     Examples:
-        >>> format_money_short(45000)
+        >>> format_money_short(500)
+        '500đ'
+        >>> format_money_short(45_000)
         '45k'
-        >>> format_money_short(1500000)
-        '1.5tr'
-        >>> format_money_short(25000000)
+        >>> format_money_short(45_500)
+        '46k'
+        >>> format_money_short(2_350_000)
+        '2tr350'
+        >>> format_money_short(2_350_400)
+        '2tr350'
+        >>> format_money_short(2_350_500)
+        '2tr351'
+        >>> format_money_short(25_000_000)
         '25tr'
-        >>> format_money_short(1200000000)
-        '1.2 tỷ'
+        >>> format_money_short(1_500_000)
+        '1tr500'
+        >>> format_money_short(1_200_000_000)
+        '1tỷ200'
+        >>> format_money_short(2_000_000_000)
+        '2 tỷ'
+        >>> format_money_short(0)
+        '0đ'
+        >>> format_money_short(-2_350_000)
+        '-2tr350'
     """
-    amount = float(amount)
-    sign = "-" if amount < 0 else ""
-    amount = abs(amount)
+    value = float(amount) if not isinstance(amount, Decimal) else float(amount)
+    sign = "-" if value < 0 else ""
+    raw = abs(value)
 
-    if amount < 1000:
-        return f"{sign}{int(amount)}đ"
-    if amount < 1_000_000:
-        value = amount / 1000
-        formatted = f"{int(value)}" if value == int(value) else f"{value:.1f}"
-        return f"{sign}{formatted}k"
-    if amount < 1_000_000_000:
-        value = amount / 1_000_000
-        formatted = f"{int(value)}" if value == int(value) else f"{value:.1f}"
-        return f"{sign}{formatted}tr"
-    value = amount / 1_000_000_000
-    formatted = f"{int(value)}" if value == int(value) else f"{value:.1f}"
-    return f"{sign}{formatted} tỷ"
+    if raw < 1:
+        return "0đ"
+    if raw < 1_000:
+        return f"{sign}{_round_half_up(raw, 1)}đ"
+
+    # Round to nearest 1,000đ to preserve thousand precision everywhere.
+    thousands_total = _round_half_up(raw, 1000)
+    if thousands_total < 1_000:
+        return f"{sign}{thousands_total}k"
+
+    if thousands_total < 1_000_000:
+        millions, thousands = divmod(thousands_total, 1000)
+        if thousands == 0:
+            return f"{sign}{millions}tr"
+        return f"{sign}{millions}tr{thousands:03d}"
+
+    # Tỷ range: round to nearest 1tr (sub-tr precision <0.001% — not useful).
+    tr_total = _round_half_up(raw, 1_000_000)
+    billions, millions = divmod(tr_total, 1000)
+    if millions == 0:
+        return f"{sign}{billions} tỷ"
+    return f"{sign}{billions}tỷ{millions:03d}"
 
 
-def format_money_full(amount: float) -> str:
+def format_money_full(amount) -> str:
     """Format đầy đủ với dấu phẩy ngăn cách hàng nghìn.
-
-    Dùng trong tin nhắn xác nhận giao dịch, nơi cần chính xác tuyệt đối.
 
     Examples:
         >>> format_money_full(45000)
@@ -46,4 +85,4 @@ def format_money_full(amount: float) -> str:
         >>> format_money_full(1500000)
         '1,500,000đ'
     """
-    return f"{int(round(amount)):,}đ"
+    return f"{int(round(float(amount))):,}đ"

--- a/backend/bot/formatters/money.py
+++ b/backend/bot/formatters/money.py
@@ -8,14 +8,22 @@ mất chính xác ở mức triệu (ví dụ 2,350,000đ → "2tr350", KHÔNG p
 from decimal import ROUND_HALF_UP, Decimal
 
 
-def _round_half_up(value: float, divisor: int) -> int:
+def _to_decimal(amount) -> Decimal:
+    if isinstance(amount, Decimal):
+        return amount
+    if isinstance(amount, int):
+        return Decimal(amount)
+    return Decimal(repr(amount))
+
+
+def _round_half_up(value: Decimal, divisor: int) -> int:
     """Round ``value / divisor`` half-away-from-zero to int.
 
     Python's built-in ``round`` uses banker's rounding (round-half-even), which
     would turn 2,350,500 into 2,350 (then "2tr350") instead of the user-expected
     2,351 ("2tr351"). Use Decimal ROUND_HALF_UP for predictable display.
     """
-    quotient = Decimal(int(value)) / Decimal(divisor) if isinstance(value, int) else Decimal(repr(value)) / Decimal(divisor)
+    quotient = value / Decimal(divisor)
     return int(quotient.quantize(Decimal("1"), rounding=ROUND_HALF_UP))
 
 
@@ -48,7 +56,7 @@ def format_money_short(amount) -> str:
         >>> format_money_short(-2_350_000)
         '-2tr350'
     """
-    value = float(amount) if not isinstance(amount, Decimal) else float(amount)
+    value = _to_decimal(amount)
     sign = "-" if value < 0 else ""
     raw = abs(value)
 
@@ -85,4 +93,5 @@ def format_money_full(amount) -> str:
         >>> format_money_full(1500000)
         '1,500,000đ'
     """
-    return f"{int(round(float(amount))):,}đ"
+    rounded = _to_decimal(amount).quantize(Decimal("1"), rounding=ROUND_HALF_UP)
+    return f"{int(rounded):,}đ"

--- a/backend/intent/classifier/llm_based.py
+++ b/backend/intent/classifier/llm_based.py
@@ -66,6 +66,7 @@ INTENTS:
 - query_expenses_by_category: Hỏi chi tiêu theo loại (ăn uống, sức khỏe...)
 - query_income: Hỏi thu nhập / lương
 - query_cashflow: Hỏi dòng tiền / dư cuối tháng
+- query_money_in: Hỏi các khoản tiền vào (quà, được cho, hoàn tiền) — KHÔNG phải lương/thu nhập định kỳ
 - query_market: Hỏi giá thị trường (cổ phiếu VNM, crypto BTC, vàng SJC, VN-Index). Bao gồm cả câu hỏi tổng quát kiểu "giá vàng", "giá crypto", "giá cổ phiếu".
 - query_goals: Hỏi mục tiêu của user
 - query_goal_progress: Hỏi tiến độ mục tiêu cụ thể

--- a/backend/intent/dispatcher.py
+++ b/backend/intent/dispatcher.py
@@ -383,6 +383,12 @@ class IntentDispatcher:
             )
 
             return QueryIncomeHandler()
+        if intent == IntentType.QUERY_MONEY_IN:
+            from backend.intent.handlers.query_expenses import (
+                QueryMoneyInHandler,
+            )
+
+            return QueryMoneyInHandler()
         if intent == IntentType.QUERY_CASHFLOW:
             from backend.intent.handlers.query_cashflow import (
                 QueryCashflowHandler,

--- a/backend/intent/handlers/query_cashflow.py
+++ b/backend/intent/handlers/query_cashflow.py
@@ -61,8 +61,10 @@ class CashflowPeriod:
     spend_current: Decimal
     spend_recurring: Decimal
     spend_total: Decimal
+    money_in: Decimal
     net: Decimal
     expenses: list[Expense]
+    money_in_txs: list[Expense]
 
 
 class QueryCashflowHandler(IntentHandler):
@@ -100,13 +102,17 @@ class QueryCashflowHandler(IntentHandler):
     ) -> str:
         name = user.display_name or "bạn"
         label_vi = _cashflow_period_label(time_range)
-        if current.income <= 0 and current.spend_total <= 0:
+        if (
+            current.income <= 0
+            and current.spend_total <= 0
+            and current.money_in <= 0
+        ):
             return (
                 f"{name} chưa có dữ liệu thu / chi {label_vi} 🌱\n"
                 "Mình cần ít nhất một nguồn thu và vài giao dịch để tính dòng tiền."
             )
 
-        saving_rate = _safe_rate(current.net, current.income)
+        saving_rate = _safe_rate(current.net, current.income + current.money_in)
         arrow = "💚" if current.net >= 0 else "🟥"
         sign = "+" if current.net >= 0 else "−"
         net_word = "dư" if current.net >= 0 else "vượt thu"
@@ -116,6 +122,8 @@ class QueryCashflowHandler(IntentHandler):
             self._income_card(current, previous, streams, time_range),
             "",
             self._expense_card(current, previous),
+            "",
+            self._money_in_card(current, previous),
             "",
             "💎 *Tỷ lệ tiết kiệm*",
             f"{_format_percent(saving_rate) if saving_rate is not None else '—'}",
@@ -152,6 +160,17 @@ class QueryCashflowHandler(IntentHandler):
         ]
         return "\n".join(lines)
 
+    def _money_in_card(
+        self, current: CashflowPeriod, previous: CashflowPeriod
+    ) -> str:
+        money_in_delta = _delta_text(current.money_in, previous.money_in)
+        lines = [
+            "💰 *Tiền vào tháng*",
+            f"Tổng: *{format_money_full(current.money_in)}* "
+            f"({money_in_delta} vs tháng trước)",
+        ]
+        return "\n".join(lines)
+
     def _format_monthly_detail(
         self,
         user: User,
@@ -168,6 +187,7 @@ class QueryCashflowHandler(IntentHandler):
             f"Chi: *{format_money_full(period.spend_total)}*",
             f"• Chi tiêu hiện tại: {format_money_full(period.spend_current)}",
             f"• Chi phí định kì: {format_money_full(period.spend_recurring)}",
+            f"Tiền vào: *{format_money_full(period.money_in)}*",
             f"Dư / thiếu: *{sign}{format_money_full(abs(period.net))}*",
             "",
             "💼 *Top nguồn thu*",
@@ -232,17 +252,29 @@ async def _build_period(
     expenses = await _fetch_expenses(
         db, user, start=time_range.start, end=time_range.end
     )
+    money_in_txs = await _fetch_expenses(
+        db,
+        user,
+        start=time_range.start,
+        end=time_range.end,
+        transaction_type="money_in",
+    )
     spend_current = sum(Decimal(tx.amount or 0) for tx in expenses)
     spend_recurring = await _recurring_expense_for_period(db, user, time_range)
     spend_total = spend_current + spend_recurring
-    net = income - spend_total
+    money_in = sum(
+        (Decimal(tx.amount or 0) for tx in money_in_txs), Decimal(0)
+    )
+    net = income + money_in - spend_total
     return CashflowPeriod(
         income=income,
         spend_current=spend_current,
         spend_recurring=spend_recurring,
         spend_total=spend_total,
+        money_in=money_in,
         net=net,
         expenses=expenses,
+        money_in_txs=money_in_txs,
     )
 
 

--- a/backend/intent/handlers/query_expenses.py
+++ b/backend/intent/handlers/query_expenses.py
@@ -80,6 +80,7 @@ async def _fetch_expenses(
     start: date,
     end: date,
     category: str | None = None,
+    transaction_type: str | None = "expense",
 ) -> list[Expense]:
     stmt = select(Expense).where(
         Expense.user_id == user.id,
@@ -87,6 +88,8 @@ async def _fetch_expenses(
         Expense.expense_date >= start,
         Expense.expense_date <= end,
     )
+    if transaction_type is not None:
+        stmt = stmt.where(Expense.transaction_type == transaction_type)
     if category:
         stmt = stmt.where(Expense.category == category)
     stmt = stmt.order_by(Expense.amount.desc())
@@ -158,6 +161,55 @@ class QueryExpensesHandler(IntentHandler):
         return _format_listing(
             expenses, time_range=time_range, user=user
         )
+
+
+def _format_money_in_listing(
+    rows: list[Expense],
+    *,
+    time_range: TimeRange,
+    user: User,
+) -> str:
+    total = sum(Decimal(tx.amount or 0) for tx in rows)
+    count = len(rows)
+    label_vi = _TIME_LABELS_VI.get(time_range.label, time_range.label)
+    lines = [
+        f"💰 Tiền vào {label_vi}:",
+        f"Tổng: *{format_money_full(total)}* ({count} giao dịch)",
+        "",
+    ]
+    top = sorted(rows, key=lambda x: Decimal(x.amount or 0), reverse=True)[
+        :_TOP_N_TRANSACTIONS
+    ]
+    for tx in top:
+        merchant = tx.merchant or tx.note or "Tiền vào"
+        lines.append(f"💰 {merchant} — {format_money_short(tx.amount)}")
+    if count > _TOP_N_TRANSACTIONS:
+        lines.append("")
+        lines.append(f"_...và {count - _TOP_N_TRANSACTIONS} giao dịch nhỏ hơn_")
+    return "\n".join(lines)
+
+
+def _empty_money_in_message(*, time_range: TimeRange, user: User) -> str:
+    name = user.display_name or "bạn"
+    label_vi = _TIME_LABELS_VI.get(time_range.label, time_range.label)
+    return f"{name} chưa có khoản tiền vào nào {label_vi} 🌱"
+
+
+class QueryMoneyInHandler(IntentHandler):
+    async def handle(
+        self, intent: IntentResult, user: User, db: AsyncSession
+    ) -> str:
+        time_range = _resolve_time_range(intent)
+        rows = await _fetch_expenses(
+            db,
+            user,
+            start=time_range.start,
+            end=time_range.end,
+            transaction_type="money_in",
+        )
+        if not rows:
+            return _empty_money_in_message(time_range=time_range, user=user)
+        return _format_money_in_listing(rows, time_range=time_range, user=user)
 
 
 class QueryExpensesByCategoryHandler(IntentHandler):

--- a/backend/intent/intents.py
+++ b/backend/intent/intents.py
@@ -28,6 +28,7 @@ class IntentType(str, Enum):
     QUERY_EXPENSES = "query_expenses"
     QUERY_EXPENSES_BY_CATEGORY = "query_expenses_by_category"
     QUERY_INCOME = "query_income"
+    QUERY_MONEY_IN = "query_money_in"
     QUERY_CASHFLOW = "query_cashflow"
     QUERY_MARKET = "query_market"
     QUERY_GOALS = "query_goals"

--- a/backend/jobs/daily_snapshot_job.py
+++ b/backend/jobs/daily_snapshot_job.py
@@ -42,7 +42,15 @@ SOURCE_AUTO_DAILY = "auto_daily"
 
 
 async def _fetch_active_assets(db: AsyncSession) -> list[Asset]:
-    stmt = select(Asset).where(Asset.is_active.is_(True))
+    # Mirror ``asset_service.get_user_assets`` defaults: snapshot only the
+    # asset set that counts toward "real" net worth. Placeholder and
+    # unconfirmed rows are work-in-progress (e.g. mid-onboarding capture)
+    # and must not anchor "vs hôm qua" comparisons.
+    stmt = select(Asset).where(
+        Asset.is_active.is_(True),
+        Asset.is_placeholder_asset.is_(False),
+        Asset.is_confirmed.is_(True),
+    )
     return list((await db.execute(stmt)).scalars())
 
 

--- a/backend/miniapp/static/js/cashflow_dashboard.js
+++ b/backend/miniapp/static/js/cashflow_dashboard.js
@@ -276,12 +276,27 @@ async function fetchJSON(url, options = {}) {
     return res.json();
 }
 
+// Round only to nearest 1,000đ — same rule as DashboardCommon.formatMoneyShort.
 function fmtMoney(v) {
     if (isNaN(v)) return "—";
-    if (Math.abs(v) >= 1e9) return `${(v / 1e9).toFixed(1)} tỷ`;
-    if (Math.abs(v) >= 1e6) return `${(v / 1e6).toFixed(1)} tr`;
-    if (Math.abs(v) >= 1e3) return `${(v / 1e3).toFixed(0)}k`;
-    return v.toFixed(0) + " đ";
+    const value = Number(v) || 0;
+    const sign = value < 0 ? '-' : '';
+    const raw = Math.abs(value);
+    if (raw < 1) return '0đ';
+    if (raw < 1_000) return sign + Math.round(raw) + 'đ';
+    const thousandsTotal = Math.round(raw / 1_000);
+    if (thousandsTotal < 1_000) return sign + thousandsTotal + 'k';
+    if (thousandsTotal < 1_000_000) {
+        const millions = Math.floor(thousandsTotal / 1_000);
+        const thousands = thousandsTotal % 1_000;
+        if (thousands === 0) return sign + millions + 'tr';
+        return sign + millions + 'tr' + String(thousands).padStart(3, '0');
+    }
+    const trTotal = Math.round(raw / 1_000_000);
+    const billions = Math.floor(trTotal / 1_000);
+    const millions = trTotal % 1_000;
+    if (millions === 0) return sign + billions + ' tỷ';
+    return sign + billions + 'tỷ' + String(millions).padStart(3, '0');
 }
 
 function escHtml(s) {

--- a/backend/miniapp/static/js/dashboard_common.js
+++ b/backend/miniapp/static/js/dashboard_common.js
@@ -68,19 +68,28 @@
         }
     }
 
-    // Canonical 2-decimal precision for billions ("1.23 tỷ"). The legacy
-    // dashboard.js used 1-decimal; aligning to this is a precision boost,
-    // not a regression — same rounding rule across all dashboards.
+    // Numbers are rounded only to the nearest 1,000đ so a 2,350,000đ
+    // money-in transaction renders as "2tr350" (not "2.4tr"). Tỷ range
+    // rounds to the nearest 1tr to keep the badge short on mobile.
     function formatMoneyShort(amount) {
-        const abs = Math.abs(amount);
-        if (abs >= 1_000_000_000) {
-            return (amount / 1_000_000_000).toFixed(2).replace(/\.?0+$/, '') + ' tỷ';
+        const value = Number(amount) || 0;
+        const sign = value < 0 ? '-' : '';
+        const raw = Math.abs(value);
+        if (raw < 1) return '0đ';
+        if (raw < 1_000) return sign + Math.round(raw) + 'đ';
+        const thousandsTotal = Math.round(raw / 1_000);
+        if (thousandsTotal < 1_000) return sign + thousandsTotal + 'k';
+        if (thousandsTotal < 1_000_000) {
+            const millions = Math.floor(thousandsTotal / 1_000);
+            const thousands = thousandsTotal % 1_000;
+            if (thousands === 0) return sign + millions + 'tr';
+            return sign + millions + 'tr' + String(thousands).padStart(3, '0');
         }
-        if (abs >= 1_000_000) {
-            return (amount / 1_000_000).toFixed(1).replace(/\.0$/, '') + 'tr';
-        }
-        if (abs >= 1_000) return Math.round(amount / 1_000) + 'k';
-        return Math.round(amount) + 'đ';
+        const trTotal = Math.round(raw / 1_000_000);
+        const billions = Math.floor(trTotal / 1_000);
+        const millions = trTotal % 1_000;
+        if (millions === 0) return sign + billions + ' tỷ';
+        return sign + billions + 'tỷ' + String(millions).padStart(3, '0');
     }
 
     function formatMoneyFull(amount) {

--- a/backend/miniapp/static/js/twin_dashboard.js
+++ b/backend/miniapp/static/js/twin_dashboard.js
@@ -496,15 +496,31 @@
         if (theme.button_text_color) root.style.setProperty('--primary-text', theme.button_text_color);
     }
 
-    function formatMoneyShort(value) {
-        if (value >= 1_000_000_000) return `${trim(value / 1_000_000_000)} tỷ`;
-        if (value >= 1_000_000) return `${trim(value / 1_000_000)}tr`;
-        if (value >= 1_000) return `${trim(value / 1_000)}k`;
-        return `${Math.round(value).toLocaleString('en-US')}đ`;
+    // Mirror dashboard_common.js formatMoneyShort exactly — Twin dashboard
+    // keeps a local copy because it's loaded before dashboard_common in
+    // some legacy entry points. Round only to nearest 1,000đ.
+    function formatMoneyShort(amount) {
+        const value = Number(amount) || 0;
+        const sign = value < 0 ? '-' : '';
+        const raw = Math.abs(value);
+        if (raw < 1) return '0đ';
+        if (raw < 1_000) return sign + Math.round(raw) + 'đ';
+        const thousandsTotal = Math.round(raw / 1_000);
+        if (thousandsTotal < 1_000) return sign + thousandsTotal + 'k';
+        if (thousandsTotal < 1_000_000) {
+            const millions = Math.floor(thousandsTotal / 1_000);
+            const thousands = thousandsTotal % 1_000;
+            if (thousands === 0) return sign + millions + 'tr';
+            return sign + millions + 'tr' + String(thousands).padStart(3, '0');
+        }
+        const trTotal = Math.round(raw / 1_000_000);
+        const billions = Math.floor(trTotal / 1_000);
+        const millions = trTotal % 1_000;
+        if (millions === 0) return sign + billions + ' tỷ';
+        return sign + billions + 'tỷ' + String(millions).padStart(3, '0');
     }
 
     function formatMoneyFull(value) { return `${Math.round(value).toLocaleString('en-US')}đ`; }
-    function trim(value) { return value.toFixed(value >= 10 ? 0 : 1).replace('.0', ''); }
 
     const DATE_FORMAT_BY_LANGUAGE = {
         vi: { locale: 'vi-VN', options: { day: '2-digit', month: '2-digit', year: 'numeric' } },

--- a/backend/tests/test_daily_snapshot_job.py
+++ b/backend/tests/test_daily_snapshot_job.py
@@ -141,6 +141,43 @@ async def test_insert_exception_marks_run_failed_and_rolls_back():
 
 
 @pytest.mark.asyncio
+async def test_fetch_active_assets_excludes_placeholder_and_unconfirmed():
+    """The snapshot job must use the same filter as ``get_user_assets``.
+
+    Without this, placeholder / unconfirmed rows would write snapshots
+    that ``calculate()`` never sees, producing phantom day-over-day
+    declines on the morning briefing.
+    """
+    from sqlalchemy.dialects import postgresql
+
+    captured: dict = {}
+
+    class _ExecResult:
+        def scalars(self):
+            return []
+
+    db = MagicMock()
+
+    async def _execute(stmt):
+        captured["stmt"] = stmt
+        return _ExecResult()
+
+    db.execute = _execute
+
+    await job._fetch_active_assets(db)
+
+    compiled = str(
+        captured["stmt"].compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    ).lower()
+    assert "is_active" in compiled and "true" in compiled
+    assert "is_placeholder_asset" in compiled and "false" in compiled
+    assert "is_confirmed" in compiled
+
+
+@pytest.mark.asyncio
 async def test_fetch_failure_returns_zero_counters():
     """If we can't even read the asset list, no counters are written."""
     factory, _ = _patch_factory()

--- a/backend/tests/test_dashboard_common.py
+++ b/backend/tests/test_dashboard_common.py
@@ -116,9 +116,11 @@ def test_dashboard_common_exposes_expected_helpers() -> None:
 
 
 def test_format_money_short_canonical_precision() -> None:
-    """Canonical 2-decimal precision for billions, 1-decimal for millions,
-    rounded thousands, rounded raw đồng. Mirrors the rule the expense and
-    wealth dashboards depended on before extraction.
+    """Rounding rule: only ever round to the nearest 1,000đ in the triệu
+    range — so 2,350,000đ renders as "2tr350" (NOT the legacy "2.4tr").
+    Tỷ range rounds to the nearest 1tr to keep the badge short on mobile.
+    Mirrors backend/bot/formatters/money.py — keep both implementations
+    in sync so server-rendered summaries and dashboard widgets agree.
     """
     cases = _evaluate("""
         return {
@@ -126,19 +128,36 @@ def test_format_money_short_canonical_precision() -> None:
             '500': DC.formatMoneyShort(500),
             '1500': DC.formatMoneyShort(1500),
             '12345': DC.formatMoneyShort(12345),
+            '45500': DC.formatMoneyShort(45500),
+            '2350000': DC.formatMoneyShort(2350000),
+            '2350400': DC.formatMoneyShort(2350400),
+            '2350500': DC.formatMoneyShort(2350500),
+            '1050000': DC.formatMoneyShort(1050000),
             '1500000': DC.formatMoneyShort(1500000),
+            '25000000': DC.formatMoneyShort(25000000),
+            '1200000000': DC.formatMoneyShort(1200000000),
             '1234567890': DC.formatMoneyShort(1234567890),
             '2000000000': DC.formatMoneyShort(2000000000),
+            'neg2350000': DC.formatMoneyShort(-2350000),
             'neg45000': DC.formatMoneyShort(-45000),
         };
     """)
     assert cases["0"] == "0đ"
     assert cases["500"] == "500đ"
-    assert cases["1500"] == "2k"  # round
+    assert cases["1500"] == "2k"
     assert cases["12345"] == "12k"
-    assert cases["1500000"] == "1.5tr"
-    assert cases["1234567890"] == "1.23 tỷ"
-    assert cases["2000000000"] == "2 tỷ"  # trailing zeros stripped
+    assert cases["45500"] == "46k"
+    # User-reported bug: badge showed "2.4tr" for a 2,350,000đ money-in entry.
+    assert cases["2350000"] == "2tr350"
+    assert cases["2350400"] == "2tr350"
+    assert cases["2350500"] == "2tr351"
+    assert cases["1050000"] == "1tr050"
+    assert cases["1500000"] == "1tr500"
+    assert cases["25000000"] == "25tr"
+    assert cases["1200000000"] == "1tỷ200"
+    assert cases["1234567890"] == "1tỷ235"
+    assert cases["2000000000"] == "2 tỷ"
+    assert cases["neg2350000"] == "-2tr350"
     assert cases["neg45000"] == "-45k"
 
 

--- a/backend/tests/test_intent/test_query_cashflow.py
+++ b/backend/tests/test_intent/test_query_cashflow.py
@@ -29,6 +29,20 @@ _THIRTY_DAYS = TimeRange(
 )
 
 
+def _fetch_expenses_side_effect(expenses=None, money_in=None):
+    """Return a side_effect for ``_fetch_expenses`` that routes by
+    ``transaction_type`` so tests don't need to know call order."""
+    expenses = expenses or []
+    money_in = money_in or []
+
+    async def _impl(db, user, *, start, end, category=None, transaction_type="expense"):
+        if transaction_type == "money_in":
+            return money_in
+        return expenses
+
+    return _impl
+
+
 def _user(name: str = "An") -> MagicMock:
     user = MagicMock()
     user.id = uuid.uuid4()
@@ -85,7 +99,7 @@ async def test_starter_gets_simple_message_no_jargon():
 
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[expense]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=[expense])),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("0")),
@@ -117,7 +131,7 @@ async def test_mass_affluent_gets_savings_rate_breakdown():
     expenses = [MagicMock(amount=Decimal("20000000"))]
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=expenses),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=expenses)),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("0")),
@@ -147,7 +161,7 @@ async def test_no_data_message():
 
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect()),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("0")),
@@ -179,7 +193,7 @@ async def test_cashflow_overview_splits_income_and_expense_cards():
     shopping = MagicMock(amount=Decimal("1000000"), category="shopping")
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[food, shopping]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=[food, shopping])),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("500000")),
@@ -230,7 +244,7 @@ async def test_cashflow_current_month_detail_report():
     )
     with patch(
         "backend.intent.handlers.query_cashflow._fetch_expenses",
-        AsyncMock(return_value=[tx1, tx2]),
+        new=AsyncMock(side_effect=_fetch_expenses_side_effect(expenses=[tx1, tx2])),
     ), patch(
         "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
         AsyncMock(return_value=Decimal("3000000")),
@@ -253,6 +267,92 @@ async def test_cashflow_current_month_detail_report():
     assert "Chi tiêu hiện tại" in response
     assert "Chi phí định kì" in response
     assert "Tiền nhà" in response
+
+
+@pytest.mark.asyncio
+async def test_cashflow_overview_includes_money_in_card_and_correct_net():
+    """Bug fix: money_in must show as a separate card AND be added to net
+    (net = income + money_in - spend_total), not folded into expenses."""
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_CASHFLOW,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="[menu:cashflow:overview]",
+    )
+    salary = _stream(Decimal("30000000"))
+    salary.stream_type = "salary"
+    salary.name = "Lương"
+    db = _fake_db_with_streams([salary])
+    style = style_for_level(WealthLevel.MASS_AFFLUENT, Decimal("500000000"))
+
+    expense = MagicMock(amount=Decimal("10000000"), category="food")
+    gift = MagicMock(amount=Decimal("2000000"), category="other", merchant="Bố cho")
+    with patch(
+        "backend.intent.handlers.query_cashflow._fetch_expenses",
+        new=AsyncMock(
+            side_effect=_fetch_expenses_side_effect(
+                expenses=[expense], money_in=[gift]
+            )
+        ),
+    ), patch(
+        "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
+        AsyncMock(return_value=Decimal("0")),
+    ), patch(
+        "backend.intent.handlers.query_cashflow.resolve_style",
+        AsyncMock(return_value=style),
+    ):
+        response = await QueryCashflowHandler().handle(intent, user, db)
+
+    assert "💰 *Tiền vào tháng*" in response
+    # Net = 30M income + 2M money_in - 10M spend = 22M dư
+    assert "dư 22tr" in response.lower() or "22.000.000" in response
+
+
+@pytest.mark.asyncio
+async def test_cashflow_monthly_detail_shows_money_in_line():
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_CASHFLOW,
+        confidence=1.0,
+        parameters={"focus": "current_month_detail", "time_range": "this_month"},
+        raw_text="[menu:cashflow:monthly_report]",
+    )
+    salary = _stream(Decimal("20000000"))
+    salary.stream_type = "salary"
+    salary.name = "Lương"
+    db = _fake_db_with_streams([salary])
+    style = style_for_level(WealthLevel.MASS_AFFLUENT, Decimal("500000000"))
+
+    expense = MagicMock(
+        amount=Decimal("5000000"),
+        category="food",
+        merchant="Nhà hàng",
+        expense_date=date.today().replace(day=3),
+    )
+    gift = MagicMock(
+        amount=Decimal("1000000"),
+        category="other",
+        merchant="Tìm trong ngăn bàn",
+        expense_date=date.today().replace(day=2),
+    )
+    with patch(
+        "backend.intent.handlers.query_cashflow._fetch_expenses",
+        new=AsyncMock(
+            side_effect=_fetch_expenses_side_effect(
+                expenses=[expense], money_in=[gift]
+            )
+        ),
+    ), patch(
+        "backend.intent.handlers.query_cashflow._recurring_expense_for_period",
+        AsyncMock(return_value=Decimal("0")),
+    ), patch(
+        "backend.intent.handlers.query_cashflow.resolve_style",
+        AsyncMock(return_value=style),
+    ):
+        response = await QueryCashflowHandler().handle(intent, user, db)
+
+    assert "Tiền vào:" in response
 
 
 class TestIncomeForPeriodFromStreams:

--- a/backend/tests/test_intent/test_query_expenses.py
+++ b/backend/tests/test_intent/test_query_expenses.py
@@ -1,0 +1,168 @@
+"""Tests for ``_fetch_expenses`` transaction_type filter and the new
+``QueryMoneyInHandler``."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from backend.intent.handlers.query_expenses import (
+    QueryExpensesHandler,
+    QueryMoneyInHandler,
+    _fetch_expenses,
+)
+from backend.intent.intents import IntentResult, IntentType
+
+
+def _user(name: str = "An") -> MagicMock:
+    user = MagicMock()
+    user.id = uuid.uuid4()
+    user.display_name = name
+    return user
+
+
+def _capture_db():
+    """Return (db, captured_stmts) — capturing the SQL each call sees so
+    tests can assert ``transaction_type`` was filtered."""
+    captured: list = []
+
+    async def _execute(stmt):
+        captured.append(stmt)
+        result = MagicMock()
+        scalars = MagicMock()
+        scalars.all.return_value = []
+        result.scalars.return_value = scalars
+        return result
+
+    db = MagicMock()
+    db.execute = AsyncMock(side_effect=_execute)
+    return db, captured
+
+
+@pytest.mark.asyncio
+async def test_fetch_expenses_defaults_to_expense_type():
+    db, captured = _capture_db()
+    user = _user()
+    await _fetch_expenses(
+        db, user, start=date(2026, 5, 1), end=date(2026, 5, 31)
+    )
+    assert len(captured) == 1
+    sql = str(captured[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "transaction_type" in sql
+    assert "'expense'" in sql
+
+
+@pytest.mark.asyncio
+async def test_fetch_expenses_money_in_filters_correctly():
+    db, captured = _capture_db()
+    user = _user()
+    await _fetch_expenses(
+        db,
+        user,
+        start=date(2026, 5, 1),
+        end=date(2026, 5, 31),
+        transaction_type="money_in",
+    )
+    sql = str(captured[0].compile(compile_kwargs={"literal_binds": True}))
+    assert "'money_in'" in sql
+
+
+@pytest.mark.asyncio
+async def test_fetch_expenses_none_type_returns_all():
+    db, captured = _capture_db()
+    user = _user()
+    await _fetch_expenses(
+        db,
+        user,
+        start=date(2026, 5, 1),
+        end=date(2026, 5, 31),
+        transaction_type=None,
+    )
+    sql = str(captured[0].compile(compile_kwargs={"literal_binds": True}))
+    where_clause = sql.split("WHERE", 1)[1] if "WHERE" in sql else ""
+    assert "transaction_type" not in where_clause
+
+
+@pytest.mark.asyncio
+async def test_query_expenses_handler_filters_to_expense_type():
+    """Regression: chi tiêu listing must NOT include money_in rows."""
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_EXPENSES,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="chi tiêu tháng này",
+    )
+    db = MagicMock()
+    captured_kwargs: dict = {}
+
+    async def fake_fetch(db_, user_, **kwargs):
+        captured_kwargs.update(kwargs)
+        return []
+
+    with patch(
+        "backend.intent.handlers.query_expenses._fetch_expenses",
+        new=AsyncMock(side_effect=fake_fetch),
+    ):
+        await QueryExpensesHandler().handle(intent, user, db)
+
+    # Handler doesn't explicitly pass transaction_type — relies on default.
+    # The important contract is that the default is "expense".
+    # (Verified by test_fetch_expenses_defaults_to_expense_type.)
+    assert "transaction_type" not in captured_kwargs or captured_kwargs.get(
+        "transaction_type"
+    ) in (None, "expense")
+
+
+@pytest.mark.asyncio
+async def test_query_money_in_handler_fetches_money_in_only():
+    user = _user()
+    intent = IntentResult(
+        intent=IntentType.QUERY_MONEY_IN,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="tiền vào tháng này",
+    )
+    db = MagicMock()
+    gift = MagicMock(
+        amount=Decimal("2000000"),
+        merchant="Bố cho",
+        note=None,
+    )
+    captured_kwargs: dict = {}
+
+    async def fake_fetch(db_, user_, **kwargs):
+        captured_kwargs.update(kwargs)
+        return [gift]
+
+    with patch(
+        "backend.intent.handlers.query_expenses._fetch_expenses",
+        new=AsyncMock(side_effect=fake_fetch),
+    ):
+        response = await QueryMoneyInHandler().handle(intent, user, db)
+
+    assert captured_kwargs.get("transaction_type") == "money_in"
+    assert "Tiền vào" in response
+    assert "Bố cho" in response
+
+
+@pytest.mark.asyncio
+async def test_query_money_in_handler_empty_message():
+    user = _user("Minh")
+    intent = IntentResult(
+        intent=IntentType.QUERY_MONEY_IN,
+        confidence=1.0,
+        parameters={"time_range": "this_month"},
+        raw_text="tiền vào tháng này",
+    )
+    db = MagicMock()
+    with patch(
+        "backend.intent.handlers.query_expenses._fetch_expenses",
+        new=AsyncMock(return_value=[]),
+    ):
+        response = await QueryMoneyInHandler().handle(intent, user, db)
+    assert "chưa có khoản tiền vào" in response.lower()

--- a/backend/tests/test_market_data/test_briefing_full_flow.py
+++ b/backend/tests/test_market_data/test_briefing_full_flow.py
@@ -145,7 +145,7 @@ async def test_briefing_full_flow_provider_cache_wealth_and_sections():
     assert "stock" in result.text
     assert "crypto" in result.text
     assert "gold" in result.text
-    assert "155.5tr" in result.sections["net_worth"]
+    assert "155tr500" in result.sections["net_worth"]
     assert await redis.get("market_data:stock:VNM") is not None
     assert await redis.get("market_data:crypto:BTC") is not None
     assert result.is_stale is False

--- a/backend/tests/test_money.py
+++ b/backend/tests/test_money.py
@@ -89,3 +89,7 @@ class TestFormatMoneyFull:
 
     def test_user_amount_full_precision(self):
         assert format_money_full(2_350_000) == "2,350,000đ"
+
+    def test_large_decimal_preserves_exact_value(self):
+        # float conversion would lose precision past 2**53; Decimal path keeps it.
+        assert format_money_full(Decimal("9007199254740993")) == "9,007,199,254,740,993đ"

--- a/backend/tests/test_money.py
+++ b/backend/tests/test_money.py
@@ -1,31 +1,77 @@
-"""Tests for money formatters (Issue #27)."""
+"""Tests for money formatters.
+
+Rounding rule: short-form numbers are rounded only to the nearest 1,000đ
+so a 2,350,000đ money-in transaction renders as "2tr350", not "2.4tr"
+(see issue: money-in badge rounded down to nearest 100k).
+"""
+from decimal import Decimal
+
 from backend.bot.formatters.money import format_money_full, format_money_short
 
 
 class TestFormatMoneyShort:
+    def test_zero(self):
+        assert format_money_short(0) == "0đ"
+
     def test_below_1k(self):
         assert format_money_short(500) == "500đ"
+
+    def test_sub_dong_rounds_to_zero(self):
+        assert format_money_short(0.4) == "0đ"
 
     def test_exact_k(self):
         assert format_money_short(45_000) == "45k"
 
-    def test_decimal_k(self):
-        assert format_money_short(45_500) == "45.5k"
+    def test_round_to_nearest_k(self):
+        # 45,499 → 45k; 45,500 → 46k (banker's not used — half rounds away)
+        assert format_money_short(45_499) == "45k"
+        assert format_money_short(45_500) == "46k"
 
-    def test_exact_tr(self):
+    def test_exact_tr_no_thousand_portion(self):
         assert format_money_short(25_000_000) == "25tr"
 
-    def test_decimal_tr(self):
-        assert format_money_short(1_500_000) == "1.5tr"
+    def test_million_with_thousand_portion_user_example(self):
+        # User's reported bug: 2,350,000đ must render as "2tr350", not "2.4tr".
+        assert format_money_short(2_350_000) == "2tr350"
 
-    def test_billion(self):
-        assert format_money_short(1_200_000_000) == "1.2 tỷ"
+    def test_million_rounds_down_to_nearest_thousand(self):
+        # 2,350,400 → still rounds to 2tr350
+        assert format_money_short(2_350_400) == "2tr350"
 
-    def test_zero(self):
-        assert format_money_short(0) == "0đ"
+    def test_million_rounds_up_to_nearest_thousand(self):
+        # 2,350,500 → rounds up to 2tr351
+        assert format_money_short(2_350_500) == "2tr351"
 
-    def test_negative(self):
+    def test_million_with_small_thousand_pads_to_three_digits(self):
+        # Avoid ambiguity: "1tr050" reads as 1,050,000 — "1tr50" could be misread.
+        assert format_money_short(1_050_000) == "1tr050"
+        assert format_money_short(1_001_000) == "1tr001"
+
+    def test_decimal_million_legacy_now_preserves_precision(self):
+        # Old behaviour returned "1.5tr"; new rule shows the full thousand portion.
+        assert format_money_short(1_500_000) == "1tr500"
+
+    def test_billion_exact(self):
+        assert format_money_short(2_000_000_000) == "2 tỷ"
+
+    def test_billion_with_million_portion(self):
+        assert format_money_short(1_200_000_000) == "1tỷ200"
+
+    def test_billion_rounds_to_nearest_million(self):
+        # Sub-tr precision in tỷ range is rounded to keep the badge short on mobile.
+        assert format_money_short(1_234_567_890) == "1tỷ235"
+
+    def test_negative_million(self):
+        assert format_money_short(-2_350_000) == "-2tr350"
+
+    def test_negative_k(self):
         assert format_money_short(-45_000) == "-45k"
+
+    def test_decimal_input(self):
+        assert format_money_short(Decimal("2350000")) == "2tr350"
+
+    def test_float_input(self):
+        assert format_money_short(2_350_000.0) == "2tr350"
 
 
 class TestFormatMoneyFull:
@@ -40,3 +86,6 @@ class TestFormatMoneyFull:
 
     def test_float_rounds(self):
         assert format_money_full(12345.6) == "12,346đ"
+
+    def test_user_amount_full_precision(self):
+        assert format_money_full(2_350_000) == "2,350,000đ"

--- a/backend/tests/test_net_worth_calculator.py
+++ b/backend/tests/test_net_worth_calculator.py
@@ -203,6 +203,60 @@ class TestCalculateHistorical:
         total = await nwc.calculate_historical(db, uuid.uuid4(), date(2026, 4, 1))
         assert total == Decimal(0)
 
+    async def test_query_joins_assets_and_filters_ghost_states(self):
+        """Regression: phantom -19.5% on morning briefing.
+
+        Soft-deleted, placeholder, and unconfirmed assets must be excluded
+        from the historical sum so it matches ``get_user_assets`` semantics.
+        We assert the SQL text itself (rather than mocking row-level
+        behaviour) because the filter belongs to the query plan — that's
+        what guarantees DB-side consistency under any data shape.
+        """
+        result = MagicMock()
+        result.scalar.return_value = Decimal(0)
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+
+        await nwc.calculate_historical(db, uuid.uuid4(), date(2026, 6, 4))
+
+        executed_stmt = db.execute.await_args.args[0]
+        sql = str(executed_stmt).lower()
+        assert "join assets" in sql
+        assert "a.is_active = true" in sql
+        assert "a.is_placeholder_asset = false" in sql
+        assert "a.is_confirmed = true" in sql
+        # The join must be wired through the asset_id FK, not a cross-join.
+        assert "a.id = s.asset_id" in sql
+
+    async def test_change_excludes_sold_asset_snapshot_regression(
+        self, monkeypatch
+    ):
+        """End-to-end shape of the bug shown in the screenshot.
+
+        User holds 2.5 tỷ today. Yesterday a ~592.8tr stock was sold (cash
+        proceeds NOT yet re-added). Pre-fix: historical summed both the
+        live cash + the sold stock snapshot ⇒ previous ≈ 3.09 tỷ ⇒
+        -19.5%. Post-fix: the JOIN drops the sold asset, so previous
+        matches current and the briefing reports a flat change.
+        """
+        monkeypatch.setattr(
+            "backend.wealth.services.asset_service.get_user_assets",
+            AsyncMock(return_value=[_asset("cash", "VCB", 2_500_000_000)]),
+        )
+        # The post-fix query returns only the still-held assets'
+        # snapshots, so previous == current.
+        result = MagicMock()
+        result.scalar.return_value = Decimal("2_500_000_000")
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+
+        change = await nwc.calculate_change(db, uuid.uuid4(), period="day")
+
+        assert change.current == Decimal("2_500_000_000")
+        assert change.previous == Decimal("2_500_000_000")
+        assert change.change_absolute == Decimal(0)
+        assert change.change_percentage == 0.0
+
 
 @pytest.mark.asyncio
 class TestCalculateChange:

--- a/backend/tests/test_net_worth_calculator.py
+++ b/backend/tests/test_net_worth_calculator.py
@@ -222,11 +222,35 @@ class TestCalculateHistorical:
         executed_stmt = db.execute.await_args.args[0]
         sql = str(executed_stmt).lower()
         assert "join assets" in sql
-        assert "a.is_active = true" in sql
         assert "a.is_placeholder_asset = false" in sql
         assert "a.is_confirmed = true" in sql
+        # is_active is TIME-GATED, not absolute: an asset sold after the
+        # target date was still owned on that date. Dropping it would
+        # silently erase reproducible past net worth.
+        assert "a.is_active = true or a.sold_at > :target_date" in sql
         # The join must be wired through the asset_id FK, not a cross-join.
         assert "a.id = s.asset_id" in sql
+
+    async def test_query_preserves_assets_sold_after_target_date(self):
+        """Codex review #940: ``calculate_historical(target_date)`` must
+        include assets that were *still owned* on ``target_date`` even
+        if the user has sold them since. Anything else breaks the
+        "snapshots remain → past net worth stays reproducible" contract
+        the model docstring promises, and silently zeros out callers
+        like ``compute_net_worth_growth`` after every sale.
+        """
+        result = MagicMock()
+        result.scalar.return_value = Decimal(0)
+        db = MagicMock()
+        db.execute = AsyncMock(return_value=result)
+
+        await nwc.calculate_historical(db, uuid.uuid4(), date(2026, 4, 30))
+
+        sql = str(db.execute.await_args.args[0]).lower()
+        # The disjunction is the entire point of the fix — assert it
+        # exactly so a future "simplification" back to ``is_active = TRUE``
+        # would trip the test.
+        assert "is_active = true or a.sold_at > :target_date" in sql
 
     async def test_change_excludes_sold_asset_snapshot_regression(
         self, monkeypatch

--- a/backend/tests/test_storytelling_handler.py
+++ b/backend/tests/test_storytelling_handler.py
@@ -637,8 +637,8 @@ class TestConfirmationKeyboard:
         )
         assert "Nhà hàng" in body
         assert "2 giao dịch" in body
-        # Total = 2,300,000 → "2.3tr"
-        assert "2.3tr" in body
+        # Total = 2,300,000 → "2tr300" (round to nearest 1,000đ only).
+        assert "2tr300" in body
 
     def test_format_pending_confirmation_html_escapes_merchant(self):
         body = h.format_pending_confirmation(

--- a/backend/wealth/services/net_worth_calculator.py
+++ b/backend/wealth/services/net_worth_calculator.py
@@ -192,15 +192,28 @@ async def calculate_historical(
     Uses Postgres ``DISTINCT ON (asset_id)`` to pick the latest snapshot
     on or before the target date — one row per asset, single scan.
     Returns 0 if no snapshots exist on/before that date.
+
+    The JOIN on ``assets`` with ``is_active / is_placeholder_asset /
+    is_confirmed`` mirrors ``asset_service.get_user_assets`` so the
+    historical figure is computed over the exact same asset set as
+    :func:`calculate`. Without this guard, snapshots belonging to
+    soft-deleted, placeholder, or unconfirmed assets would inflate
+    "hôm qua" while being excluded from "hôm nay", producing phantom
+    declines on the morning briefing. Index ``idx_assets_real`` covers
+    the predicate.
     """
     stmt = text(
         """
         SELECT COALESCE(SUM(value), 0) AS total FROM (
-            SELECT DISTINCT ON (asset_id) value
-            FROM asset_snapshots
-            WHERE user_id = :user_id
-              AND snapshot_date <= :target_date
-            ORDER BY asset_id, snapshot_date DESC
+            SELECT DISTINCT ON (s.asset_id) s.value
+            FROM asset_snapshots s
+            JOIN assets a ON a.id = s.asset_id
+            WHERE s.user_id = :user_id
+              AND s.snapshot_date <= :target_date
+              AND a.is_active = TRUE
+              AND a.is_placeholder_asset = FALSE
+              AND a.is_confirmed = TRUE
+            ORDER BY s.asset_id, s.snapshot_date DESC
         ) latest
         """
     ).bindparams(

--- a/backend/wealth/services/net_worth_calculator.py
+++ b/backend/wealth/services/net_worth_calculator.py
@@ -193,14 +193,18 @@ async def calculate_historical(
     on or before the target date — one row per asset, single scan.
     Returns 0 if no snapshots exist on/before that date.
 
-    The JOIN on ``assets`` with ``is_active / is_placeholder_asset /
-    is_confirmed`` mirrors ``asset_service.get_user_assets`` so the
-    historical figure is computed over the exact same asset set as
-    :func:`calculate`. Without this guard, snapshots belonging to
-    soft-deleted, placeholder, or unconfirmed assets would inflate
-    "hôm qua" while being excluded from "hôm nay", producing phantom
-    declines on the morning briefing. Index ``idx_assets_real`` covers
-    the predicate.
+    The JOIN on ``assets`` mirrors ``asset_service.get_user_assets`` for
+    placeholder / unconfirmed gating (those are work-in-progress rows
+    that never represented real holdings, so their snapshots must not
+    anchor any historical comparison). For ``is_active`` we time-gate
+    instead of dropping every inactive asset: an asset sold *after*
+    ``target_date`` was still owned on that date, and its snapshot must
+    count toward past net worth — otherwise "how much did I have on
+    Apr 30" silently drops everything sold since, and the asset model's
+    contract ("snapshots remain so net-worth-at-date stays
+    reproducible") breaks. Index ``idx_assets_real`` covers the
+    placeholder/confirmed predicates; ``sold_at`` is low-cardinality
+    and the JOIN is selective.
     """
     stmt = text(
         """
@@ -210,9 +214,9 @@ async def calculate_historical(
             JOIN assets a ON a.id = s.asset_id
             WHERE s.user_id = :user_id
               AND s.snapshot_date <= :target_date
-              AND a.is_active = TRUE
               AND a.is_placeholder_asset = FALSE
               AND a.is_confirmed = TRUE
+              AND (a.is_active = TRUE OR a.sold_at > :target_date)
             ORDER BY s.asset_id, s.snapshot_date DESC
         ) latest
         """

--- a/content/intent_patterns.yaml
+++ b/content/intent_patterns.yaml
@@ -165,6 +165,21 @@ query_income:
     - pattern: 'tong\s+thu\s*nhap\s+(?:thang|nam)'
       confidence: 0.9
 
+query_money_in:
+  description: "User asks about money-in transactions (gifts, refunds, found cash) for a period."
+  patterns:
+    - pattern: 'tien\s+vao.*(?:thang|tuan|nam|hom)'
+      confidence: 0.95
+    - pattern: '^(?:liet\s*ke|list|xem)\s+tien\s+vao'
+      confidence: 0.9
+    - pattern: 'tien\s+vao\s+(?:cua\s+)?(?:toi|minh)?'
+      confidence: 0.85
+    - pattern: 'khoan\s+thu\s+khac.*(?:thang|tuan)'
+      confidence: 0.85
+  parameter_extractors:
+    time_range:
+      use_extractor: time_range
+
 query_cashflow:
   description: "User asks net cashflow / savings for a period."
   patterns:


### PR DESCRIPTION
## Release 1.4.4.11 (10th prod release)

Merge `main` → `prod`.

### Commits included (main ahead of prod)

- 38028a5 Merge PR #942 (claude/compassionate-goldberg-DSpgY)
- f80b9f2 fix(money): keep Decimal precision in formatters
- 5f12e1b fix(money): round short-form to nearest 1,000đ instead of 100k
- 1a17de7 Merge PR #941 (claude/zen-tesla-rLX1N)
- ce71011 fix(intent): separate money_in from expense queries & cashflow math
- 40e401e Merge PR #940 (claude/peaceful-hawking-Q0A2a)
- 04a5a09 fix(net-worth): preserve assets sold after historical target_date
- 0710429 fix(briefing): align historical net worth with current asset filters

### Theme

Bug fixes:
- Money formatting precision (Decimal preservation, 1k rounding)
- Intent classification: money_in vs expense separation, cashflow math
- Historical net worth: preserve sold assets, align with current asset filters

### Test plan
- [ ] Operator review of diff on GitHub
- [ ] Merge via GitHub UI (no fast-forward push from CLI)
- [ ] Post-merge smoke test on prod


---
_Generated by [Claude Code](https://claude.ai/code/session_015ZGrLhZK44GUF8Wnxyq7ou)_