### PR TITLE
fix(money): stop unit abbreviation from matching a word prefix

### DIFF
--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -75,7 +75,9 @@ _NOT_REGISTERED = "Bạn chưa đăng ký. Gửi /start để bắt đầu."
 # pipeline.
 _AMOUNT_TOKEN_PATTERN = (
     r"\d{1,3}(?:[.,]\d{3})+"
-    r"|\d+(?:[.,]\d+)?(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?:\s*\d+)?)?"
+    # The lookahead keeps a unit letter from gluing onto a word ("tr" in
+    # "trên", "k" in "kem") — see _DUOC_AMOUNT_RE below.
+    r"|\d+(?:[.,]\d+)?(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?!(?!rưỡi|ruoi)[^\W\d_])(?:\s*\d+)?)?"
 )
 
 _SIGNED_TX_RE = re.compile(
@@ -100,9 +102,15 @@ _AMOUNT_TOKEN_RE = re.compile(
 # intent pipeline. This mirrors the Tier-1 YAML rule, which also demands
 # a money suffix for this shape. Keep the unit list in sync with
 # ``_AMOUNT_TOKEN_PATTERN`` above.
+# The ``(?!(?!rưỡi|ruoi)[^\W\d_])`` after each unit alternation stops a unit
+# letter from matching the prefix of an ordinary word — without it the "tr" in
+# "199999 trên momo" was read as triệu and booked 199,999 as 199,999,000,000đ.
+# ``[^\W\d_]`` is "a (unicode) letter"; digits/space/end still let the unit
+# stand ("100tr", "20tr5", "500k"), and the inner ``(?!rưỡi|ruoi)`` keeps a
+# glued half-word working ("3trrưỡi" = 3.5 triệu).
 _DUOC_AMOUNT_RE = re.compile(
-    r"(?P<amt>\d{1,3}(?:[.,]\d{3})+(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd))?"
-    r"|\d+(?:[.,]\d+)?\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?:\s*\d+)?)",
+    r"(?P<amt>\d{1,3}(?:[.,]\d{3})+(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?!(?!rưỡi|ruoi)[^\W\d_]))?"
+    r"|\d+(?:[.,]\d+)?\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?!(?!rưỡi|ruoi)[^\W\d_])(?:\s*\d+)?)",
     re.IGNORECASE,
 )
 

--- a/backend/intent/handlers/action_quick_transaction.py
+++ b/backend/intent/handlers/action_quick_transaction.py
@@ -107,8 +107,12 @@ Quy tắc:
 Chỉ trả về JSON, không giải thích."""
 
 
+# The lookahead after the unit stops "tr"/"k" from matching the prefix of a
+# word ("tr" in "trên", "k" in "kem") and inflating the amount ×1,000,000.
+# ``[^\W\d_]`` is "a letter"; the inner ``(?!rưỡi|ruoi)`` lets a glued
+# half-word through, matching backend.wealth.amount_parser.
 _AMOUNT_RE = re.compile(
-    r"(?<!\w)(\d+(?:[.,]\d+)?)(?:\s*(k|K|ngàn|nghìn|ngan|nghin|tr|triệu|trieu))?",
+    r"(?<!\w)(\d+(?:[.,]\d+)?)(?:\s*(k|K|ngàn|nghìn|ngan|nghin|tr|triệu|trieu)(?!(?!rưỡi|ruoi)[^\W\d_]))?",
     re.IGNORECASE,
 )
 _SPLIT_RE = re.compile(r"\s*(?:,|\+|\n|\s+và\s+)\s*", re.IGNORECASE)

--- a/backend/tests/test_amount_parser.py
+++ b/backend/tests/test_amount_parser.py
@@ -107,6 +107,33 @@ class TestParseAmount:
     def test_sub_amount_after_unit(self, raw, expected):
         assert parse_amount(raw) == expected
 
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # Regression: a unit abbreviation must NOT match the prefix of
+            # an ordinary word. "199999 trên momo" was read as "199999 tr"
+            # (= 199,999 triệu = 199,999,000,000đ) because "tr" greedily
+            # ate the start of "trên". The number has no real unit, so it
+            # parses as the bare amount.
+            ("199999 trên momo", Decimal("199999")),
+            ("100 trên bàn", Decimal("100")),  # "tr" in "trên"
+            ("199999 trong ví", Decimal("199999")),  # "tr" in "trong"
+            ("50 kem", Decimal("50")),  # "k" in "kem"
+            ("5 ký gạo", Decimal("5")),  # "k" in "ký"
+            ("3 ngày", Decimal("3")),  # "ngà" in "ngày" not "ngàn"
+            ("10 do dự", Decimal("10")),  # "d" in "do"
+            # The fix must not break a real unit glued to a number, a unit
+            # followed by a digit, or the half-word "rưỡi" right after.
+            ("100tr", Decimal("100000000")),
+            ("20tr5", Decimal("20500000")),
+            ("3trrưỡi", Decimal("3500000")),
+            ("500k", Decimal("500000")),
+            ("2tỷ", Decimal("2000000000")),
+        ],
+    )
+    def test_unit_must_not_be_word_prefix(self, raw, expected):
+        assert parse_amount(raw) == expected
+
 
 class TestParseLabelAndAmount:
     @pytest.mark.parametrize(
@@ -185,6 +212,25 @@ class TestParseLabelAndAmount:
         ],
     )
     def test_ruoi_in_labeled_amount(
+        self, raw, expected_label, expected_amount
+    ):
+        result = parse_label_and_amount(raw)
+        assert result is not None, f"parser returned None for {raw!r}"
+        label, amount = result
+        assert label == expected_label
+        assert amount == expected_amount
+
+    @pytest.mark.parametrize(
+        "raw,expected_label,expected_amount",
+        [
+            # Regression: the trailing word after a bare amount must not be
+            # swallowed as a unit. "199999 trên momo" → 199,999đ, not
+            # 199,999,000,000đ.
+            ("199999 trên momo", "", Decimal("199999")),
+            ("Quỹ 50 kem", "Quỹ", Decimal("50")),
+        ],
+    )
+    def test_trailing_word_not_read_as_unit(
         self, raw, expected_label, expected_amount
     ):
         result = parse_label_and_amount(raw)

--- a/backend/wealth/amount_parser.py
+++ b/backend/wealth/amount_parser.py
@@ -44,7 +44,14 @@ _AMOUNT_RE = re.compile(
     (?P<int>\d{1,3}(?:[.,]\d{3})+|\d+)            # 1,000,000 or 1000000
     (?:[.,](?P<frac>\d+))?                        # optional .5 or ,5
     \s*
-    (?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)?
+    (?:(?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)
+       (?!(?!rưỡi|ruoi)[^\W\d_]))?                # a unit must not be the prefix of a
+                                                  # word: the "tr" in "trên", the "k"
+                                                  # in "kem", the "d" in "do" are NOT
+                                                  # units. ``[^\W\d_]`` is "a letter";
+                                                  # the inner ``(?!rưỡi|ruoi)`` still
+                                                  # lets a glued half-word through
+                                                  # ("3trrưỡi" = 3.5 triệu).
     (?:\s*(?P<sub>\d+))?                          # "25tr320" or "1 tỷ 500" sub-amount
     (?:\s*(?P<half>rưỡi|ruoi))?                   # "rưỡi" → +0.5 of unit
     \s*
@@ -174,7 +181,8 @@ _LABELED_AMOUNT_RE = re.compile(
     (?:^|(?<=\s))
     (?P<num>\d{1,3}(?:[.,]\d{3})+|\d+(?:[.,]\d+)?)
     \s*
-    (?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)?
+    (?:(?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)
+       (?!(?!rưỡi|ruoi)[^\W\d_]))?                # see _AMOUNT_RE: unit ≠ word prefix
     (?:\s*(?P<sub>\d+))?
     (?:\s*(?P<half>rưỡi|ruoi))?
     """,

--- a/tests/test_message_money_in_fastpath.py
+++ b/tests/test_message_money_in_fastpath.py
@@ -11,6 +11,50 @@ from types import SimpleNamespace
 import pytest
 
 from backend.bot.handlers import message as message_handler
+from backend.bot.handlers.message import _parse_duoc_money_in
+
+
+class TestDuocMoneyInAmountScaling:
+    """Regression for the ×1,000,000 money-in scaling bug.
+
+    "Vừa được cho 199999 trên momo" was booked as 199,999,000,000đ because
+    the amount regex matched "199999 tr" — the "tr" of "trên" — and read it
+    as the triệu unit. A unit abbreviation must never glue onto the prefix
+    of an ordinary word.
+    """
+
+    def test_word_starting_with_unit_does_not_inflate_amount(self):
+        # The exact message from the bug report. "199999" carries no real
+        # unit, so the strict được-fast-path declines (returns None) and the
+        # message falls through to the intent pipeline — crucially it is NOT
+        # booked as 199,999,000,000đ.
+        assert _parse_duoc_money_in("Vừa được cho 199999 trên momo") is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "được bố cho 100 trên bàn",  # "tr" in "trên"
+            "được mẹ cho 50 kem",  # "k" in "kem"
+        ],
+    )
+    def test_unit_prefixed_words_never_booked(self, text):
+        assert _parse_duoc_money_in(text) is None
+
+    @pytest.mark.parametrize(
+        "text,expected_amount",
+        [
+            # Real units must still parse — the fix is surgical.
+            ("được bố cho 500k", 500_000.0),
+            ("được lì xì 50 ngàn", 50_000.0),
+            ("được thưởng 2tr", 2_000_000.0),
+            ("được bố cho 1.000.000", 1_000_000.0),
+        ],
+    )
+    def test_real_units_still_record(self, text, expected_amount):
+        parsed = _parse_duoc_money_in(text)
+        assert parsed is not None, f"fast-path declined a real money-in: {text!r}"
+        assert parsed["amount"] == expected_amount
+        assert parsed["transaction_type"] == "money_in"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Bug

A money-in like **"Vừa được cho 199999 trên momo"** was recorded as **199,999,000,000đ** (199,999 tỷ) instead of **199,999đ** — a ×1,000,000 inflation. The tell-tale sign is in the confirmation card: the merchant read **"ên momo"** — the **"tr"** of **"trên"** had been eaten.

## Root cause

The amount-extraction regexes list currency units (`tr`, `k`, `ty`, `tỷ`, `d`, …) with **no trailing word boundary**. So `"199999 trên"` matched as `"199999 tr"`, and `parse_amount` read the bare `"tr"` as the **triệu** unit → `199999 × 1,000,000`.

This was a whole class of bug, not just the money-in path:

```
parse_amount("199999 trên momo")  → 199,999,000,000   (should be 199,999)
parse_amount("50 kem")            → 50,000            ("k" in "kem")
parse_amount("5 ký gạo")          → 5,000             ("k" in "ký")
parse_amount("100 trên bàn")      → 100,000,000       ("tr" in "trên")
```

## Fix

Add a negative lookahead `(?!(?!rưỡi|ruoi)[^\W\d_])` after every currency unit: a unit may not be immediately followed by a letter, so it can no longer glue onto the prefix of an ordinary word. The inner `(?!rưỡi|ruoi)` keeps the glued half-word working (`"3trrưỡi"` = 3.5 triệu), and digits still pass so `"20tr5"` is unaffected.

Applied to all four amount regexes that shared the flaw:
- `backend/wealth/amount_parser.py` — `_AMOUNT_RE`, `_LABELED_AMOUNT_RE` (canonical parser)
- `backend/bot/handlers/message.py` — `_DUOC_AMOUNT_RE` (money-in fast-path), `_AMOUNT_TOKEN_PATTERN`
- `backend/intent/handlers/action_quick_transaction.py` — `_AMOUNT_RE`

After the fix, `"được cho 199999 trên momo"` no longer mis-books: the strict được-fast-path (which requires a real unit) declines and the message falls through to the intent pipeline, while the canonical `parse_amount` now returns the correct `199,999`.

## Tests

- `test_unit_must_not_be_word_prefix` / `test_trailing_word_not_read_as_unit` in `test_amount_parser.py` — the bug cases plus must-still-work cases (`100tr`, `20tr5`, `3trrưỡi`, `500k`, `2tỷ`).
- `TestDuocMoneyInAmountScaling` in `test_message_money_in_fastpath.py` — the exact reported message, unit-prefixed words, and real-unit money-ins.

All 138 affected tests pass; no regressions in the broader transaction/parser suites.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7u2CBSwEJKHDR7mK5JiyD)_