### PR TITLE
fix(nlu): recognise leading bare dates in transaction inputs

### DIFF
--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -149,22 +149,24 @@ async def _extract_credit_card_source(db: AsyncSession, user_id, text: str) -> t
 def _parse_signed_transaction(text: str) -> dict | None:
     if _QUESTION_HINT_RE.search(text):
         return None
-    signed = _SIGNED_TX_RE.match(text)
+
+    # Pull any transaction-date phrase out of the FULL text first so a
+    # leading bare date like "14/05/2026 -120k cà phê" still reaches the
+    # sign-aware matchers (otherwise the leading "14/05/2026" would
+    # prevent both _SIGNED_TX_RE and _AMOUNT_LED_TX_RE from matching).
+    extracted_date = extract_transaction_date(text)
+    cleaned = strip_span(text, extracted_date.span) if extracted_date else text
+
+    signed = _SIGNED_TX_RE.match(cleaned)
     if signed:
         sign = signed.group("sign")
         body = (signed.group("body") or "").strip()
     else:
-        amount_led = _AMOUNT_LED_TX_RE.match(text)
+        amount_led = _AMOUNT_LED_TX_RE.match(cleaned)
         if not amount_led:
             return None
         sign = None
         body = (amount_led.group("body") or "").strip()
-
-    # Strip any "ngày dd/mm[/yyyy]" phrase BEFORE searching for the
-    # amount so the date digits don't get mistaken for a price.
-    extracted_date = extract_transaction_date(body)
-    if extracted_date is not None:
-        body = strip_span(body, extracted_date.span)
 
     amount_match = _AMOUNT_TOKEN_RE.search(body)
     if not amount_match:

--- a/backend/bot/utils/transaction_date_extractor.py
+++ b/backend/bot/utils/transaction_date_extractor.py
@@ -1,10 +1,24 @@
 """Extract a transaction date from free-text user input.
 
-Used by the Tier-1 NLU fast-paths so a message like
-``"-1tr ăn tối ngày 16/05/2026"`` records the expense on 16/05/2026 instead
-of today. Matching is anchored on Vietnamese date keywords (``ngày``, ``hôm``,
-``vào ngày``) to avoid false positives — a phrase like ``"mua 12/3 phần
-pizza"`` MUST NOT be re-interpreted as a date.
+Three detection modes, tried in order so the most disambiguating shape
+wins:
+
+  * **Mode 0 — keyword-anchored.** ``ngày``, ``vào ngày``, ``hôm`` +
+    ``dd/mm[/yyyy]``. Authoritative whenever present.
+  * **Mode 1 — year-bearing anywhere.** A bare ``dd/mm/yyyy`` (or
+    ``dd/mm/yy``) sitting anywhere in the message. The explicit year
+    disambiguates from ratios/portions ("ăn 12/3 phần" stays untouched
+    because it has no year). Lookarounds keep the match out of digit
+    runs like phone numbers.
+  * **Mode 2 — leading bare dd/mm.** A ``dd/mm`` at the very start of
+    the message, followed by more content. To stay safe against ratios
+    like ``"1/2 ổ bánh mì 50k"`` we require **day > 12 OR month > 12**.
+    Year defaults to ``today.year`` (see :func:`parse_vietnamese_date_token`).
+
+The function returns the date together with the character span covering
+what should be stripped from the merchant/note. Mode 0 also covers the
+keyword; Modes 1 and 2 cover only the date token. Callers feed the
+result through :func:`strip_span` to clean the surrounding text.
 """
 
 from __future__ import annotations
@@ -20,13 +34,29 @@ from backend.bot.utils.date_parser import parse_vietnamese_date_token
 # phrase regex.
 _DATE_TOKEN = r"\d{1,2}[/\-.]\d{1,2}(?:[/\-.](?:\d{2}|\d{4}))?"
 
-# Keyword-anchored phrases. ``ngày`` is the canonical one; ``vào ngày`` and
-# ``hôm`` cover natural phrasings. We intentionally do NOT match bare
-# ``16/05`` without a keyword — that risks parsing ratios/portions
-# ("ăn 12/3 phần") as dates.
+# Mode 0 — keyword-anchored. ``ngày`` is canonical; ``vào ngày`` and
+# ``hôm`` cover natural phrasings. The keyword shields us from ratios
+# (``"ăn 12/3 phần"`` has no keyword and stays put).
 _DATE_PHRASE_RE = re.compile(
     rf"(?P<prefix>\b(?:vào\s+ngày|ngày|hôm))\s+(?P<token>{_DATE_TOKEN})\b",
     re.IGNORECASE,
+)
+
+# Mode 1 — year-bearing date anywhere. The (?<!\d) / (?!\d) lookarounds
+# keep the regex from biting into the middle of a digit run such as
+# ``"0902/05/2026"`` (phone number). The 4-digit (or 2-digit) year is
+# what tells a date apart from a ratio.
+_YEAR_BEARING_DATE_RE = re.compile(
+    r"(?<!\d)"
+    r"(?P<token>\d{1,2}[/\-.]\d{1,2}[/\-.](?:\d{4}|\d{2}))"
+    r"(?!\d)"
+)
+
+# Mode 2 — leading bare ``dd/mm`` (no year) followed by at least one
+# more token. The day/month numbers are captured separately so we can
+# enforce the day>12 OR month>12 disambiguation guard before parsing.
+_LEADING_BARE_DATE_RE = re.compile(
+    r"^\s*(?P<token>(?P<d>\d{1,2})[/\-.](?P<m>\d{1,2}))(?=\s+\S)"
 )
 
 
@@ -35,9 +65,9 @@ class ExtractedDate:
     """Result of date extraction.
 
     ``span`` is the half-open ``(start, end)`` slice in the input text
-    covering BOTH the keyword and the token, so the caller can strip the
-    whole phrase from the merchant/note without leaving a dangling
-    ``"ngày"``.
+    that should be stripped from the merchant/note. For Mode 0 it covers
+    the keyword and the token; for Modes 1 and 2 it covers only the
+    token itself.
     """
 
     value: date
@@ -47,21 +77,45 @@ class ExtractedDate:
 def extract_transaction_date(
     text: str, *, today: date | None = None
 ) -> ExtractedDate | None:
-    """Find the first ``ngày <dd/mm[/yyyy]>``-style phrase in ``text``.
+    """Find a transaction date in ``text``.
 
-    Returns ``None`` when no recognisable date phrase is present, or when
-    the captured token is malformed (e.g. ``ngày 31/02`` → invalid). The
-    caller then keeps ``date.today()``.
+    Returns ``None`` when no recognisable date is present, or when the
+    candidate token is malformed (e.g. ``31/02/2026`` → invalid). The
+    caller then keeps ``date.today()``. Mode precedence — keyword,
+    year-bearing, leading bare — is documented at the module level.
     """
     if not text:
         return None
+
+    # Mode 0 — keyword-anchored phrase (most authoritative).
     match = _DATE_PHRASE_RE.search(text)
-    if not match:
-        return None
-    parsed = parse_vietnamese_date_token(match.group("token"), today=today)
-    if parsed is None:
-        return None
-    return ExtractedDate(value=parsed, span=match.span())
+    if match:
+        parsed = parse_vietnamese_date_token(match.group("token"), today=today)
+        if parsed is None:
+            return None
+        return ExtractedDate(value=parsed, span=match.span())
+
+    # Mode 1 — year-bearing date sitting anywhere in the message.
+    match = _YEAR_BEARING_DATE_RE.search(text)
+    if match:
+        parsed = parse_vietnamese_date_token(match.group("token"), today=today)
+        if parsed is None:
+            return None
+        return ExtractedDate(value=parsed, span=match.span("token"))
+
+    # Mode 2 — leading bare ``dd/mm``, disambiguated by day>12 OR month>12.
+    match = _LEADING_BARE_DATE_RE.match(text)
+    if match:
+        day = int(match.group("d"))
+        month = int(match.group("m"))
+        if day > 12 or month > 12:
+            parsed = parse_vietnamese_date_token(
+                match.group("token"), today=today
+            )
+            if parsed is not None:
+                return ExtractedDate(value=parsed, span=match.span("token"))
+
+    return None
 
 
 def strip_span(text: str, span: tuple[int, int]) -> str:

--- a/backend/tests/test_signed_transaction_parser.py
+++ b/backend/tests/test_signed_transaction_parser.py
@@ -182,3 +182,84 @@ def test_duoc_money_in_invalid_date_falls_back_silently() -> None:
     assert parsed is not None
     assert parsed["amount"] == 500_000
     assert "expense_date" not in parsed
+
+
+# ---------------------------------------------------------------------------
+# Keyword-less date fast-path — the user can lead the message with a bare
+# ``dd/mm/yyyy`` date and the Tier-1 parsers MUST still record the date.
+# This is the bug the screenshot showed: ``14/05/2026 ăn gà kfc 120k`` was
+# logged with today's date because the sign/amount-led matchers fired on
+# the date digits before the date extractor saw them.
+# ---------------------------------------------------------------------------
+
+
+def test_signed_expense_with_leading_year_bearing_date() -> None:
+    parsed = _parse_signed_transaction("14/05/2026 -1tr ăn tối")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 1_000_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "ăn tối"
+
+
+def test_amount_led_expense_with_leading_year_bearing_date() -> None:
+    """The exact screenshot bug: no sign, leading date, then amount+merchant."""
+    parsed = _parse_signed_transaction("14/05/2026 120k cà phê")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 120_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "cà phê"
+
+
+def test_signed_money_in_with_leading_year_bearing_date() -> None:
+    parsed = _parse_signed_transaction("14/05/2026 +5tr thưởng")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "money_in"
+    assert parsed["amount"] == 5_000_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "thưởng"
+
+
+def test_signed_expense_with_trailing_year_bearing_date() -> None:
+    parsed = _parse_signed_transaction("-50k cà phê 02/06/2026")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 50_000
+    assert parsed["expense_date"] == "2026-06-02"
+    assert "02/06" not in parsed["merchant"]
+    assert parsed["merchant"] == "cà phê"
+
+
+def test_amount_led_expense_with_leading_bare_dd_mm() -> None:
+    """Leading ``dd/mm`` (no year) with day>12 is unambiguously a date."""
+    parsed = _parse_signed_transaction("14/05 120k cà phê")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 120_000
+    assert parsed["expense_date"] is not None
+    assert parsed["expense_date"].endswith("-05-14")
+    assert parsed["merchant"] == "cà phê"
+
+
+def test_duoc_money_in_with_leading_year_bearing_date() -> None:
+    parsed = _parse_duoc_money_in("14/05/2026 được bố cho 500k")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "money_in"
+    assert parsed["amount"] == 500_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "bố cho"
+
+
+def test_ratio_shape_not_parsed_as_transaction() -> None:
+    """``1/2 ổ bánh mì 50k`` must NOT be parsed as a 1-Feb expense — the
+    Mode 2 guard (day>12 OR month>12) keeps ratios untouched."""
+    parsed = _parse_signed_transaction("1/2 ổ bánh mì 50k")
+    # Even if the parser does record this as an expense, the expense_date
+    # MUST NOT be set from the leading "1/2".
+    if parsed is not None:
+        assert "expense_date" not in parsed

--- a/backend/tests/test_transaction_date_extractor.py
+++ b/backend/tests/test_transaction_date_extractor.py
@@ -87,3 +87,150 @@ def test_strip_span_handles_mid_text_phrase() -> None:
 
 def test_strip_span_empty_input() -> None:
     assert strip_span("", (0, 0)) == ""
+
+
+# ---------------------------------------------------------------------------
+# Mode 1 — year-bearing date sitting anywhere in the message. The explicit
+# year disambiguates from ratios; lookarounds keep the regex out of digit
+# runs like phone numbers.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Leading year-bearing date — the original screenshot bug.
+        ("14/05/2026 ăn gà kfc 120k", date(2026, 5, 14)),
+        # Mid-message year-bearing.
+        ("ăn tối 1tr 16/05/2026", date(2026, 5, 16)),
+        # Trailing year-bearing.
+        ("-50k cà phê 02/06/2026", date(2026, 6, 2)),
+        # Dash separator.
+        ("14-05-2026 ăn tối 100k", date(2026, 5, 14)),
+        # Dot separator.
+        ("14.05.2026 ăn tối 100k", date(2026, 5, 14)),
+        # 2-digit year.
+        ("14/05/26 ăn tối 100k", date(2026, 5, 14)),
+        # Money-in shape with leading date.
+        ("15/01/2026 +5tr thưởng tết", date(2026, 1, 15)),
+    ],
+)
+def test_extract_year_bearing_anywhere(text: str, expected: date) -> None:
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None, f"expected a date in {text!r}"
+    assert result.value == expected
+
+
+def test_year_bearing_invalid_returns_none() -> None:
+    # Year-bearing but invalid (31 Feb) → None, caller defaults to today.
+    assert extract_transaction_date("31/02/2026 ăn tối", today=_TODAY) is None
+
+
+def test_year_bearing_inside_digit_run_ignored() -> None:
+    # A phone number must NOT be parsed as a date — lookarounds prevent
+    # the regex from biting into the middle of a digit run.
+    assert extract_transaction_date("gọi 0902/05/2026", today=_TODAY) is None
+
+
+def test_year_bearing_span_covers_only_token() -> None:
+    text = "ăn tối 1tr 16/05/2026"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    start, end = result.span
+    assert text[start:end] == "16/05/2026"
+
+
+def test_keyword_beats_year_bearing_when_both_present() -> None:
+    # Mode 0 wins over Mode 1 because the keyword is the most
+    # authoritative shape.
+    text = "ăn tối ngày 16/05 hôm 25/12/2025 quên"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    assert result.value == date(2026, 5, 16)
+
+
+# ---------------------------------------------------------------------------
+# Mode 2 — leading bare ``dd/mm`` followed by more content, disambiguated
+# by ``day > 12 OR month > 12``. Conservative on purpose: ratios like
+# ``1/2 ổ bánh mì`` or ``12/3 phần`` stay untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected_month,expected_day",
+    [
+        ("14/05 ăn gà 120k", 5, 14),  # day > 12
+        ("25/06 cà phê 50k", 6, 25),  # day > 12
+        ("31/01 tiền lương 5tr", 1, 31),  # day > 12
+    ],
+)
+def test_extract_leading_bare_dd_mm_when_disambiguated(
+    text: str, expected_month: int, expected_day: int
+) -> None:
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None, f"expected a date in {text!r}"
+    assert result.value.month == expected_month
+    assert result.value.day == expected_day
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Both <=12 → ambiguous (could be a ratio). Bail out rather than
+        # risk parsing "1/2 ổ bánh mì 50k" as 1 Feb.
+        "1/2 ổ bánh mì 50k",
+        "12/3 phần pizza 50k",
+        "5/6 ly nước 30k",
+        # Leading dd/mm with NOTHING after — not a transaction shape.
+        "14/05",
+    ],
+)
+def test_leading_bare_dd_mm_rejected_when_ambiguous(text: str) -> None:
+    assert extract_transaction_date(text, today=_TODAY) is None
+
+
+def test_leading_bare_dd_mm_span_covers_only_token() -> None:
+    text = "14/05 ăn gà 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    start, end = result.span
+    assert text[start:end] == "14/05"
+
+
+def test_leading_bare_dd_mm_defaults_to_today_year() -> None:
+    text = "14/05 ăn gà 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    assert result.value.year == _TODAY.year
+
+
+# ---------------------------------------------------------------------------
+# Strip-span integration — the leading-date and trailing-date variants
+# must leave clean merchant text behind.
+# ---------------------------------------------------------------------------
+
+
+def test_strip_span_removes_leading_year_bearing_date() -> None:
+    text = "14/05/2026 ăn gà kfc 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    assert "14/05" not in stripped
+    assert stripped == "ăn gà kfc 120k"
+
+
+def test_strip_span_removes_trailing_year_bearing_date() -> None:
+    text = "-50k cà phê 02/06/2026"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    assert "02/06" not in stripped
+    assert stripped == "-50k cà phê"
+
+
+def test_strip_span_removes_leading_bare_dd_mm() -> None:
+    text = "14/05 ăn gà 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    assert stripped == "ăn gà 120k"


### PR DESCRIPTION
## Summary

Bug from the screenshot: typing `14/05/2026 ăn gà kfc 120k` recorded today (16:40) instead of 14/05/2026. PR #932's date extractor only fired on keyword anchors (`ngày` / `vào ngày` / `hôm`), so a bare leading date had no anchor — and worse, the leading `14/05/2026` then blocked `_SIGNED_TX_RE` and `_AMOUNT_LED_TX_RE` from matching, so the entire Tier-1 fast-path fell through.

The fix lands in two places:

### 1. `transaction_date_extractor.py` — 2 new detection modes

| Mode | Trigger | Disambiguation |
|---|---|---|
| 0 (existing) | `ngày` / `vào ngày` / `hôm` + `dd/mm[/yyyy]` | Keyword is authoritative |
| **1 (new)** | year-bearing `dd/mm/yyyy` (or `dd/mm/yy`) **anywhere** | Explicit year rules out ratios ("ăn 12/3 phần" stays untouched). `(?<!\d)`/`(?!\d)` lookarounds keep the regex out of phone numbers ("0902/05/2026") |
| **2 (new)** | leading bare `dd/mm` followed by more content | Requires **day > 12 OR month > 12** — keeps "1/2 ổ bánh mì 50k" untouched while accepting "14/05 ăn gà 120k" |

Mode 0 still wins when both Mode 0 and Mode 1 are present.

### 2. `_parse_signed_transaction` — strip date **before** sign/amount regex

Previously the date was stripped from the captured `body` *after* `_SIGNED_TX_RE` / `_AMOUNT_LED_TX_RE` had already matched — useless when the leading date prevented matching in the first place. Now we strip the date from the **full text** first, then run the sign/amount-led matchers on the cleaned string.

### Coverage across NLU tiers and transaction types

The same `extract_transaction_date` + `strip_span` pair is already wired into:
- **Tier 1** (this PR): `_parse_signed_transaction` (signed `+/-`, amount-led, bare amounts) AND `_parse_duoc_money_in` (the "được … cho 500k" money-in shape)
- **Tier 1.5** (LLM-JSON fallback) and **Tier 2** (LLM-classified, `action_quick_transaction`): already use `extract_transaction_date(text)` on the full message

So the fix automatically extends to **all transaction shapes — expense AND money-in — across all three NLU tiers** without further changes.

## Test plan

- [x] `pytest backend/tests/test_transaction_date_extractor.py` — 48/48 pass (3 modes, span boundaries, strip-span integration, phone-number / ratio guards, keyword precedence)
- [x] `pytest backend/tests/test_signed_transaction_parser.py` — 36/36 pass (screenshot-bug regression: leading year-bearing date for signed-expense, amount-led-expense, signed-money-in, "được … cho" money-in; trailing year-bearing date; ratio guard)
- [ ] Manual smoke in Telegram (post-merge): `14/05/2026 ăn gà kfc 120k`, `14/05 120k cà phê`, `-50k cà phê 02/06/2026`, `+5tr thưởng tết ngày 15/01/2026`, `được bố cho 500k ngày 15/05/2026` — all must record on the stated date, not today
- [ ] Verify ratios `1/2 ổ bánh mì 50k` and `12/3 phần pizza 50k` still parse as expenses with today's date

### Out of scope (pre-existing failure)

`test_signed_transaction_fast_path.py::test_money_in_always_uses_wizard` fails on the baseline (verified via `git stash` + rerun) — appears to be a regression from PR #944's money-in scaling change, not caused by this PR. Tracking separately.

https://claude.ai/code/session_0185fRYsLs1vkJ2frTTEwnaq

---
_Generated by [Claude Code](https://claude.ai/code/session_0185fRYsLs1vkJ2frTTEwnaq)_