### PR TITLE
fix(source): unstuck wallet source picker (#948)

### DIFF
--- a/alembic/versions/20260605_relax_wallet_provider_constraint_948.py
+++ b/alembic/versions/20260605_relax_wallet_provider_constraint_948.py
@@ -1,0 +1,63 @@
+"""relax wallet provider constraint when source_asset_id pins the wallet
+
+Revision ID: 20260605relaxwalletck
+Revises: 20260530defaultmoneyinsource
+Create Date: 2026-06-05
+
+Issue #948: tapping an e-wallet asset in the source picker failed with
+``IntegrityError`` on ``ck_expenses_wallet_source_consistency`` because
+the picker only stores ``source_asset_id`` (the wallet asset row already
+identifies the provider) and intentionally leaves ``e_wallet_provider``
+NULL. The old constraint required ``e_wallet_provider IS NOT NULL``
+whenever ``source_type='e_wallet'``, which contradicts the code path.
+
+This migration relaxes the constraint so the provider column may be
+NULL when ``source_asset_id`` is set — the asset row is the source of
+truth in that case. The provider column remains required when the
+expense is tagged as an e-wallet payment without a linked asset.
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20260605relaxwalletck"
+down_revision = "20260530defaultmoneyinsource"
+branch_labels = None
+depends_on = None
+
+
+_OLD_CONSTRAINT = (
+    "(source_type = 'e_wallet' AND e_wallet_provider IS NOT NULL) OR "
+    "((source_type IS NULL OR source_type <> 'e_wallet') AND "
+    "e_wallet_provider IS NULL)"
+)
+
+_NEW_CONSTRAINT = (
+    "(source_type = 'e_wallet' AND "
+    "(e_wallet_provider IS NOT NULL OR source_asset_id IS NOT NULL)) OR "
+    "((source_type IS NULL OR source_type <> 'e_wallet') AND "
+    "e_wallet_provider IS NULL)"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_expenses_wallet_source_consistency", "expenses", type_="check"
+    )
+    op.create_check_constraint(
+        "ck_expenses_wallet_source_consistency",
+        "expenses",
+        _NEW_CONSTRAINT,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_expenses_wallet_source_consistency", "expenses", type_="check"
+    )
+    op.create_check_constraint(
+        "ck_expenses_wallet_source_consistency",
+        "expenses",
+        _OLD_CONSTRAINT,
+    )

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -220,9 +220,32 @@ async def _handle_source_selection_callback(
         source_asset_id=source_asset_id,
         expense_date=expense_date_value,
     )
-    expense = await expense_service.create_expense(db, user.id, expense_data)
-    from backend.services import wizard_service
-
+    # Issue #948 safety net: if the write fails (e.g. DB check-constraint
+    # violation on the e_wallet flow), the user must still get feedback —
+    # otherwise the tapped button spins forever while the worker silently
+    # marks the update as failed.
+    try:
+        expense = await expense_service.create_expense(db, user.id, expense_data)
+    except Exception:
+        logger.exception(
+            "create_expense failed in source-selection flow for user %s (data=%s)",
+            user.id,
+            data,
+        )
+        await wizard_service.clear(db, user.id)
+        await answer_callback(
+            callback_id,
+            text="Mình chưa ghi được giao dịch này 🌱 Bạn gõ lại giúp mình nhé.",
+            show_alert=True,
+        )
+        if chat_id is not None:
+            await send_message(
+                chat_id,
+                "Mình chưa ghi được giao dịch vừa rồi 🌱 Bạn gõ lại giúp "
+                "mình nhé — nếu lặp lại, thử chọn nguồn khác xem sao.",
+                parse_mode=None,
+            )
+        return True
     await wizard_service.clear(db, user.id)
     tx_sign = "+" if expense.transaction_type == "money_in" else "-"
     # Render the source label through the canonical resolver so that asset-
@@ -1025,7 +1048,33 @@ async def _handle_change_source_subpicker(
         await answer_callback(callback_id)
         return True
 
-    updated = await expense_service.update_expense(db, user.id, expense.id, update)
+    # Issue #948 safety net: a failed update (e.g. DB check-constraint
+    # violation on the e_wallet flow) must not leave the user with a
+    # stuck spinner on the source-change picker.
+    try:
+        updated = await expense_service.update_expense(
+            db, user.id, expense.id, update
+        )
+    except Exception:
+        logger.exception(
+            "update_expense failed in change-source flow for user %s (data=%s)",
+            user.id,
+            data,
+        )
+        await wizard_service.clear(db, user.id)
+        await answer_callback(
+            callback_id,
+            text="Mình chưa đổi được nguồn tiền 🌱 Bạn thử lại giúp mình nhé.",
+            show_alert=True,
+        )
+        if chat_id is not None:
+            await send_message(
+                chat_id,
+                "Mình chưa đổi được nguồn tiền 🌱 Bạn thử lại giúp mình "
+                "nhé — nếu lặp lại, chọn nguồn khác xem sao.",
+                parse_mode=None,
+            )
+        return True
     await wizard_service.clear(db, user.id)
     if updated is None:
         await answer_callback(

--- a/backend/tests/test_callbacks_change_source.py
+++ b/backend/tests/test_callbacks_change_source.py
@@ -277,4 +277,67 @@ async def test_change_source_subpicker_rejects_when_not_in_flow(monkeypatch):
     )
     assert handled is True
     answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_change_source_subpicker_update_failure_alerts_user(monkeypatch):
+    """Issue #948 safety net for the change-source flow: when
+    ``update_expense`` raises (e.g. DB check-constraint violation on
+    the e_wallet flow), the picker must surface a friendly alert and a
+    chat fallback rather than leaving the user staring at a stuck spinner.
+
+    Contract mirrors the create_expense safety net:
+      - ``answer_callback`` fires with ``show_alert=True`` and a Bé Tiền-
+        tone Vietnamese message.
+      - A chat ``send_message`` fallback follows.
+      - The wizard state is cleared.
+      - The re-render is skipped (no successful update to render).
+    """
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_source_edit",
+            "step": "pick_kind",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+
+    monkeypatch.setattr(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    boom = AsyncMock(side_effect=RuntimeError("simulated IntegrityError"))
+    monkeypatch.setattr(callbacks.expense_service, "update_expense", boom)
+    clear = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "clear", clear)
+    rerender = AsyncMock()
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", rerender)
+    answer = AsyncMock()
+    monkeypatch.setattr(callbacks, "answer_callback", answer)
+    send = AsyncMock()
+    monkeypatch.setattr(callbacks, "send_message", send)
+
+    callback_query = {
+        "id": "cb1",
+        "data": "chsrc_wl:22222222-2222-2222-2222-222222222222",
+        "from": {"id": 7},
+        "message": {"chat": {"id": 10}, "message_id": 20},
+    }
+    handled = await callbacks._handle_change_source_subpicker(
+        SimpleNamespace(), callback_query
+    )
+
+    assert handled is True
+    rerender.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    alert_text = (answer.await_args.kwargs.get("text") or "").lower()
+    assert "chưa đổi" in alert_text or "không đổi" in alert_text
+    send.assert_awaited_once()
+    clear.assert_awaited_once()
     assert answer.await_args.kwargs.get("show_alert") is True

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -654,3 +654,87 @@ async def test_handle_transaction_callback_routes_txsrc_wallet_prefix():
 
     assert handled is True
     source_handler.assert_awaited_once_with(db, cb)
+
+
+@pytest.mark.asyncio
+async def test_create_expense_failure_alerts_user_and_clears_wizard():
+    """Issue #948 safety net: when ``create_expense`` raises (e.g. DB
+    check-constraint violation on the e_wallet flow), the user must NOT
+    be left staring at a stuck spinner.
+
+    Contract:
+      - ``answer_callback`` fires with ``show_alert=True`` and a friendly
+        Vietnamese message (Bé Tiền tone — no harsh wording).
+      - A chat fallback ``send_message`` follows so the message survives
+        the alert dismiss.
+      - The wizard state is cleared so the user can retry from scratch.
+      - The handler returns ``True`` so the dispatcher stops processing.
+    """
+    user = _user()
+    db = MagicMock()
+    wallet_id = uuid.uuid4()
+
+    answer = AsyncMock()
+    send = AsyncMock()
+    edit_text = AsyncMock()
+    boom = AsyncMock(side_effect=RuntimeError("simulated IntegrityError"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks.expense_service, "create_expense", boom),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()) as wizard_clear,
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_wallet:{wallet_id}")
+        )
+
+    assert handled is True
+    # The picker message is NOT edited on failure — the user gets a fresh
+    # chat message + alert instead.
+    edit_text.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    alert_text = (answer.await_args.kwargs.get("text") or "").lower()
+    # Friendly Bé Tiền tone — never harsh.
+    assert "chưa ghi" in alert_text or "không ghi" in alert_text
+    send.assert_awaited_once()
+    sent_text = send.await_args.args[1].lower()
+    assert "chưa ghi" in sent_text or "không ghi" in sent_text
+    wizard_clear.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_expense_failure_does_not_crash_without_chat_id():
+    """If Telegram somehow delivers a callback without a chat (rare —
+    shouldn't happen for inline keyboards but is defensively guarded),
+    the safety net must still alert the user via ``answer_callback``
+    without raising on the missing ``chat_id``."""
+    user = _user()
+    db = MagicMock()
+    wallet_id = uuid.uuid4()
+
+    cb = _callback(f"txsrc_wallet:{wallet_id}")
+    cb["message"] = {}  # no chat key — chat_id resolves to None
+
+    answer = AsyncMock()
+    send = AsyncMock()
+    boom = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks.expense_service, "create_expense", boom),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(db, cb)
+
+    assert handled is True
+    answer.assert_awaited_once()
+    # No chat to send a fallback into — skip silently rather than crash.
+    send.assert_not_awaited()


### PR DESCRIPTION
Closes #948.

## What was broken

Tapping an e-wallet asset in the source picker left users staring at a silent spinner. Two interacting bugs:

1. **Constraint mismatch (root cause).** The source picker stores `source_asset_id` and intentionally leaves `e_wallet_provider` NULL — the wallet asset row already identifies the provider. But `ck_expenses_wallet_source_consistency` demanded a non-NULL provider whenever `source_type='e_wallet'`, so every insert blew up with `IntegrityError`.
2. **Silent failure.** The worker's `process_update_safely` swallows exceptions, so the handler never reached `answer_callback`. The user got no feedback at all.

## Fix

- **Migration `20260605_relax_wallet_provider_constraint_948.py`** — relax `ck_expenses_wallet_source_consistency` so `e_wallet_provider` may be NULL when `source_asset_id` is set. The asset row is the source of truth in that case. Provider remains required when the expense is tagged as e-wallet without a linked asset.
- **Handler safety nets** in `_handle_source_selection_callback` and `_handle_change_source_subpicker` — wrap `create_expense` / `update_expense` in try/except. On failure: log via `logger.exception`, clear the wizard, alert with a warm Bé Tiền message (`"Mình chưa ghi được giao dịch này 🌱 Bạn gõ lại giúp mình nhé."` / `"Mình chưa đổi được nguồn tiền 🌱 Bạn thử lại giúp mình nhé."`), send a chat fallback, return True. Even if a future DB error sneaks in, the UI never hangs again.

## Tests

3 new regression tests (all green, full suite for both files passes 27/27):

- `test_create_expense_failure_alerts_user_and_clears_wizard` — mocks `create_expense` raising; asserts `edit_message_text` NOT awaited, `answer_callback` awaited with `show_alert=True` and friendly Vietnamese, `send_message` awaited, wizard cleared.
- `test_create_expense_failure_does_not_crash_without_chat_id` — no `chat` key in callback message; still alerts via `answer_callback`, skips `send_message`.
- `test_change_source_subpicker_update_failure_alerts_user` — mirror for the change-source flow.

## Test plan

- [x] `pytest backend/tests/test_callbacks_source_selection.py backend/tests/test_callbacks_change_source.py -v` → 27 passed
- [ ] `alembic upgrade head` on staging — confirm constraint relaxed and the failing case from #948 now inserts cleanly
- [ ] Tap an e-wallet asset in the source picker end-to-end on staging

## Notes

- Secondary bug in #948 (the `199,000,000,000,000 VND` amount from the same screenshot) is **not** addressed here — it's an amount-parser issue and warrants its own investigation.

https://claude.ai/code/session_018kTay4GbXrFUWz5hkNjpWc

---
_Generated by [Claude Code](https://claude.ai/code/session_018kTay4GbXrFUWz5hkNjpWc)_