### PR TITLE
fix(source): show user's real e-wallet assets in source picker

### DIFF
--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -36,7 +36,7 @@ from backend.bot.keyboards.transaction_keyboard import (
     category_picker_keyboard,
     confirm_delete_keyboard,
     credit_card_source_keyboard,
-    e_wallet_provider_keyboard,
+    e_wallet_picker_keyboard,
     source_asset_keyboard,
     source_picker_keyboard,
     transaction_actions_keyboard,
@@ -96,18 +96,44 @@ async def _handle_source_selection_callback(
     wallet_provider = None
     if data == "txsrc:bank_pick":
         assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
-        bank_assets = [a for a in assets if (a.subtype or "").lower() in ("bank_checking", "bank_account")]
+        bank_assets = [
+            a
+            for a in assets
+            if (a.subtype or "").lower() in ("bank_checking", "bank_account")
+        ]
         if not bank_assets:
-            await answer_callback(callback_id, text="Bạn chưa có tài khoản thanh toán nào 🌱", show_alert=True)
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có tài khoản thanh toán nào 🌱",
+                show_alert=True,
+            )
             return True
-        await edit_message_reply_markup(chat_id=chat_id, message_id=message_id, reply_markup=source_asset_keyboard(bank_assets))
-        await answer_callback(callback_id)
-        return True
-    if data == "txsrc:e_wallet":
         await edit_message_reply_markup(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=e_wallet_provider_keyboard(),
+            reply_markup=source_asset_keyboard(bank_assets),
+        )
+        await answer_callback(callback_id)
+        return True
+    if data == "txsrc:e_wallet":
+        assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
+        wallet_assets = [
+            a
+            for a in assets
+            if (a.subtype or "").lower()
+            in ("e_wallet", "momo", "vnpay", "zalopay", "viettelpay")
+        ]
+        if not wallet_assets:
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có ví điện tử nào 🌱",
+                show_alert=True,
+            )
+            return True
+        await edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=e_wallet_picker_keyboard(wallet_assets),
         )
         await answer_callback(callback_id)
         return True
@@ -115,14 +141,18 @@ async def _handle_source_selection_callback(
         await edit_message_reply_markup(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=transaction_source_keyboard(draft.get("transaction_type", "expense")),
+            reply_markup=transaction_source_keyboard(
+                draft.get("transaction_type", "expense")
+            ),
         )
         await answer_callback(callback_id)
         return True
     if data == "txsrc:credit_card":
         cards = await list_credit_cards(db, user.id)
         if not cards:
-            await answer_callback(callback_id, text="Bạn chưa có thẻ tín dụng nào 🌱", show_alert=True)
+            await answer_callback(
+                callback_id, text="Bạn chưa có thẻ tín dụng nào 🌱", show_alert=True
+            )
             return True
         await edit_message_reply_markup(
             chat_id=chat_id,
@@ -136,7 +166,7 @@ async def _handle_source_selection_callback(
     selected_card_bank_name = None
     if data.startswith("txsrc_wallet:"):
         source_type = "e_wallet"
-        wallet_provider = data.split(":", 1)[1]
+        source_asset_id = data.split(":", 1)[1]
     elif data.startswith("txsrc_card:"):
         source_type = "credit_card"
         requested_card_id = data.split(":", 1)[1]
@@ -195,19 +225,32 @@ async def _handle_source_selection_callback(
 
     await wizard_service.clear(db, user.id)
     tx_sign = "+" if expense.transaction_type == "money_in" else "-"
-    source_label = {
-        "cash": "Tiền mặt",
-        "bank_account": "Tài khoản",
-        "momo": "Ví Momo",
-        "vnpay": "Ví VNPay",
-        "zalopay": "Ví ZaloPay",
-        "viettelpay": "Ví ViettelPay",
-        "credit_card": (
-            f"Thẻ tín dụng {selected_card_bank_name}"
-            if selected_card_bank_name
-            else "Thẻ tín dụng"
-        ),
-    }.get(wallet_provider or source_type, "không liên kết nguồn")
+    # Render the source label through the canonical resolver so that asset-
+    # backed flows (bank account / e-wallet) print "Tài khoản [<bank>]" or
+    # "Ví điện tử [<name>]" instead of generic words. Credit-card and bare
+    # "no source" cases fall back to the previous behaviour.
+    source_label: str | None = None
+    if source_type:
+        try:
+            source_label = await resolve_source_label_for_expense(db, expense)
+        except Exception:
+            logger.exception("resolve_source_label_for_expense failed (quick tx)")
+            source_label = None
+    if not source_label:
+        if source_type == "credit_card":
+            source_label = (
+                f"Thẻ tín dụng {selected_card_bank_name}"
+                if selected_card_bank_name
+                else "Thẻ tín dụng"
+            )
+        elif source_type == "cash":
+            source_label = "Tiền mặt"
+        elif source_type == "bank_account":
+            source_label = "Tài khoản"
+        elif source_type == "e_wallet":
+            source_label = "Ví điện tử"
+        else:
+            source_label = "không liên kết nguồn"
     confirmation_text = (
         f"Đã ghi nhận {tx_sign}{float(expense.amount):,.0f}đ · {source_label}"
     )
@@ -484,9 +527,7 @@ async def _handle_delete_transaction(
     await answer_callback(callback_id)
 
 
-async def _handle_receipt_category(
-    *, db, user, args, callback_id, chat_id, message_id
-):
+async def _handle_receipt_category(*, db, user, args, callback_id, chat_id, message_id):
     """User picked a category on a pending OCR receipt (before confirming).
 
     Updates the in-memory pending payload and re-renders the confirmation
@@ -801,7 +842,9 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
     if kind == "bank":
         assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
         bank_assets = [
-            a for a in assets if (a.subtype or "").lower() in ("bank_checking", "bank_account")
+            a
+            for a in assets
+            if (a.subtype or "").lower() in ("bank_checking", "bank_account")
         ]
         if not bank_assets:
             await answer_callback(
@@ -828,30 +871,49 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
             ]
         )
         await edit_message_reply_markup(
-            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup={"inline_keyboard": rows},
         )
         await answer_callback(callback_id)
         return
 
     if kind == "wallet":
-        rows = [
+        assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
+        wallet_assets = [
+            a
+            for a in assets
+            if (a.subtype or "").lower()
+            in ("e_wallet", "momo", "vnpay", "zalopay", "viettelpay")
+        ]
+        if not wallet_assets:
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có ví điện tử nào 🌱",
+                show_alert=True,
+            )
+            return
+        rows: list[list[dict]] = [
             [
-                {"text": "Momo", "callback_data": "chsrc_wl:momo"},
-                {"text": "VNPay", "callback_data": "chsrc_wl:vnpay"},
-            ],
-            [
-                {"text": "ZaloPay", "callback_data": "chsrc_wl:zalopay"},
-                {"text": "ViettelPay", "callback_data": "chsrc_wl:viettelpay"},
-            ],
+                {
+                    "text": f"👛 Ví điện tử - {a.name}",
+                    "callback_data": f"chsrc_wl:{a.id}",
+                }
+            ]
+            for a in wallet_assets
+        ]
+        rows.append(
             [
                 {
                     "text": "↩️ Quay lại",
                     "callback_data": f"{CallbackPrefix.CHANGE_SOURCE}:{expense.id}",
                 }
-            ],
-        ]
+            ]
+        )
         await edit_message_reply_markup(
-            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup={"inline_keyboard": rows},
         )
         await answer_callback(callback_id)
         return
@@ -883,7 +945,9 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
             ]
         )
         await edit_message_reply_markup(
-            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup={"inline_keyboard": rows},
         )
         await answer_callback(callback_id)
         return
@@ -919,7 +983,9 @@ async def _handle_change_source_subpicker(
     draft = dict(state.get("draft") or {})
     expense_id_str = draft.get("expense_id")
     if not expense_id_str:
-        await answer_callback(callback_id, text="Yêu cầu này đã hết hạn rồi 🌱", show_alert=True)
+        await answer_callback(
+            callback_id, text="Yêu cầu này đã hết hạn rồi 🌱", show_alert=True
+        )
         return True
 
     expense = await resolve_transaction_by_callback_id(db, user.id, expense_id_str)
@@ -940,12 +1006,12 @@ async def _handle_change_source_subpicker(
             e_wallet_provider=None,
         )
     elif data.startswith("chsrc_wl:"):
-        provider = data.split(":", 1)[1]
+        asset_id = data.split(":", 1)[1]
         update = ExpenseUpdate(
             source_type="e_wallet",
-            e_wallet_provider=provider,
-            source_asset_id=None,
+            source_asset_id=asset_id,
             source_credit_card_id=None,
+            e_wallet_provider=None,
         )
     elif data.startswith("chsrc_cc:"):
         card_id = data.split(":", 1)[1]

--- a/backend/bot/keyboards/transaction_keyboard.py
+++ b/backend/bot/keyboards/transaction_keyboard.py
@@ -269,20 +269,20 @@ def credit_card_source_keyboard(cards: list) -> InlineKeyboardMarkup:
     return {"inline_keyboard": rows}
 
 
-def e_wallet_provider_keyboard() -> InlineKeyboardMarkup:
-    return {
-        "inline_keyboard": [
+def e_wallet_picker_keyboard(wallets: list) -> InlineKeyboardMarkup:
+    rows: list[list[dict]] = []
+    for w in wallets:
+        rows.append(
             [
-                {"text": "Momo", "callback_data": "txsrc_wallet:momo"},
-                {"text": "VNPay", "callback_data": "txsrc_wallet:vnpay"},
-            ],
-            [
-                {"text": "ZaloPay", "callback_data": "txsrc_wallet:zalopay"},
-                {"text": "ViettelPay", "callback_data": "txsrc_wallet:viettelpay"},
-            ],
-            [{"text": "↪️ Bỏ qua nguồn", "callback_data": "txsrc:skip"}],
-        ]
-    }
+                {
+                    "text": f"👛 Ví điện tử - {w.name}",
+                    "callback_data": f"txsrc_wallet:{w.id}",
+                }
+            ]
+        )
+    rows.append([{"text": "↩️ Quay lại chọn nguồn", "callback_data": "txsrc:back"}])
+    rows.append([{"text": "↪️ Bỏ qua nguồn", "callback_data": "txsrc:skip"}])
+    return {"inline_keyboard": rows}
 
 
 def source_asset_keyboard(assets: list) -> InlineKeyboardMarkup:

--- a/backend/services/expense_service.py
+++ b/backend/services/expense_service.py
@@ -245,7 +245,12 @@ async def resolve_source_asset_for_payload(
         provider = data.e_wallet_provider
         if source_type == "e_wallet":
             provider = provider or inferred_provider
-            if provider not in EWALLET_PROVIDERS:
+            # When source_asset_id pins an explicit wallet, the asset row IS the
+            # source of truth — provider is denormalized decoration. Generic
+            # `subtype="e_wallet"` assets (created via the cash wizard) carry no
+            # provider hint, and that's fine: resolve_source_label_for_expense
+            # falls back to asset.name to render "Ví điện tử [<name>]".
+            if provider is not None and provider not in EWALLET_PROVIDERS:
                 raise ValueError("e_wallet_provider is not supported")
         else:
             provider = None
@@ -284,20 +289,33 @@ async def resolve_source_asset_for_payload(
     )
 
 
-
-
 def _source_label(source_type: str | None) -> str:
-    return {"cash": "Tiền mặt", "bank_account": "Tài khoản", "e_wallet": "Ví điện tử"}.get(source_type or "", "Nguồn khác")
+    return {
+        "cash": "Tiền mặt",
+        "bank_account": "Tài khoản",
+        "e_wallet": "Ví điện tử",
+    }.get(source_type or "", "Nguồn khác")
 
 
-async def _create_transaction_record(db: AsyncSession, user_id: uuid.UUID, expense: Expense, *, status: str = "active", original_transaction_id: uuid.UUID | None = None, edited_at: datetime | None = None, reversed_at: datetime | None = None) -> Transaction:
+async def _create_transaction_record(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    expense: Expense,
+    *,
+    status: str = "active",
+    original_transaction_id: uuid.UUID | None = None,
+    edited_at: datetime | None = None,
+    reversed_at: datetime | None = None,
+) -> Transaction:
     tx = Transaction(
         user_id=user_id,
         source_asset_id=expense.source_asset_id,
         source_type=expense.source_type or "expense_category",
         source_label=_source_label(expense.source_type),
         amount=Decimal(str(expense.amount or 0)),
-        direction="inflow" if expense.transaction_type == TRANSACTION_TYPE_MONEY_IN else "outflow",
+        direction="inflow"
+        if expense.transaction_type == TRANSACTION_TYPE_MONEY_IN
+        else "outflow",
         note=expense.note or expense.merchant,
         category=expense.category,
         status=status,
@@ -544,7 +562,9 @@ async def update_expense(
                 db, user_id, merged
             )
             update_data["source_asset_id"] = source_resolution.source_asset_id
-            update_data["source_credit_card_id"] = source_resolution.source_credit_card_id
+            update_data["source_credit_card_id"] = (
+                source_resolution.source_credit_card_id
+            )
             update_data["source_type"] = source_resolution.source_type
             update_data["e_wallet_provider"] = source_resolution.e_wallet_provider
             raw_data = dict(update_data.get("raw_data", expense.raw_data) or {})
@@ -564,7 +584,13 @@ async def update_expense(
     if existing_tx and existing_tx.status == "active":
         existing_tx.status = "edited"
         existing_tx.edited_at = datetime.utcnow()
-    await _create_transaction_record(db, user_id, expense, original_transaction_id=(existing_tx.id if existing_tx else None), edited_at=datetime.utcnow())
+    await _create_transaction_record(
+        db,
+        user_id,
+        expense,
+        original_transaction_id=(existing_tx.id if existing_tx else None),
+        edited_at=datetime.utcnow(),
+    )
 
     await db.refresh(expense)
     return expense

--- a/backend/tests/test_callbacks_change_source.py
+++ b/backend/tests/test_callbacks_change_source.py
@@ -90,6 +90,18 @@ async def test_change_source_wallet_swaps_to_subpicker(monkeypatch):
         "resolve_transaction_by_callback_id",
         AsyncMock(return_value=expense),
     )
+    wallet_one_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    wallet_two_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    wallets = [
+        SimpleNamespace(id=wallet_one_id, name="MoMo cá nhân", subtype="momo"),
+        SimpleNamespace(id=wallet_two_id, name="Ví ZaloPay", subtype="e_wallet"),
+        SimpleNamespace(
+            id="cccccccc-cccc-cccc-cccc-cccccccccccc",
+            name="Vietcombank",
+            subtype="bank_checking",
+        ),
+    ]
+    monkeypatch.setattr(callbacks, "list_assets", AsyncMock(return_value=wallets))
     edit_markup = AsyncMock()
     monkeypatch.setattr(callbacks, "edit_message_reply_markup", edit_markup)
     monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
@@ -105,11 +117,95 @@ async def test_change_source_wallet_swaps_to_subpicker(monkeypatch):
     edit_markup.assert_awaited_once()
     markup = edit_markup.await_args.kwargs["reply_markup"]
     callbacks_data = [
-        btn["callback_data"]
-        for row in markup["inline_keyboard"]
-        for btn in row
+        btn["callback_data"] for row in markup["inline_keyboard"] for btn in row
     ]
-    assert any(cd.startswith("chsrc_wl:momo") for cd in callbacks_data)
+    assert f"chsrc_wl:{wallet_one_id}" in callbacks_data
+    assert f"chsrc_wl:{wallet_two_id}" in callbacks_data
+    # Bank-typed assets must NOT leak into the wallet sub-picker.
+    assert not any(cd.startswith("chsrc_wl:cccccccc") for cd in callbacks_data)
+    labels = [btn["text"] for row in markup["inline_keyboard"] for btn in row]
+    assert any("MoMo cá nhân" in label for label in labels)
+    assert any("Ví ZaloPay" in label for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_change_source_wallet_alerts_when_user_has_no_wallets(monkeypatch):
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    monkeypatch.setattr(callbacks, "list_assets", AsyncMock(return_value=[]))
+    edit_markup = AsyncMock()
+    monkeypatch.setattr(callbacks, "edit_message_reply_markup", edit_markup)
+    answer = AsyncMock()
+    monkeypatch.setattr(callbacks, "answer_callback", answer)
+
+    await callbacks._handle_change_source(
+        db=SimpleNamespace(),
+        user=SimpleNamespace(id=42),
+        args=["tx-1", "wallet"],
+        callback_id="cb1",
+        chat_id=10,
+        message_id=20,
+    )
+
+    edit_markup.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    assert "ví điện tử" in answer.await_args.kwargs.get("text", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_change_source_subpicker_applies_wallet_asset(monkeypatch):
+    """chsrc_wl:<asset_uuid> resolves to source_type=e_wallet + source_asset_id."""
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    updated = SimpleNamespace(id="tx-1", transaction_type="expense")
+
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_source_edit",
+            "step": "pick_kind",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+
+    monkeypatch.setattr(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    update_expense = AsyncMock(return_value=updated)
+    monkeypatch.setattr(callbacks.expense_service, "update_expense", update_expense)
+    clear = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "clear", clear)
+    rerender = AsyncMock()
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", rerender)
+    monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
+
+    wallet_uuid = "22222222-2222-2222-2222-222222222222"
+    callback_query = {
+        "id": "cb1",
+        "data": f"chsrc_wl:{wallet_uuid}",
+        "from": {"id": 7},
+        "message": {"chat": {"id": 10}, "message_id": 20},
+    }
+    handled = await callbacks._handle_change_source_subpicker(
+        SimpleNamespace(), callback_query
+    )
+    assert handled is True
+    update_arg = update_expense.await_args.args[3]
+    assert update_arg.source_type == "e_wallet"
+    assert str(update_arg.source_asset_id) == wallet_uuid
+    assert update_arg.source_credit_card_id is None
+    assert update_arg.e_wallet_provider is None
+    clear.assert_awaited_once()
+    rerender.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -2,26 +2,35 @@
 `txsrc_wallet:*`).
 
 Issue #799 reported that after a user typed "+20 tỷ lương" → tapped
-``e_wallet`` → tapped ``ZaloPay`` (callback ``txsrc_wallet:zalopay``),
-the database write succeeded but no confirmation message was ever sent
-back to Telegram. The user was left staring at the source-picker screen
-with no feedback.
+``e_wallet`` → tapped a wallet, the database write succeeded but no
+confirmation message was ever sent back to Telegram. The user was left
+staring at the source-picker screen with no feedback.
+
+Issue #897 follow-up: the wallet picker is now keyed by ``source_asset_id``
+(real user wallet) instead of a hard-coded provider list, mirroring the
+bank-account flow. ``txsrc_wallet:<asset_uuid>`` pins the asset; the
+confirmation renders "Ví điện tử [<asset.name>]" via
+``resolve_source_label_for_expense``.
 
 These tests pin the contract:
-  - The wallet-provider branch MUST call ``edit_message_text`` to
-    replace the picker with a confirmation line.
+  - The wallet-asset branch MUST call ``edit_message_text`` to replace
+    the picker with a confirmation line.
   - It MUST also fire ``answer_callback`` so the user's tap spinner
     clears.
   - The wizard state is cleared after a successful save.
   - A non-wallet source (``txsrc:cash``) follows the same contract.
-  - The intermediate ``txsrc:e_wallet`` tap swaps the keyboard without
-    creating an expense.
+  - The intermediate ``txsrc:e_wallet`` tap swaps the keyboard to list
+    the user's actual wallet assets without creating an expense.
+  - Empty-wallet users get a friendly alert instead of an empty picker.
 """
+
 from __future__ import annotations
 
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from backend.bot.keyboards.transaction_keyboard import transaction_source_keyboard  # noqa: E402
 
 import pytest
 
@@ -73,45 +82,69 @@ def _expense(transaction_type: str = "money_in", amount: float = 20_000_000_000.
     return expense
 
 
+def _wallet_asset(name: str = "MoMo cá nhân", subtype: str = "e_wallet"):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name=name,
+        subtype=subtype,
+        asset_type="cash",
+        is_active=True,
+    )
+
+
 @pytest.mark.asyncio
-async def test_txsrc_wallet_zalopay_sends_confirmation_message():
-    """The bug: ``txsrc_wallet:zalopay`` wrote to DB but never edited the
-    source-picker message. The user was stuck on the picker screen."""
+async def test_txsrc_wallet_asset_sends_confirmation_with_asset_name():
+    """After tapping a specific wallet asset, the picker is replaced by
+    a confirmation line that includes the asset's display name —
+    "Ví điện tử [<name>]" — rendered via ``resolve_source_label_for_expense``.
+
+    This is the visible contract for Issue #897: the user picked a real
+    wallet (not a provider key), so the bot must echo that wallet back."""
     user = _user()
     db = MagicMock()
     expense = _expense()
+    wallet_id = uuid.uuid4()
 
     edit_text = AsyncMock(return_value={"ok": True})
     answer = AsyncMock()
     send = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ) as create, patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", send
-    ), patch.object(
-        callbacks, "answer_callback", answer
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
-    ) as wizard_clear:
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ) as create,
+        patch.object(
+            callbacks,
+            "resolve_source_label_for_expense",
+            AsyncMock(return_value="Ví điện tử [MoMo cá nhân]"),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()) as wizard_clear,
+    ):
         handled = await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc_wallet:zalopay")
+            db, _callback(f"txsrc_wallet:{wallet_id}")
         )
 
     assert handled is True
     create.assert_awaited_once()
+    payload = create.await_args.args[2]
+    assert payload.source_type == "e_wallet"
+    assert str(payload.source_asset_id) == str(wallet_id)
+    # provider must NOT be set from a hard-coded key — the asset is the truth.
+    assert payload.e_wallet_provider is None
     wizard_clear.assert_awaited_once()
     edit_text.assert_awaited_once()
     edit_kwargs = edit_text.await_args.kwargs
     assert edit_kwargs["chat_id"] == 999
     assert edit_kwargs["message_id"] == 42
     assert "+20,000,000,000" in edit_kwargs["text"]
-    assert "ZaloPay" in edit_kwargs["text"]
+    assert "Ví điện tử [MoMo cá nhân]" in edit_kwargs["text"]
     # No fallback send_message when edit succeeded.
     send.assert_not_awaited()
     answer.assert_awaited_once()
@@ -127,27 +160,32 @@ async def test_txsrc_wallet_falls_back_to_send_when_edit_fails():
     user = _user()
     db = MagicMock()
     expense = _expense()
+    wallet_id = uuid.uuid4()
 
     edit_text = AsyncMock(return_value=None)
     send = AsyncMock()
     answer = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ), patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", send
-    ), patch.object(
-        callbacks, "answer_callback", answer
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ),
+        patch.object(
+            callbacks,
+            "resolve_source_label_for_expense",
+            AsyncMock(return_value="Ví điện tử [ZaloPay nhà]"),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
     ):
         await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc_wallet:zalopay")
+            db, _callback(f"txsrc_wallet:{wallet_id}")
         )
 
     edit_text.assert_awaited_once()
@@ -155,43 +193,51 @@ async def test_txsrc_wallet_falls_back_to_send_when_edit_fails():
     sent_chat_id, sent_text = send.await_args.args[0], send.await_args.args[1]
     assert sent_chat_id == 999
     assert "+20,000,000,000" in sent_text
-    assert "ZaloPay" in sent_text
+    assert "Ví điện tử [ZaloPay nhà]" in sent_text
     answer.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_txsrc_wallet_uses_provider_label_for_each_wallet():
-    """Every wallet provider gets a friendly label, not the raw key."""
+async def test_txsrc_wallet_uses_asset_name_for_each_wallet():
+    """The asset-keyed flow honours every wallet's own display name —
+    whether it's a named provider asset (MoMo, ZaloPay…) or a generic
+    user-created e_wallet asset. No hardcoded provider-label table."""
     user = _user()
     db = MagicMock()
     expense = _expense()
 
     cases = [
-        ("momo", "Momo"),
-        ("vnpay", "VNPay"),
-        ("zalopay", "ZaloPay"),
-        ("viettelpay", "ViettelPay"),
+        "Ví điện tử [MoMo cá nhân]",
+        "Ví điện tử [VNPay công ty]",
+        "Ví điện tử [ZaloPay vợ]",
+        "Ví điện tử [Ví của bé]",  # user-created generic subtype
     ]
-    for provider, expected_label in cases:
+    for expected_label in cases:
         # Wizard state must look "active" each round because
         # ``wizard_service.clear`` is the production teardown.
         user.wizard_state = _money_in_state()
+        wallet_id = uuid.uuid4()
         edit_text = AsyncMock(return_value={"ok": True})
-        with patch.object(
-            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-        ), patch.object(
-            callbacks.expense_service,
-            "create_expense",
-            AsyncMock(return_value=expense),
-        ), patch.object(
-            callbacks, "edit_message_text", edit_text
-        ), patch.object(
-            callbacks, "answer_callback", AsyncMock()
-        ), patch(
-            "backend.services.wizard_service.clear", AsyncMock()
+        with (
+            patch.object(
+                callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+            ),
+            patch.object(
+                callbacks.expense_service,
+                "create_expense",
+                AsyncMock(return_value=expense),
+            ),
+            patch.object(
+                callbacks,
+                "resolve_source_label_for_expense",
+                AsyncMock(return_value=expected_label),
+            ),
+            patch.object(callbacks, "edit_message_text", edit_text),
+            patch.object(callbacks, "answer_callback", AsyncMock()),
+            patch("backend.services.wizard_service.clear", AsyncMock()),
         ):
             await callbacks._handle_source_selection_callback(
-                db, _callback(f"txsrc_wallet:{provider}")
+                db, _callback(f"txsrc_wallet:{wallet_id}")
             )
         edit_text.assert_awaited_once()
         assert expected_label in edit_text.await_args.kwargs["text"]
@@ -207,20 +253,24 @@ async def test_txsrc_cash_sends_confirmation_message():
 
     edit_text = AsyncMock(return_value={"ok": True})
     answer = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ), patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", AsyncMock()
-    ), patch.object(
-        callbacks, "answer_callback", answer
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ),
+        patch.object(
+            callbacks,
+            "resolve_source_label_for_expense",
+            AsyncMock(return_value="Tiền mặt"),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", AsyncMock()),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
     ):
         handled = await callbacks._handle_source_selection_callback(
             db, _callback("txsrc:cash")
@@ -241,45 +291,49 @@ async def test_txsrc_skip_still_sends_confirmation_message():
     expense = _expense()
 
     edit_text = AsyncMock(return_value={"ok": True})
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ), patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", AsyncMock()
-    ), patch.object(
-        callbacks, "answer_callback", AsyncMock()
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", AsyncMock()),
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
     ):
-        await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc:skip")
-        )
+        await callbacks._handle_source_selection_callback(db, _callback("txsrc:skip"))
     edit_text.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_txsrc_e_wallet_swaps_keyboard_without_creating_expense():
-    """The intermediate ``txsrc:e_wallet`` tap just replaces the keyboard
-    with the wallet-provider picker. It must NOT call ``create_expense``."""
+async def test_txsrc_e_wallet_lists_user_wallets_in_keyboard():
+    """The intermediate ``txsrc:e_wallet`` tap swaps the keyboard to a
+    picker listing the user's actual wallet assets — NOT a hardcoded
+    provider list. Each row carries ``txsrc_wallet:<asset_uuid>``.
+
+    The handler must NOT call ``create_expense``: it's just a sub-menu."""
     user = _user()
     db = MagicMock()
+    wallets = [
+        _wallet_asset(name="MoMo cá nhân", subtype="e_wallet"),
+        _wallet_asset(name="ZaloPay vợ", subtype="zalopay"),
+    ]
 
     edit_markup = AsyncMock()
     answer = AsyncMock()
     create = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service, "create_expense", create
-    ), patch.object(
-        callbacks, "edit_message_reply_markup", edit_markup
-    ), patch.object(
-        callbacks, "answer_callback", answer
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_assets", AsyncMock(return_value=wallets)),
+        patch.object(callbacks.expense_service, "create_expense", create),
+        patch.object(callbacks, "edit_message_reply_markup", edit_markup),
+        patch.object(callbacks, "answer_callback", answer),
     ):
         handled = await callbacks._handle_source_selection_callback(
             db, _callback("txsrc:e_wallet")
@@ -289,6 +343,89 @@ async def test_txsrc_e_wallet_swaps_keyboard_without_creating_expense():
     create.assert_not_awaited()
     edit_markup.assert_awaited_once()
     answer.assert_awaited_once()
+    kb = edit_markup.await_args.kwargs["reply_markup"]["inline_keyboard"]
+    # First N rows = one button per wallet asset.
+    labels = [row[0]["text"] for row in kb[: len(wallets)]]
+    assert "MoMo cá nhân" in labels[0]
+    assert "ZaloPay vợ" in labels[1]
+    callback_data = [row[0]["callback_data"] for row in kb[: len(wallets)]]
+    assert callback_data[0] == f"txsrc_wallet:{wallets[0].id}"
+    assert callback_data[1] == f"txsrc_wallet:{wallets[1].id}"
+
+
+@pytest.mark.asyncio
+async def test_txsrc_e_wallet_alerts_when_user_has_no_wallets():
+    """If the user taps "👛 Ví điện tử" but owns no wallet assets, the
+    handler must surface a friendly alert (mirrors the bank-account
+    empty-state at ``txsrc:bank_pick``) — not show an empty keyboard.
+
+    The expense MUST NOT be created in this branch."""
+    user = _user()
+    db = MagicMock()
+
+    answer = AsyncMock()
+    create = AsyncMock()
+    edit_markup = AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_assets", AsyncMock(return_value=[])),
+        patch.object(callbacks.expense_service, "create_expense", create),
+        patch.object(callbacks, "edit_message_reply_markup", edit_markup),
+        patch.object(callbacks, "answer_callback", answer),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:e_wallet")
+        )
+
+    assert handled is True
+    create.assert_not_awaited()
+    edit_markup.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    assert "ví điện tử" in (answer.await_args.kwargs.get("text") or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_e_wallet_filters_non_wallet_assets():
+    """``list_assets(asset_type="cash")`` returns ALL cash-family rows
+    (bank_checking, cash, e_wallet, momo…). The handler must filter to
+    wallet-only subtypes before rendering the picker, otherwise the user
+    would see their checking account in the wallet picker."""
+    user = _user()
+    db = MagicMock()
+    mixed = [
+        _wallet_asset(name="VCB checking", subtype="bank_checking"),
+        _wallet_asset(name="Tiền mặt", subtype="cash"),
+        _wallet_asset(name="MoMo cá nhân", subtype="e_wallet"),
+        _wallet_asset(name="ZaloPay vợ", subtype="zalopay"),
+    ]
+
+    edit_markup = AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_assets", AsyncMock(return_value=mixed)),
+        patch.object(callbacks, "edit_message_reply_markup", edit_markup),
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+    ):
+        await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:e_wallet")
+        )
+
+    edit_markup.assert_awaited_once()
+    kb = edit_markup.await_args.kwargs["reply_markup"]["inline_keyboard"]
+    # Only the two wallet assets should appear as picker rows. The trailing
+    # rows are "Back" / "Skip" controls.
+    wallet_rows = [
+        row for row in kb if row and row[0]["callback_data"].startswith("txsrc_wallet:")
+    ]
+    assert len(wallet_rows) == 2
+    labels = [row[0]["text"] for row in wallet_rows]
+    assert "MoMo cá nhân" in labels[0]
+    assert "ZaloPay vợ" in labels[1]
 
 
 @pytest.mark.asyncio
@@ -300,15 +437,16 @@ async def test_stale_wizard_state_does_not_call_create_expense():
 
     create = AsyncMock()
     answer = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service, "create_expense", create
-    ), patch.object(
-        callbacks, "answer_callback", answer
+    wallet_id = uuid.uuid4()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks.expense_service, "create_expense", create),
+        patch.object(callbacks, "answer_callback", answer),
     ):
         handled = await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc_wallet:zalopay")
+            db, _callback(f"txsrc_wallet:{wallet_id}")
         )
 
     assert handled is True
@@ -319,18 +457,31 @@ async def test_stale_wizard_state_does_not_call_create_expense():
 
 @pytest.mark.asyncio
 async def test_txsrc_credit_card_shows_all_cards_for_expense_only():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {"amount": 200000.0, "transaction_type": "expense"},
+        }
+    )
     db = MagicMock()
     cards = [
         SimpleNamespace(id=uuid.uuid4(), bank_name="VCB"),
         SimpleNamespace(id=uuid.uuid4(), bank_name="ACB"),
     ]
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=cards)),          patch.object(callbacks, "edit_message_reply_markup", AsyncMock()) as edit_markup,          patch.object(callbacks, "answer_callback", AsyncMock()):
-        handled = await callbacks._handle_source_selection_callback(db, _callback("txsrc:credit_card"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=cards)),
+        patch.object(
+            callbacks, "edit_message_reply_markup", AsyncMock()
+        ) as edit_markup,
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:credit_card")
+        )
 
     assert handled is True
     kb = edit_markup.await_args.kwargs["reply_markup"]["inline_keyboard"]
@@ -340,17 +491,41 @@ async def test_txsrc_credit_card_shows_all_cards_for_expense_only():
 
 @pytest.mark.asyncio
 async def test_txsrc_card_select_confirmation_mentions_bank_name():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {
+                "amount": 200000.0,
+                "transaction_type": "expense",
+                "merchant": "test",
+            },
+        }
+    )
     db = MagicMock()
     expense = _expense(transaction_type="expense", amount=200000.0)
     card_id = uuid.uuid4()
     card = SimpleNamespace(id=card_id, bank_name="MSB")
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[card])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)),          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})) as edit_text,          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
-        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[card])),
+        patch.object(
+            callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)
+        ),
+        patch.object(
+            callbacks, "resolve_source_label_for_expense", AsyncMock(return_value=None)
+        ),
+        patch.object(
+            callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})
+        ) as edit_text,
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_card:{card_id}")
+        )
 
     assert handled is True
     assert "Thẻ tín dụng MSB" in edit_text.await_args.kwargs["text"]
@@ -358,16 +533,44 @@ async def test_txsrc_card_select_confirmation_mentions_bank_name():
 
 @pytest.mark.asyncio
 async def test_txsrc_card_select_creates_expense_with_credit_card_source():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {
+                "amount": 200000.0,
+                "transaction_type": "expense",
+                "merchant": "test",
+            },
+        }
+    )
     db = MagicMock()
     expense = _expense(transaction_type="expense", amount=200000.0)
     card_id = uuid.uuid4()
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[SimpleNamespace(id=card_id, bank_name="VCB")])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)) as create,          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})),          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
-        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks,
+            "list_credit_cards",
+            AsyncMock(return_value=[SimpleNamespace(id=card_id, bank_name="VCB")]),
+        ),
+        patch.object(
+            callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)
+        ) as create,
+        patch.object(
+            callbacks, "resolve_source_label_for_expense", AsyncMock(return_value=None)
+        ),
+        patch.object(
+            callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})
+        ),
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_card:{card_id}")
+        )
 
     assert handled is True
     payload = create.await_args.args[2]
@@ -377,26 +580,43 @@ async def test_txsrc_card_select_creates_expense_with_credit_card_source():
 
 @pytest.mark.asyncio
 async def test_txsrc_card_select_rejects_unknown_card_id():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {
+                "amount": 200000.0,
+                "transaction_type": "expense",
+                "merchant": "test",
+            },
+        }
+    )
     db = MagicMock()
     card_id = uuid.uuid4()
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock()) as create,          patch.object(callbacks, "answer_callback", AsyncMock()) as answer:
-        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[])),
+        patch.object(
+            callbacks.expense_service, "create_expense", AsyncMock()
+        ) as create,
+        patch.object(callbacks, "answer_callback", AsyncMock()) as answer,
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_card:{card_id}")
+        )
 
     assert handled is True
     create.assert_not_awaited()
     answer.assert_awaited_once()
     assert "không hợp lệ" in (answer.await_args.kwargs.get("text") or "").lower()
 
-from backend.bot.keyboards.transaction_keyboard import transaction_source_keyboard
 
 def test_tx_source_keyboard_expense_includes_credit_card():
     kb = transaction_source_keyboard("expense")["inline_keyboard"]
     assert any(btn["callback_data"] == "txsrc:credit_card" for row in kb for btn in row)
+
 
 def test_tx_source_keyboard_money_in_excludes_credit_card():
     kb = transaction_source_keyboard("money_in")["inline_keyboard"]
@@ -407,6 +627,24 @@ def test_tx_source_keyboard_money_in_excludes_credit_card():
 async def test_handle_transaction_callback_routes_txsrc_bank_prefix():
     db = MagicMock()
     cb = _callback(f"txsrc_bank:{uuid.uuid4()}")
+    with patch.object(
+        callbacks,
+        "_handle_source_selection_callback",
+        AsyncMock(return_value=True),
+    ) as source_handler:
+        handled = await callbacks.handle_transaction_callback(db, cb)
+
+    assert handled is True
+    source_handler.assert_awaited_once_with(db, cb)
+
+
+@pytest.mark.asyncio
+async def test_handle_transaction_callback_routes_txsrc_wallet_prefix():
+    """Regression: ``txsrc_wallet:<uuid>`` must hit the source-selection
+    handler — not fall through to the generic callback dispatcher.
+    Otherwise the user's wallet tap silently no-ops."""
+    db = MagicMock()
+    cb = _callback(f"txsrc_wallet:{uuid.uuid4()}")
     with patch.object(
         callbacks,
         "_handle_source_selection_callback",


### PR DESCRIPTION
## Bug

Screenshot from operator: `-199 tỷ` typed against an e-wallet showed a hard-coded provider picker (Momo / VNPay / ZaloPay / ViettelPay) instead of the user's actual wallet assets. Tapping any button selected a provider *key* — not a real `Asset.id` — so the resulting expense landed with `source_asset_id = NULL` and the confirmation could not render "Ví điện tử [tên ví]".

Two duplicate bug sites:
- Quick transaction wizard (`txsrc:e_wallet` → `txsrc_wallet:<provider>`)
- Edit-source flow (`chsrc:wallet` → `chsrc_wl:<provider>`)

The bank-account path was already correct (`txsrc:bank_pick` → `txsrc_bank:<asset_uuid>` → "Tài khoản thanh toán [Vietcombank]"). E-wallet just never got the same treatment.

## Fix

Mirror the bank flow on both entry points:

| Step | Bank (already correct) | E-wallet (now) |
|---|---|---|
| Tap source kind | `txsrc:bank_pick` | `txsrc:e_wallet` |
| Sub-picker | `source_asset_keyboard(assets)` | `e_wallet_picker_keyboard(wallets)` |
| Asset callback | `txsrc_bank:<asset_uuid>` | `txsrc_wallet:<asset_uuid>` |
| Confirmation label | "Tài khoản thanh toán [Vietcombank]" | "Ví điện tử [MoMo cá nhân]" |

Both sub-pickers filter `Asset` rows where `asset_type="cash"` and `subtype ∈ {e_wallet, momo, vnpay, zalopay, viettelpay}` so legacy provider-named assets *and* generic user-created e-wallets show up. Empty-wallet users get a friendly alert ("Bạn chưa có ví điện tử nào 🌱") instead of an empty picker.

### Service-layer relaxation

`resolve_source_asset_for_payload` previously rejected `e_wallet_provider` values outside the four known providers. That made generic `subtype="e_wallet"` assets (the wizard-created ones) impossible to use as a source. Provider is now treated as optional decoration when `source_asset_id` pins the wallet — the asset row itself is the source of truth, and `resolve_source_label_for_expense` falls back to `asset.name` for display.

### Coverage of both entry points (per the bug report)

- Quick transaction (`+/-` syntax) — `_handle_source_selection_callback`
- NLP path — `message.py` opens the same `transaction_source_select` wizard, so it routes through the identical callbacks.
- Inline-keyboard edit (`💳` button on a confirmed expense) — `_handle_change_source` + `_handle_change_source_subpicker`.

## Tests

24 callbacks tests pass (8 new):
- `test_txsrc_e_wallet_lists_user_wallets_in_keyboard` — picker dynamically lists user's wallets
- `test_txsrc_e_wallet_alerts_when_user_has_no_wallets` — empty-state alert
- `test_txsrc_e_wallet_filters_non_wallet_assets` — bank/cash assets filtered out
- `test_txsrc_wallet_asset_sends_confirmation_with_asset_name` — payload pins `source_asset_id`, label uses asset name
- `test_txsrc_wallet_falls_back_to_send_when_edit_fails` — Telegram 4xx fallback
- `test_txsrc_wallet_uses_asset_name_for_each_wallet` — every wallet renders its own name
- `test_change_source_wallet_swaps_to_subpicker` — edit flow lists real wallets
- `test_change_source_wallet_alerts_when_user_has_no_wallets` — edit-flow empty state
- `test_change_source_subpicker_applies_wallet_asset` — `chsrc_wl:<uuid>` writes `source_type=e_wallet` + `source_asset_id`
- `test_handle_transaction_callback_routes_txsrc_wallet_prefix` — routing regression

## Test plan
- [ ] Operator types `-199 tỷ` against a user with one or more e-wallet assets and confirms the picker lists those wallets (not hard-coded provider names).
- [ ] Tapping a wallet writes an expense with `source_asset_id` pointing at the picked wallet and the confirmation reads "Ví điện tử [tên ví]".
- [ ] Operator with zero e-wallet assets sees the "Bạn chưa có ví điện tử nào 🌱" alert.
- [ ] Inline edit (💳 button) on an existing expense reaches the same wallet sub-picker and applies correctly.
- [ ] NLP path ("trừ 50k MoMo") opens the same wizard and resolves to a real asset.


---
_Generated by [Claude Code](https://claude.ai/code/session_011sbJgCkYkgNbD1V9S2Z5A2)_