### PR TITLE
fix(admin): serve SPA at /admin/ (canonical URL) in addition to /

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
@@ -334,6 +334,22 @@ async def health_check():
 
 _ADMIN_STATIC = Path(__file__).parent / "static" / "admin"
 if _ADMIN_STATIC.exists():
+    # Canonical admin URL is /admin/ (matches Cloudflare ingress + deploy
+    # script success message). Starlette's Mount("/admin", ...) only
+    # matches /admin/* — bare /admin still 404s without an explicit
+    # redirect, so add one before mounting.
+    @app.get("/admin", include_in_schema=False)
+    async def _admin_trailing_slash():
+        return RedirectResponse(url="/admin/", status_code=308)
+
+    # /admin mount must come BEFORE / so the more-specific prefix wins
+    # for /admin/login, /admin/assets/*, etc.
+    app.mount(
+        "/admin",
+        SPAStaticFiles(directory=str(_ADMIN_STATIC), html=True),
+        name="admin-spa-prefix",
+    )
+    # Root mount kept for backward-compat: pre-fix users had / bookmarked.
     app.mount(
         "/", SPAStaticFiles(directory=str(_ADMIN_STATIC), html=True), name="admin-spa"
     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -337,8 +337,9 @@ if _ADMIN_STATIC.exists():
     # Canonical admin URL is /admin/ (matches Cloudflare ingress + deploy
     # script success message). Starlette's Mount("/admin", ...) only
     # matches /admin/* — bare /admin still 404s without an explicit
-    # redirect, so add one before mounting.
-    @app.get("/admin", include_in_schema=False)
+    # redirect. Register GET + HEAD so `curl -I` and uptime probes also
+    # see the 308 instead of falling through to the static mount.
+    @app.api_route("/admin", methods=["GET", "HEAD"], include_in_schema=False)
     async def _admin_trailing_slash():
         return RedirectResponse(url="/admin/", status_code=308)
 

--- a/betien-admin/src/main.jsx
+++ b/betien-admin/src/main.jsx
@@ -5,9 +5,14 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import './styles.css';
 
+// SPA is served at both / (legacy bookmarks) and /admin/ (canonical, matches
+// Cloudflare ingress). Detect at runtime so React Router treats /admin/login
+// as /login instead of falling through to the catch-all `*` route.
+const routerBasename = window.location.pathname.startsWith('/admin') ? '/admin' : '/';
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={routerBasename}>
       <AuthProvider>
         <App />
       </AuthProvider>

--- a/tests/test_phase_4_2_5/test_admin_spa_fallback.py
+++ b/tests/test_phase_4_2_5/test_admin_spa_fallback.py
@@ -130,7 +130,7 @@ def dual_mount_app(tmp_path: Path) -> TestClient:
     async def ping():
         return {"ok": True}
 
-    @app.get("/admin", include_in_schema=False)
+    @app.api_route("/admin", methods=["GET", "HEAD"], include_in_schema=False)
     async def admin_redirect():
         return RedirectResponse(url="/admin/", status_code=308)
 
@@ -155,6 +155,14 @@ def test_admin_trailing_slash_serves_spa(dual_mount_app: TestClient):
 
 def test_admin_bare_redirects_to_trailing_slash(dual_mount_app: TestClient):
     resp = dual_mount_app.get("/admin")
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/admin/"
+
+
+def test_admin_bare_head_also_redirects(dual_mount_app: TestClient):
+    # `curl -I` and uptime probes use HEAD — must see the redirect, not fall
+    # through to the static mount and 404.
+    resp = dual_mount_app.head("/admin")
     assert resp.status_code == 308
     assert resp.headers["location"] == "/admin/"
 

--- a/tests/test_phase_4_2_5/test_admin_spa_fallback.py
+++ b/tests/test_phase_4_2_5/test_admin_spa_fallback.py
@@ -103,3 +103,100 @@ def test_no_accept_header_does_not_fall_back(spa_app: TestClient):
     # Plain HTTP clients (curl with no -H) get a clean 404, not HTML.
     resp = spa_app.get("/nope", headers={"Accept": "application/json"})
     assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# Dual-mount regression — issue: /admin/ canonical URL must serve the SPA,
+# not 404. main.py mounts SPAStaticFiles at both /admin and / and redirects
+# bare /admin → /admin/. These tests mirror that wiring.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def dual_mount_app(tmp_path: Path) -> TestClient:
+    static_dir = tmp_path / "admin"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<html>admin spa</html>")
+    (static_dir / "favicon.ico").write_bytes(b"\x00")
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir()
+    (assets_dir / "index.js").write_text("console.log('app')")
+
+    from fastapi.responses import RedirectResponse
+
+    app = FastAPI()
+
+    @app.get("/api/v1/ping")
+    async def ping():
+        return {"ok": True}
+
+    @app.get("/admin", include_in_schema=False)
+    async def admin_redirect():
+        return RedirectResponse(url="/admin/", status_code=308)
+
+    app.mount(
+        "/admin",
+        SPAStaticFiles(directory=str(static_dir), html=True),
+        name="admin-spa-prefix",
+    )
+    app.mount(
+        "/", SPAStaticFiles(directory=str(static_dir), html=True), name="admin-spa"
+    )
+    return TestClient(app, follow_redirects=False)
+
+
+def test_admin_trailing_slash_serves_spa(dual_mount_app: TestClient):
+    # Canonical URL — must work for both browser AND curl-style requests.
+    for accept in (BROWSER_ACCEPT, "*/*", "application/json"):
+        resp = dual_mount_app.get("/admin/", headers={"Accept": accept})
+        assert resp.status_code == 200, f"accept={accept}: {resp.status_code}"
+        assert "admin spa" in resp.text, f"accept={accept}: {resp.text!r}"
+
+
+def test_admin_bare_redirects_to_trailing_slash(dual_mount_app: TestClient):
+    resp = dual_mount_app.get("/admin")
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/admin/"
+
+
+def test_admin_subpath_browser_navigation_serves_index(dual_mount_app: TestClient):
+    for path in ("/admin/login", "/admin/users", "/admin/anything/deep"):
+        resp = dual_mount_app.get(path, headers={"Accept": BROWSER_ACCEPT})
+        assert resp.status_code == 200, f"{path}: {resp.status_code}"
+        assert "admin spa" in resp.text
+
+
+def test_admin_real_asset_served_directly(dual_mount_app: TestClient):
+    # SPA build references /assets/* at root — but ALSO must resolve
+    # under /admin/assets/* so an /admin/-based index.html can load them.
+    resp = dual_mount_app.get("/admin/assets/index.js")
+    assert resp.status_code == 200
+    assert "console.log" in resp.text
+
+    resp = dual_mount_app.get("/assets/index.js")
+    assert resp.status_code == 200
+    assert "console.log" in resp.text
+
+
+def test_admin_api_not_swallowed(dual_mount_app: TestClient):
+    # Real API route still wins over SPA mounts.
+    resp = dual_mount_app.get("/api/v1/ping")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    # Unknown API path keeps real 404, even with browser Accept.
+    resp = dual_mount_app.get(
+        "/api/v1/unknown", headers={"Accept": BROWSER_ACCEPT}
+    )
+    assert resp.status_code == 404
+    assert "admin spa" not in resp.text
+
+
+def test_admin_subpath_missing_asset_keeps_404(dual_mount_app: TestClient):
+    # Browsers fetching <script>/<link>/<img> under /admin/ never send
+    # text/html — must get a real 404 instead of HTML masquerading as JS.
+    resp = dual_mount_app.get(
+        "/admin/assets/missing.js", headers={"Accept": "*/*"}
+    )
+    assert resp.status_code == 404
+    assert "admin spa" not in resp.text


### PR DESCRIPTION
## Summary

Production hits `finance.nuitruc.ai/admin/` — the documented canonical URL per `scripts/rebuild-finance-prod.sh` — but FastAPI only mounted `SPAStaticFiles` at `/`. Bare `/admin/` was returning **404** because Starlette's `StaticFiles` only serves `index.html` when the URL maps to a directory under the mount root, and `admin` is not a directory inside the SPA build.

**Fix:** dual-mount `SPAStaticFiles` at both `/admin` and `/` (more-specific prefix first, so `/admin/login`, `/admin/assets/*` resolve under `/admin`), plus an explicit **308** redirect for bare `/admin` → `/admin/`, since Starlette's `Mount("/admin", ...)` only matches `/admin/<path>`, not the bare prefix.

The root mount stays for backward compat with existing bookmarks.

## What changed
- `backend/main.py`
  - Add `RedirectResponse` import.
  - Register `GET /admin` → 308 to `/admin/` (before the mounts so it wins).
  - Mount `SPAStaticFiles` at `/admin` *before* `/` so the more-specific prefix wins for `/admin/login`, `/admin/assets/*`, etc.
- `tests/test_phase_4_2_5/test_admin_spa_fallback.py`
  - New `dual_mount_app` fixture mirrors the main.py wiring.
  - 6 new tests covering the canonical `/admin/` path, the bare `/admin` redirect, subpath browser navigation, asset resolution under both `/admin/assets/*` and `/assets/*`, API isolation, and that missing assets don't get HTML masquerading as JS.

## SPA rebuild pipeline review (per user request)

Per `kiểm tra lại cách rebuild SPA trên production`: `scripts/rebuild-finance-prod.sh` invokes `dc build backend`, which triggers `backend/Dockerfile`'s `admin-build` multi-stage:

1. `FROM node:22-slim AS admin-build` — installs npm deps from `betien-admin/package-lock.json`.
2. `ARG VITE_API_BASE` (default `https://admin.betien.vn/api/admin`) — Vite inlines this at build time.
3. `npm run build` → output to `/admin/dist`.
4. Python stage: `COPY --from=admin-build /admin/dist /app/backend/static/admin`.
5. At runtime, my updated `main.py` mounts that directory at both `/admin/` and `/`.

Pipeline itself is healthy — host needs only Docker, no npm. No changes required there.

## Test plan
- [x] All 18 tests in `tests/test_phase_4_2_5/test_admin_spa_fallback.py` pass locally (12 existing + 6 new).
- [x] Lint check on changed files introduces no new errors (`E402` warnings on the test file are pre-existing from the `sys.path` + `importorskip` pattern).
- [ ] After deploy, smoke test on prod:
  - `curl -I https://finance.nuitruc.ai/admin/` → `200`, `text/html`
  - `curl -I https://finance.nuitruc.ai/admin` → `308 Location: /admin/`
  - `curl -I -H "Accept: text/html" https://finance.nuitruc.ai/admin/login` → `200`, `text/html`
  - `curl -I https://finance.nuitruc.ai/admin/assets/<built-asset>.js` → `200`, `text/javascript`
  - `curl -I https://finance.nuitruc.ai/` still returns the SPA (no regression).
  - `curl -I https://finance.nuitruc.ai/api/v1/unknown` → `404` (API isolation intact).

## Note on cloudflared

The user's initial diagnostic also mentioned cloudflared running with 0 established connections. That's an infra-side issue (tunnel config / network), not in the FastAPI codebase, and is out of scope for this PR. Once the tunnel reconnects, this fix makes `/admin/` reachable through it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01HwbCkijcixx58EVVfEwMqC)_