### PR TITLE
Release 1.4.4.12 — merge main into prod (11th release)

### DIFF
--- a/alembic/versions/20260605_relax_wallet_provider_constraint_948.py
+++ b/alembic/versions/20260605_relax_wallet_provider_constraint_948.py
@@ -1,0 +1,63 @@
+"""relax wallet provider constraint when source_asset_id pins the wallet
+
+Revision ID: 20260605relaxwalletck
+Revises: 20260530defaultmoneyinsource
+Create Date: 2026-06-05
+
+Issue #948: tapping an e-wallet asset in the source picker failed with
+``IntegrityError`` on ``ck_expenses_wallet_source_consistency`` because
+the picker only stores ``source_asset_id`` (the wallet asset row already
+identifies the provider) and intentionally leaves ``e_wallet_provider``
+NULL. The old constraint required ``e_wallet_provider IS NOT NULL``
+whenever ``source_type='e_wallet'``, which contradicts the code path.
+
+This migration relaxes the constraint so the provider column may be
+NULL when ``source_asset_id`` is set — the asset row is the source of
+truth in that case. The provider column remains required when the
+expense is tagged as an e-wallet payment without a linked asset.
+"""
+
+from alembic import op
+
+
+# revision identifiers, used by Alembic.
+revision = "20260605relaxwalletck"
+down_revision = "20260530defaultmoneyinsource"
+branch_labels = None
+depends_on = None
+
+
+_OLD_CONSTRAINT = (
+    "(source_type = 'e_wallet' AND e_wallet_provider IS NOT NULL) OR "
+    "((source_type IS NULL OR source_type <> 'e_wallet') AND "
+    "e_wallet_provider IS NULL)"
+)
+
+_NEW_CONSTRAINT = (
+    "(source_type = 'e_wallet' AND "
+    "(e_wallet_provider IS NOT NULL OR source_asset_id IS NOT NULL)) OR "
+    "((source_type IS NULL OR source_type <> 'e_wallet') AND "
+    "e_wallet_provider IS NULL)"
+)
+
+
+def upgrade() -> None:
+    op.drop_constraint(
+        "ck_expenses_wallet_source_consistency", "expenses", type_="check"
+    )
+    op.create_check_constraint(
+        "ck_expenses_wallet_source_consistency",
+        "expenses",
+        _NEW_CONSTRAINT,
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "ck_expenses_wallet_source_consistency", "expenses", type_="check"
+    )
+    op.create_check_constraint(
+        "ck_expenses_wallet_source_consistency",
+        "expenses",
+        _OLD_CONSTRAINT,
+    )

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -220,9 +220,32 @@ async def _handle_source_selection_callback(
         source_asset_id=source_asset_id,
         expense_date=expense_date_value,
     )
-    expense = await expense_service.create_expense(db, user.id, expense_data)
-    from backend.services import wizard_service
-
+    # Issue #948 safety net: if the write fails (e.g. DB check-constraint
+    # violation on the e_wallet flow), the user must still get feedback —
+    # otherwise the tapped button spins forever while the worker silently
+    # marks the update as failed.
+    try:
+        expense = await expense_service.create_expense(db, user.id, expense_data)
+    except Exception:
+        logger.exception(
+            "create_expense failed in source-selection flow for user %s (data=%s)",
+            user.id,
+            data,
+        )
+        await wizard_service.clear(db, user.id)
+        await answer_callback(
+            callback_id,
+            text="Mình chưa ghi được giao dịch này 🌱 Bạn gõ lại giúp mình nhé.",
+            show_alert=True,
+        )
+        if chat_id is not None:
+            await send_message(
+                chat_id,
+                "Mình chưa ghi được giao dịch vừa rồi 🌱 Bạn gõ lại giúp "
+                "mình nhé — nếu lặp lại, thử chọn nguồn khác xem sao.",
+                parse_mode=None,
+            )
+        return True
     await wizard_service.clear(db, user.id)
     tx_sign = "+" if expense.transaction_type == "money_in" else "-"
     # Render the source label through the canonical resolver so that asset-
@@ -1025,7 +1048,33 @@ async def _handle_change_source_subpicker(
         await answer_callback(callback_id)
         return True
 
-    updated = await expense_service.update_expense(db, user.id, expense.id, update)
+    # Issue #948 safety net: a failed update (e.g. DB check-constraint
+    # violation on the e_wallet flow) must not leave the user with a
+    # stuck spinner on the source-change picker.
+    try:
+        updated = await expense_service.update_expense(
+            db, user.id, expense.id, update
+        )
+    except Exception:
+        logger.exception(
+            "update_expense failed in change-source flow for user %s (data=%s)",
+            user.id,
+            data,
+        )
+        await wizard_service.clear(db, user.id)
+        await answer_callback(
+            callback_id,
+            text="Mình chưa đổi được nguồn tiền 🌱 Bạn thử lại giúp mình nhé.",
+            show_alert=True,
+        )
+        if chat_id is not None:
+            await send_message(
+                chat_id,
+                "Mình chưa đổi được nguồn tiền 🌱 Bạn thử lại giúp mình "
+                "nhé — nếu lặp lại, chọn nguồn khác xem sao.",
+                parse_mode=None,
+            )
+        return True
     await wizard_service.clear(db, user.id)
     if updated is None:
         await answer_callback(

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -166,7 +166,14 @@ async def _handle_source_selection_callback(
     selected_card_bank_name = None
     if data.startswith("txsrc_wallet:"):
         source_type = "e_wallet"
-        source_asset_id = data.split(":", 1)[1]
+        suffix = data.split(":", 1)[1]
+        # Backward-compat: pre-#948 clients sent provider names ("momo") instead
+        # of asset UUIDs. Keep accepting them so in-flight callbacks from
+        # older message bubbles don't dead-end. New flow uses asset UUIDs.
+        if suffix in expense_service.EWALLET_PROVIDERS:
+            wallet_provider = suffix
+        else:
+            source_asset_id = suffix
     elif data.startswith("txsrc_card:"):
         source_type = "credit_card"
         requested_card_id = data.split(":", 1)[1]
@@ -232,6 +239,11 @@ async def _handle_source_selection_callback(
             user.id,
             data,
         )
+        # An aborted SQLAlchemy transaction leaves the session in a
+        # ``PendingRollbackError`` state — wizard_service.clear would then
+        # crash and the user gets no feedback. Rollback first so the
+        # subsequent wizard write succeeds.
+        await db.rollback()
         await wizard_service.clear(db, user.id)
         await answer_callback(
             callback_id,
@@ -1029,13 +1041,24 @@ async def _handle_change_source_subpicker(
             e_wallet_provider=None,
         )
     elif data.startswith("chsrc_wl:"):
-        asset_id = data.split(":", 1)[1]
-        update = ExpenseUpdate(
-            source_type="e_wallet",
-            source_asset_id=asset_id,
-            source_credit_card_id=None,
-            e_wallet_provider=None,
-        )
+        suffix = data.split(":", 1)[1]
+        # Backward-compat: pre-#948 callbacks used provider names ("momo")
+        # rather than asset UUIDs. Accept both so older message bubbles
+        # don't dead-end after a deploy.
+        if suffix in expense_service.EWALLET_PROVIDERS:
+            update = ExpenseUpdate(
+                source_type="e_wallet",
+                source_asset_id=None,
+                source_credit_card_id=None,
+                e_wallet_provider=suffix,
+            )
+        else:
+            update = ExpenseUpdate(
+                source_type="e_wallet",
+                source_asset_id=suffix,
+                source_credit_card_id=None,
+                e_wallet_provider=None,
+            )
     elif data.startswith("chsrc_cc:"):
         card_id = data.split(":", 1)[1]
         update = ExpenseUpdate(
@@ -1052,15 +1075,17 @@ async def _handle_change_source_subpicker(
     # violation on the e_wallet flow) must not leave the user with a
     # stuck spinner on the source-change picker.
     try:
-        updated = await expense_service.update_expense(
-            db, user.id, expense.id, update
-        )
+        updated = await expense_service.update_expense(db, user.id, expense.id, update)
     except Exception:
         logger.exception(
             "update_expense failed in change-source flow for user %s (data=%s)",
             user.id,
             data,
         )
+        # Mirror the create_expense path: an aborted SQLAlchemy transaction
+        # leaves the session in a ``PendingRollbackError`` state — rollback
+        # first so the wizard cleanup write succeeds.
+        await db.rollback()
         await wizard_service.clear(db, user.id)
         await answer_callback(
             callback_id,

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -36,7 +36,7 @@ from backend.bot.keyboards.transaction_keyboard import (
     category_picker_keyboard,
     confirm_delete_keyboard,
     credit_card_source_keyboard,
-    e_wallet_provider_keyboard,
+    e_wallet_picker_keyboard,
     source_asset_keyboard,
     source_picker_keyboard,
     transaction_actions_keyboard,
@@ -96,18 +96,44 @@ async def _handle_source_selection_callback(
     wallet_provider = None
     if data == "txsrc:bank_pick":
         assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
-        bank_assets = [a for a in assets if (a.subtype or "").lower() in ("bank_checking", "bank_account")]
+        bank_assets = [
+            a
+            for a in assets
+            if (a.subtype or "").lower() in ("bank_checking", "bank_account")
+        ]
         if not bank_assets:
-            await answer_callback(callback_id, text="Bạn chưa có tài khoản thanh toán nào 🌱", show_alert=True)
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có tài khoản thanh toán nào 🌱",
+                show_alert=True,
+            )
             return True
-        await edit_message_reply_markup(chat_id=chat_id, message_id=message_id, reply_markup=source_asset_keyboard(bank_assets))
-        await answer_callback(callback_id)
-        return True
-    if data == "txsrc:e_wallet":
         await edit_message_reply_markup(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=e_wallet_provider_keyboard(),
+            reply_markup=source_asset_keyboard(bank_assets),
+        )
+        await answer_callback(callback_id)
+        return True
+    if data == "txsrc:e_wallet":
+        assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
+        wallet_assets = [
+            a
+            for a in assets
+            if (a.subtype or "").lower()
+            in ("e_wallet", "momo", "vnpay", "zalopay", "viettelpay")
+        ]
+        if not wallet_assets:
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có ví điện tử nào 🌱",
+                show_alert=True,
+            )
+            return True
+        await edit_message_reply_markup(
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup=e_wallet_picker_keyboard(wallet_assets),
         )
         await answer_callback(callback_id)
         return True
@@ -115,14 +141,18 @@ async def _handle_source_selection_callback(
         await edit_message_reply_markup(
             chat_id=chat_id,
             message_id=message_id,
-            reply_markup=transaction_source_keyboard(draft.get("transaction_type", "expense")),
+            reply_markup=transaction_source_keyboard(
+                draft.get("transaction_type", "expense")
+            ),
         )
         await answer_callback(callback_id)
         return True
     if data == "txsrc:credit_card":
         cards = await list_credit_cards(db, user.id)
         if not cards:
-            await answer_callback(callback_id, text="Bạn chưa có thẻ tín dụng nào 🌱", show_alert=True)
+            await answer_callback(
+                callback_id, text="Bạn chưa có thẻ tín dụng nào 🌱", show_alert=True
+            )
             return True
         await edit_message_reply_markup(
             chat_id=chat_id,
@@ -136,7 +166,7 @@ async def _handle_source_selection_callback(
     selected_card_bank_name = None
     if data.startswith("txsrc_wallet:"):
         source_type = "e_wallet"
-        wallet_provider = data.split(":", 1)[1]
+        source_asset_id = data.split(":", 1)[1]
     elif data.startswith("txsrc_card:"):
         source_type = "credit_card"
         requested_card_id = data.split(":", 1)[1]
@@ -195,19 +225,32 @@ async def _handle_source_selection_callback(
 
     await wizard_service.clear(db, user.id)
     tx_sign = "+" if expense.transaction_type == "money_in" else "-"
-    source_label = {
-        "cash": "Tiền mặt",
-        "bank_account": "Tài khoản",
-        "momo": "Ví Momo",
-        "vnpay": "Ví VNPay",
-        "zalopay": "Ví ZaloPay",
-        "viettelpay": "Ví ViettelPay",
-        "credit_card": (
-            f"Thẻ tín dụng {selected_card_bank_name}"
-            if selected_card_bank_name
-            else "Thẻ tín dụng"
-        ),
-    }.get(wallet_provider or source_type, "không liên kết nguồn")
+    # Render the source label through the canonical resolver so that asset-
+    # backed flows (bank account / e-wallet) print "Tài khoản [<bank>]" or
+    # "Ví điện tử [<name>]" instead of generic words. Credit-card and bare
+    # "no source" cases fall back to the previous behaviour.
+    source_label: str | None = None
+    if source_type:
+        try:
+            source_label = await resolve_source_label_for_expense(db, expense)
+        except Exception:
+            logger.exception("resolve_source_label_for_expense failed (quick tx)")
+            source_label = None
+    if not source_label:
+        if source_type == "credit_card":
+            source_label = (
+                f"Thẻ tín dụng {selected_card_bank_name}"
+                if selected_card_bank_name
+                else "Thẻ tín dụng"
+            )
+        elif source_type == "cash":
+            source_label = "Tiền mặt"
+        elif source_type == "bank_account":
+            source_label = "Tài khoản"
+        elif source_type == "e_wallet":
+            source_label = "Ví điện tử"
+        else:
+            source_label = "không liên kết nguồn"
     confirmation_text = (
         f"Đã ghi nhận {tx_sign}{float(expense.amount):,.0f}đ · {source_label}"
     )
@@ -484,9 +527,7 @@ async def _handle_delete_transaction(
     await answer_callback(callback_id)
 
 
-async def _handle_receipt_category(
-    *, db, user, args, callback_id, chat_id, message_id
-):
+async def _handle_receipt_category(*, db, user, args, callback_id, chat_id, message_id):
     """User picked a category on a pending OCR receipt (before confirming).
 
     Updates the in-memory pending payload and re-renders the confirmation
@@ -801,7 +842,9 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
     if kind == "bank":
         assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
         bank_assets = [
-            a for a in assets if (a.subtype or "").lower() in ("bank_checking", "bank_account")
+            a
+            for a in assets
+            if (a.subtype or "").lower() in ("bank_checking", "bank_account")
         ]
         if not bank_assets:
             await answer_callback(
@@ -828,30 +871,49 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
             ]
         )
         await edit_message_reply_markup(
-            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup={"inline_keyboard": rows},
         )
         await answer_callback(callback_id)
         return
 
     if kind == "wallet":
-        rows = [
+        assets = await list_assets(db, user.id, asset_type="cash", limit=500, offset=0)
+        wallet_assets = [
+            a
+            for a in assets
+            if (a.subtype or "").lower()
+            in ("e_wallet", "momo", "vnpay", "zalopay", "viettelpay")
+        ]
+        if not wallet_assets:
+            await answer_callback(
+                callback_id,
+                text="Bạn chưa có ví điện tử nào 🌱",
+                show_alert=True,
+            )
+            return
+        rows: list[list[dict]] = [
             [
-                {"text": "Momo", "callback_data": "chsrc_wl:momo"},
-                {"text": "VNPay", "callback_data": "chsrc_wl:vnpay"},
-            ],
-            [
-                {"text": "ZaloPay", "callback_data": "chsrc_wl:zalopay"},
-                {"text": "ViettelPay", "callback_data": "chsrc_wl:viettelpay"},
-            ],
+                {
+                    "text": f"👛 Ví điện tử - {a.name}",
+                    "callback_data": f"chsrc_wl:{a.id}",
+                }
+            ]
+            for a in wallet_assets
+        ]
+        rows.append(
             [
                 {
                     "text": "↩️ Quay lại",
                     "callback_data": f"{CallbackPrefix.CHANGE_SOURCE}:{expense.id}",
                 }
-            ],
-        ]
+            ]
+        )
         await edit_message_reply_markup(
-            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup={"inline_keyboard": rows},
         )
         await answer_callback(callback_id)
         return
@@ -883,7 +945,9 @@ async def _handle_change_source(*, db, user, args, callback_id, chat_id, message
             ]
         )
         await edit_message_reply_markup(
-            chat_id=chat_id, message_id=message_id, reply_markup={"inline_keyboard": rows}
+            chat_id=chat_id,
+            message_id=message_id,
+            reply_markup={"inline_keyboard": rows},
         )
         await answer_callback(callback_id)
         return
@@ -919,7 +983,9 @@ async def _handle_change_source_subpicker(
     draft = dict(state.get("draft") or {})
     expense_id_str = draft.get("expense_id")
     if not expense_id_str:
-        await answer_callback(callback_id, text="Yêu cầu này đã hết hạn rồi 🌱", show_alert=True)
+        await answer_callback(
+            callback_id, text="Yêu cầu này đã hết hạn rồi 🌱", show_alert=True
+        )
         return True
 
     expense = await resolve_transaction_by_callback_id(db, user.id, expense_id_str)
@@ -940,12 +1006,12 @@ async def _handle_change_source_subpicker(
             e_wallet_provider=None,
         )
     elif data.startswith("chsrc_wl:"):
-        provider = data.split(":", 1)[1]
+        asset_id = data.split(":", 1)[1]
         update = ExpenseUpdate(
             source_type="e_wallet",
-            e_wallet_provider=provider,
-            source_asset_id=None,
+            source_asset_id=asset_id,
             source_credit_card_id=None,
+            e_wallet_provider=None,
         )
     elif data.startswith("chsrc_cc:"):
         card_id = data.split(":", 1)[1]

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -75,7 +75,9 @@ _NOT_REGISTERED = "Bạn chưa đăng ký. Gửi /start để bắt đầu."
 # pipeline.
 _AMOUNT_TOKEN_PATTERN = (
     r"\d{1,3}(?:[.,]\d{3})+"
-    r"|\d+(?:[.,]\d+)?(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?:\s*\d+)?)?"
+    # The lookahead keeps a unit letter from gluing onto a word ("tr" in
+    # "trên", "k" in "kem") — see _DUOC_AMOUNT_RE below.
+    r"|\d+(?:[.,]\d+)?(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?!(?!rưỡi|ruoi)[^\W\d_])(?:\s*\d+)?)?"
 )
 
 _SIGNED_TX_RE = re.compile(
@@ -100,9 +102,15 @@ _AMOUNT_TOKEN_RE = re.compile(
 # intent pipeline. This mirrors the Tier-1 YAML rule, which also demands
 # a money suffix for this shape. Keep the unit list in sync with
 # ``_AMOUNT_TOKEN_PATTERN`` above.
+# The ``(?!(?!rưỡi|ruoi)[^\W\d_])`` after each unit alternation stops a unit
+# letter from matching the prefix of an ordinary word — without it the "tr" in
+# "199999 trên momo" was read as triệu and booked 199,999 as 199,999,000,000đ.
+# ``[^\W\d_]`` is "a (unicode) letter"; digits/space/end still let the unit
+# stand ("100tr", "20tr5", "500k"), and the inner ``(?!rưỡi|ruoi)`` keeps a
+# glued half-word working ("3trrưỡi" = 3.5 triệu).
 _DUOC_AMOUNT_RE = re.compile(
-    r"(?P<amt>\d{1,3}(?:[.,]\d{3})+(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd))?"
-    r"|\d+(?:[.,]\d+)?\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?:\s*\d+)?)",
+    r"(?P<amt>\d{1,3}(?:[.,]\d{3})+(?:\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?!(?!rưỡi|ruoi)[^\W\d_]))?"
+    r"|\d+(?:[.,]\d+)?\s*(?:tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)(?!(?!rưỡi|ruoi)[^\W\d_])(?:\s*\d+)?)",
     re.IGNORECASE,
 )
 

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -149,22 +149,24 @@ async def _extract_credit_card_source(db: AsyncSession, user_id, text: str) -> t
 def _parse_signed_transaction(text: str) -> dict | None:
     if _QUESTION_HINT_RE.search(text):
         return None
-    signed = _SIGNED_TX_RE.match(text)
+
+    # Pull any transaction-date phrase out of the FULL text first so a
+    # leading bare date like "14/05/2026 -120k cà phê" still reaches the
+    # sign-aware matchers (otherwise the leading "14/05/2026" would
+    # prevent both _SIGNED_TX_RE and _AMOUNT_LED_TX_RE from matching).
+    extracted_date = extract_transaction_date(text)
+    cleaned = strip_span(text, extracted_date.span) if extracted_date else text
+
+    signed = _SIGNED_TX_RE.match(cleaned)
     if signed:
         sign = signed.group("sign")
         body = (signed.group("body") or "").strip()
     else:
-        amount_led = _AMOUNT_LED_TX_RE.match(text)
+        amount_led = _AMOUNT_LED_TX_RE.match(cleaned)
         if not amount_led:
             return None
         sign = None
         body = (amount_led.group("body") or "").strip()
-
-    # Strip any "ngày dd/mm[/yyyy]" phrase BEFORE searching for the
-    # amount so the date digits don't get mistaken for a price.
-    extracted_date = extract_transaction_date(body)
-    if extracted_date is not None:
-        body = strip_span(body, extracted_date.span)
 
     amount_match = _AMOUNT_TOKEN_RE.search(body)
     if not amount_match:

--- a/backend/bot/keyboards/transaction_keyboard.py
+++ b/backend/bot/keyboards/transaction_keyboard.py
@@ -269,20 +269,20 @@ def credit_card_source_keyboard(cards: list) -> InlineKeyboardMarkup:
     return {"inline_keyboard": rows}
 
 
-def e_wallet_provider_keyboard() -> InlineKeyboardMarkup:
-    return {
-        "inline_keyboard": [
+def e_wallet_picker_keyboard(wallets: list) -> InlineKeyboardMarkup:
+    rows: list[list[dict]] = []
+    for w in wallets:
+        rows.append(
             [
-                {"text": "Momo", "callback_data": "txsrc_wallet:momo"},
-                {"text": "VNPay", "callback_data": "txsrc_wallet:vnpay"},
-            ],
-            [
-                {"text": "ZaloPay", "callback_data": "txsrc_wallet:zalopay"},
-                {"text": "ViettelPay", "callback_data": "txsrc_wallet:viettelpay"},
-            ],
-            [{"text": "↪️ Bỏ qua nguồn", "callback_data": "txsrc:skip"}],
-        ]
-    }
+                {
+                    "text": f"👛 Ví điện tử - {w.name}",
+                    "callback_data": f"txsrc_wallet:{w.id}",
+                }
+            ]
+        )
+    rows.append([{"text": "↩️ Quay lại chọn nguồn", "callback_data": "txsrc:back"}])
+    rows.append([{"text": "↪️ Bỏ qua nguồn", "callback_data": "txsrc:skip"}])
+    return {"inline_keyboard": rows}
 
 
 def source_asset_keyboard(assets: list) -> InlineKeyboardMarkup:

--- a/backend/bot/utils/transaction_date_extractor.py
+++ b/backend/bot/utils/transaction_date_extractor.py
@@ -1,10 +1,24 @@
 """Extract a transaction date from free-text user input.
 
-Used by the Tier-1 NLU fast-paths so a message like
-``"-1tr ăn tối ngày 16/05/2026"`` records the expense on 16/05/2026 instead
-of today. Matching is anchored on Vietnamese date keywords (``ngày``, ``hôm``,
-``vào ngày``) to avoid false positives — a phrase like ``"mua 12/3 phần
-pizza"`` MUST NOT be re-interpreted as a date.
+Three detection modes, tried in order so the most disambiguating shape
+wins:
+
+  * **Mode 0 — keyword-anchored.** ``ngày``, ``vào ngày``, ``hôm`` +
+    ``dd/mm[/yyyy]``. Authoritative whenever present.
+  * **Mode 1 — year-bearing anywhere.** A bare ``dd/mm/yyyy`` (or
+    ``dd/mm/yy``) sitting anywhere in the message. The explicit year
+    disambiguates from ratios/portions ("ăn 12/3 phần" stays untouched
+    because it has no year). Lookarounds keep the match out of digit
+    runs like phone numbers.
+  * **Mode 2 — leading bare dd/mm.** A ``dd/mm`` at the very start of
+    the message, followed by more content. To stay safe against ratios
+    like ``"1/2 ổ bánh mì 50k"`` we require **day > 12 OR month > 12**.
+    Year defaults to ``today.year`` (see :func:`parse_vietnamese_date_token`).
+
+The function returns the date together with the character span covering
+what should be stripped from the merchant/note. Mode 0 also covers the
+keyword; Modes 1 and 2 cover only the date token. Callers feed the
+result through :func:`strip_span` to clean the surrounding text.
 """
 
 from __future__ import annotations
@@ -20,13 +34,29 @@ from backend.bot.utils.date_parser import parse_vietnamese_date_token
 # phrase regex.
 _DATE_TOKEN = r"\d{1,2}[/\-.]\d{1,2}(?:[/\-.](?:\d{2}|\d{4}))?"
 
-# Keyword-anchored phrases. ``ngày`` is the canonical one; ``vào ngày`` and
-# ``hôm`` cover natural phrasings. We intentionally do NOT match bare
-# ``16/05`` without a keyword — that risks parsing ratios/portions
-# ("ăn 12/3 phần") as dates.
+# Mode 0 — keyword-anchored. ``ngày`` is canonical; ``vào ngày`` and
+# ``hôm`` cover natural phrasings. The keyword shields us from ratios
+# (``"ăn 12/3 phần"`` has no keyword and stays put).
 _DATE_PHRASE_RE = re.compile(
     rf"(?P<prefix>\b(?:vào\s+ngày|ngày|hôm))\s+(?P<token>{_DATE_TOKEN})\b",
     re.IGNORECASE,
+)
+
+# Mode 1 — year-bearing date anywhere. The (?<!\d) / (?!\d) lookarounds
+# keep the regex from biting into the middle of a digit run such as
+# ``"0902/05/2026"`` (phone number). The 4-digit (or 2-digit) year is
+# what tells a date apart from a ratio.
+_YEAR_BEARING_DATE_RE = re.compile(
+    r"(?<!\d)"
+    r"(?P<token>\d{1,2}[/\-.]\d{1,2}[/\-.](?:\d{4}|\d{2}))"
+    r"(?!\d)"
+)
+
+# Mode 2 — leading bare ``dd/mm`` (no year) followed by at least one
+# more token. The day/month numbers are captured separately so we can
+# enforce the day>12 OR month>12 disambiguation guard before parsing.
+_LEADING_BARE_DATE_RE = re.compile(
+    r"^\s*(?P<token>(?P<d>\d{1,2})[/\-.](?P<m>\d{1,2}))(?=\s+\S)"
 )
 
 
@@ -35,9 +65,9 @@ class ExtractedDate:
     """Result of date extraction.
 
     ``span`` is the half-open ``(start, end)`` slice in the input text
-    covering BOTH the keyword and the token, so the caller can strip the
-    whole phrase from the merchant/note without leaving a dangling
-    ``"ngày"``.
+    that should be stripped from the merchant/note. For Mode 0 it covers
+    the keyword and the token; for Modes 1 and 2 it covers only the
+    token itself.
     """
 
     value: date
@@ -47,21 +77,45 @@ class ExtractedDate:
 def extract_transaction_date(
     text: str, *, today: date | None = None
 ) -> ExtractedDate | None:
-    """Find the first ``ngày <dd/mm[/yyyy]>``-style phrase in ``text``.
+    """Find a transaction date in ``text``.
 
-    Returns ``None`` when no recognisable date phrase is present, or when
-    the captured token is malformed (e.g. ``ngày 31/02`` → invalid). The
-    caller then keeps ``date.today()``.
+    Returns ``None`` when no recognisable date is present, or when the
+    candidate token is malformed (e.g. ``31/02/2026`` → invalid). The
+    caller then keeps ``date.today()``. Mode precedence — keyword,
+    year-bearing, leading bare — is documented at the module level.
     """
     if not text:
         return None
+
+    # Mode 0 — keyword-anchored phrase (most authoritative).
     match = _DATE_PHRASE_RE.search(text)
-    if not match:
-        return None
-    parsed = parse_vietnamese_date_token(match.group("token"), today=today)
-    if parsed is None:
-        return None
-    return ExtractedDate(value=parsed, span=match.span())
+    if match:
+        parsed = parse_vietnamese_date_token(match.group("token"), today=today)
+        if parsed is None:
+            return None
+        return ExtractedDate(value=parsed, span=match.span())
+
+    # Mode 1 — year-bearing date sitting anywhere in the message.
+    match = _YEAR_BEARING_DATE_RE.search(text)
+    if match:
+        parsed = parse_vietnamese_date_token(match.group("token"), today=today)
+        if parsed is None:
+            return None
+        return ExtractedDate(value=parsed, span=match.span("token"))
+
+    # Mode 2 — leading bare ``dd/mm``, disambiguated by day>12 OR month>12.
+    match = _LEADING_BARE_DATE_RE.match(text)
+    if match:
+        day = int(match.group("d"))
+        month = int(match.group("m"))
+        if day > 12 or month > 12:
+            parsed = parse_vietnamese_date_token(
+                match.group("token"), today=today
+            )
+            if parsed is not None:
+                return ExtractedDate(value=parsed, span=match.span("token"))
+
+    return None
 
 
 def strip_span(text: str, span: tuple[int, int]) -> str:

--- a/backend/intent/handlers/action_quick_transaction.py
+++ b/backend/intent/handlers/action_quick_transaction.py
@@ -107,8 +107,12 @@ Quy tắc:
 Chỉ trả về JSON, không giải thích."""
 
 
+# The lookahead after the unit stops "tr"/"k" from matching the prefix of a
+# word ("tr" in "trên", "k" in "kem") and inflating the amount ×1,000,000.
+# ``[^\W\d_]`` is "a letter"; the inner ``(?!rưỡi|ruoi)`` lets a glued
+# half-word through, matching backend.wealth.amount_parser.
 _AMOUNT_RE = re.compile(
-    r"(?<!\w)(\d+(?:[.,]\d+)?)(?:\s*(k|K|ngàn|nghìn|ngan|nghin|tr|triệu|trieu))?",
+    r"(?<!\w)(\d+(?:[.,]\d+)?)(?:\s*(k|K|ngàn|nghìn|ngan|nghin|tr|triệu|trieu)(?!(?!rưỡi|ruoi)[^\W\d_]))?",
     re.IGNORECASE,
 )
 _SPLIT_RE = re.compile(r"\s*(?:,|\+|\n|\s+và\s+)\s*", re.IGNORECASE)

--- a/backend/main.py
+++ b/backend/main.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from fastapi import FastAPI, Request, status
 from fastapi.middleware.cors import CORSMiddleware
-from fastapi.responses import JSONResponse
+from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy import text
 
@@ -334,6 +334,22 @@ async def health_check():
 
 _ADMIN_STATIC = Path(__file__).parent / "static" / "admin"
 if _ADMIN_STATIC.exists():
+    # Canonical admin URL is /admin/ (matches Cloudflare ingress + deploy
+    # script success message). Starlette's Mount("/admin", ...) only
+    # matches /admin/* — bare /admin still 404s without an explicit
+    # redirect, so add one before mounting.
+    @app.get("/admin", include_in_schema=False)
+    async def _admin_trailing_slash():
+        return RedirectResponse(url="/admin/", status_code=308)
+
+    # /admin mount must come BEFORE / so the more-specific prefix wins
+    # for /admin/login, /admin/assets/*, etc.
+    app.mount(
+        "/admin",
+        SPAStaticFiles(directory=str(_ADMIN_STATIC), html=True),
+        name="admin-spa-prefix",
+    )
+    # Root mount kept for backward-compat: pre-fix users had / bookmarked.
     app.mount(
         "/", SPAStaticFiles(directory=str(_ADMIN_STATIC), html=True), name="admin-spa"
     )

--- a/backend/main.py
+++ b/backend/main.py
@@ -337,8 +337,9 @@ if _ADMIN_STATIC.exists():
     # Canonical admin URL is /admin/ (matches Cloudflare ingress + deploy
     # script success message). Starlette's Mount("/admin", ...) only
     # matches /admin/* — bare /admin still 404s without an explicit
-    # redirect, so add one before mounting.
-    @app.get("/admin", include_in_schema=False)
+    # redirect. Register GET + HEAD so `curl -I` and uptime probes also
+    # see the 308 instead of falling through to the static mount.
+    @app.api_route("/admin", methods=["GET", "HEAD"], include_in_schema=False)
     async def _admin_trailing_slash():
         return RedirectResponse(url="/admin/", status_code=308)
 

--- a/backend/miniapp/static/js/expense_dashboard.js
+++ b/backend/miniapp/static/js/expense_dashboard.js
@@ -728,12 +728,19 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
     }
 
 
-    function applySourceOptions(txType, selectedValue = '', existingCardId = null) {
+    function applySourceOptions(txType, selectedValue = '', existingCardId = null, existingWalletAssetId = null) {
         const key = txType === 'money_in' ? 'money_in' : 'expense';
         const sourceOptions = (lastOverview && lastOverview.source_options && lastOverview.source_options[key]) || FALLBACK_SOURCE_OPTIONS[key];
         const opts = [...sourceOptions];
         if (selectedValue === 'credit_card' && existingCardId) {
             opts.push({ value: `credit_card:${existingCardId}`, label: 'Thẻ tín dụng (đã chọn)' });
+        }
+        // Providerless wallet assets (subtype="e_wallet" with no provider hint)
+        // aren't in the server-built option list, which is keyed by provider.
+        // Surface a "preserve current" entry so editing such an expense doesn't
+        // silently rewrite the source to a fabricated Momo asset on save.
+        if (typeof selectedValue === 'string' && selectedValue.startsWith('e_wallet_asset:') && existingWalletAssetId) {
+            opts.push({ value: selectedValue, label: 'Ví điện tử (đã chọn)' });
         }
         els.modalSource.innerHTML = opts
             .map((it) => `<option value="${escapeHtml(it.value)}">${escapeHtml(it.label)}</option>`)
@@ -748,7 +755,12 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
         els.modalTitle.textContent = editingExpenseId ? (txType === 'money_in' ? 'Sửa tiền vào' : 'Sửa chi tiêu') : (txType === 'money_in' ? 'Thêm tiền vào' : 'Thêm chi tiêu');
         els.modalType.value = txType;
         applyCategoryOptions(txType);
-        applySourceOptions(txType, sourceValue(item), item?.source_credit_card_id || null);
+        applySourceOptions(
+            txType,
+            sourceValue(item),
+            item?.source_credit_card_id || null,
+            item?.source_type === 'e_wallet' ? (item?.source_asset_id || null) : null,
+        );
         els.modalAmount.value = item ? formatMoneyInput(Math.round(item.amount || 0)) : '';
         els.modalCategory.value = item?.category || (txType === 'money_in' ? 'other_income' : 'other');
         els.modalDate.value = item?.expense_date || new Date().toISOString().slice(0, 10);
@@ -771,14 +783,27 @@ const SOURCE = new URLSearchParams(window.location.search).get('source');
         if (!item || !item.source_type) return '';
         if (item.source_credit_card_id) return `credit_card:${item.source_credit_card_id}`;
         if (item.source_asset_id && item.source_type === 'bank_account') return `bank_account:${item.source_asset_id}`;
-        if (item.source_type === 'e_wallet') return `e_wallet:${item.e_wallet_provider || 'momo'}`;
+        if (item.source_type === 'e_wallet') {
+            // A provider-less wallet asset (subtype="e_wallet" from the cash
+            // wizard) round-trips by asset id, not by provider — otherwise we'd
+            // fabricate a Momo provider on edit and silently rewrite the source.
+            if (item.source_asset_id && !item.e_wallet_provider) {
+                return `e_wallet_asset:${item.source_asset_id}`;
+            }
+            if (item.e_wallet_provider) return `e_wallet:${item.e_wallet_provider}`;
+            return 'e_wallet';
+        }
         return item.source_type;
     }
 
     function parseSourceValue(value, editingItem = null) {
         if (!value) return { source_type: null, e_wallet_provider: null, source_credit_card_id: null, source_asset_id: null };
+        if (value.startsWith('e_wallet_asset:')) {
+            return { source_type: 'e_wallet', e_wallet_provider: null, source_credit_card_id: null, source_asset_id: value.split(':')[1] || null };
+        }
         if (value.startsWith('e_wallet:')) {
-            return { source_type: 'e_wallet', e_wallet_provider: value.split(':')[1] || 'momo', source_credit_card_id: null, source_asset_id: null };
+            const provider = value.split(':')[1] || null;
+            return { source_type: 'e_wallet', e_wallet_provider: provider, source_credit_card_id: null, source_asset_id: null };
         }
         if (value.startsWith('credit_card:')) return { source_type: 'credit_card', e_wallet_provider: null, source_credit_card_id: value.split(':')[1] || null, source_asset_id: null };
         if (value.startsWith('bank_account:')) return { source_type: 'bank_account', e_wallet_provider: null, source_credit_card_id: null, source_asset_id: value.split(':')[1] || null };

--- a/backend/services/expense_service.py
+++ b/backend/services/expense_service.py
@@ -245,7 +245,12 @@ async def resolve_source_asset_for_payload(
         provider = data.e_wallet_provider
         if source_type == "e_wallet":
             provider = provider or inferred_provider
-            if provider not in EWALLET_PROVIDERS:
+            # When source_asset_id pins an explicit wallet, the asset row IS the
+            # source of truth — provider is denormalized decoration. Generic
+            # `subtype="e_wallet"` assets (created via the cash wizard) carry no
+            # provider hint, and that's fine: resolve_source_label_for_expense
+            # falls back to asset.name to render "Ví điện tử [<name>]".
+            if provider is not None and provider not in EWALLET_PROVIDERS:
                 raise ValueError("e_wallet_provider is not supported")
         else:
             provider = None
@@ -284,20 +289,33 @@ async def resolve_source_asset_for_payload(
     )
 
 
-
-
 def _source_label(source_type: str | None) -> str:
-    return {"cash": "Tiền mặt", "bank_account": "Tài khoản", "e_wallet": "Ví điện tử"}.get(source_type or "", "Nguồn khác")
+    return {
+        "cash": "Tiền mặt",
+        "bank_account": "Tài khoản",
+        "e_wallet": "Ví điện tử",
+    }.get(source_type or "", "Nguồn khác")
 
 
-async def _create_transaction_record(db: AsyncSession, user_id: uuid.UUID, expense: Expense, *, status: str = "active", original_transaction_id: uuid.UUID | None = None, edited_at: datetime | None = None, reversed_at: datetime | None = None) -> Transaction:
+async def _create_transaction_record(
+    db: AsyncSession,
+    user_id: uuid.UUID,
+    expense: Expense,
+    *,
+    status: str = "active",
+    original_transaction_id: uuid.UUID | None = None,
+    edited_at: datetime | None = None,
+    reversed_at: datetime | None = None,
+) -> Transaction:
     tx = Transaction(
         user_id=user_id,
         source_asset_id=expense.source_asset_id,
         source_type=expense.source_type or "expense_category",
         source_label=_source_label(expense.source_type),
         amount=Decimal(str(expense.amount or 0)),
-        direction="inflow" if expense.transaction_type == TRANSACTION_TYPE_MONEY_IN else "outflow",
+        direction="inflow"
+        if expense.transaction_type == TRANSACTION_TYPE_MONEY_IN
+        else "outflow",
         note=expense.note or expense.merchant,
         category=expense.category,
         status=status,
@@ -544,7 +562,9 @@ async def update_expense(
                 db, user_id, merged
             )
             update_data["source_asset_id"] = source_resolution.source_asset_id
-            update_data["source_credit_card_id"] = source_resolution.source_credit_card_id
+            update_data["source_credit_card_id"] = (
+                source_resolution.source_credit_card_id
+            )
             update_data["source_type"] = source_resolution.source_type
             update_data["e_wallet_provider"] = source_resolution.e_wallet_provider
             raw_data = dict(update_data.get("raw_data", expense.raw_data) or {})
@@ -564,7 +584,13 @@ async def update_expense(
     if existing_tx and existing_tx.status == "active":
         existing_tx.status = "edited"
         existing_tx.edited_at = datetime.utcnow()
-    await _create_transaction_record(db, user_id, expense, original_transaction_id=(existing_tx.id if existing_tx else None), edited_at=datetime.utcnow())
+    await _create_transaction_record(
+        db,
+        user_id,
+        expense,
+        original_transaction_id=(existing_tx.id if existing_tx else None),
+        edited_at=datetime.utcnow(),
+    )
 
     await db.refresh(expense)
     return expense

--- a/backend/services/expense_service.py
+++ b/backend/services/expense_service.py
@@ -244,6 +244,14 @@ async def resolve_source_asset_for_payload(
         source_type = data.source_type or inferred_type
         provider = data.e_wallet_provider
         if source_type == "e_wallet":
+            # Guard against a caller pinning an arbitrary asset (e.g. a bank
+            # account) to source_type=e_wallet. Without this check we'd
+            # happily write an expense whose asset/source_type mismatch,
+            # leaving the dashboard rendering the wrong label and the
+            # source-resolver picking up bogus subtypes downstream.
+            subtype = (asset.subtype or "").lower()
+            if subtype not in EWALLET_PROVIDERS and subtype != "e_wallet":
+                raise ValueError("source_asset_id không phải ví điện tử")
             provider = provider or inferred_provider
             # When source_asset_id pins an explicit wallet, the asset row IS the
             # source of truth — provider is denormalized decoration. Generic

--- a/backend/tests/test_amount_parser.py
+++ b/backend/tests/test_amount_parser.py
@@ -107,6 +107,33 @@ class TestParseAmount:
     def test_sub_amount_after_unit(self, raw, expected):
         assert parse_amount(raw) == expected
 
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            # Regression: a unit abbreviation must NOT match the prefix of
+            # an ordinary word. "199999 trên momo" was read as "199999 tr"
+            # (= 199,999 triệu = 199,999,000,000đ) because "tr" greedily
+            # ate the start of "trên". The number has no real unit, so it
+            # parses as the bare amount.
+            ("199999 trên momo", Decimal("199999")),
+            ("100 trên bàn", Decimal("100")),  # "tr" in "trên"
+            ("199999 trong ví", Decimal("199999")),  # "tr" in "trong"
+            ("50 kem", Decimal("50")),  # "k" in "kem"
+            ("5 ký gạo", Decimal("5")),  # "k" in "ký"
+            ("3 ngày", Decimal("3")),  # "ngà" in "ngày" not "ngàn"
+            ("10 do dự", Decimal("10")),  # "d" in "do"
+            # The fix must not break a real unit glued to a number, a unit
+            # followed by a digit, or the half-word "rưỡi" right after.
+            ("100tr", Decimal("100000000")),
+            ("20tr5", Decimal("20500000")),
+            ("3trrưỡi", Decimal("3500000")),
+            ("500k", Decimal("500000")),
+            ("2tỷ", Decimal("2000000000")),
+        ],
+    )
+    def test_unit_must_not_be_word_prefix(self, raw, expected):
+        assert parse_amount(raw) == expected
+
 
 class TestParseLabelAndAmount:
     @pytest.mark.parametrize(
@@ -185,6 +212,25 @@ class TestParseLabelAndAmount:
         ],
     )
     def test_ruoi_in_labeled_amount(
+        self, raw, expected_label, expected_amount
+    ):
+        result = parse_label_and_amount(raw)
+        assert result is not None, f"parser returned None for {raw!r}"
+        label, amount = result
+        assert label == expected_label
+        assert amount == expected_amount
+
+    @pytest.mark.parametrize(
+        "raw,expected_label,expected_amount",
+        [
+            # Regression: the trailing word after a bare amount must not be
+            # swallowed as a unit. "199999 trên momo" → 199,999đ, not
+            # 199,999,000,000đ.
+            ("199999 trên momo", "", Decimal("199999")),
+            ("Quỹ 50 kem", "Quỹ", Decimal("50")),
+        ],
+    )
+    def test_trailing_word_not_read_as_unit(
         self, raw, expected_label, expected_amount
     ):
         result = parse_label_and_amount(raw)

--- a/backend/tests/test_callbacks_change_source.py
+++ b/backend/tests/test_callbacks_change_source.py
@@ -277,4 +277,67 @@ async def test_change_source_subpicker_rejects_when_not_in_flow(monkeypatch):
     )
     assert handled is True
     answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_change_source_subpicker_update_failure_alerts_user(monkeypatch):
+    """Issue #948 safety net for the change-source flow: when
+    ``update_expense`` raises (e.g. DB check-constraint violation on
+    the e_wallet flow), the picker must surface a friendly alert and a
+    chat fallback rather than leaving the user staring at a stuck spinner.
+
+    Contract mirrors the create_expense safety net:
+      - ``answer_callback`` fires with ``show_alert=True`` and a Bé Tiền-
+        tone Vietnamese message.
+      - A chat ``send_message`` fallback follows.
+      - The wizard state is cleared.
+      - The re-render is skipped (no successful update to render).
+    """
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_source_edit",
+            "step": "pick_kind",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+
+    monkeypatch.setattr(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    boom = AsyncMock(side_effect=RuntimeError("simulated IntegrityError"))
+    monkeypatch.setattr(callbacks.expense_service, "update_expense", boom)
+    clear = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "clear", clear)
+    rerender = AsyncMock()
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", rerender)
+    answer = AsyncMock()
+    monkeypatch.setattr(callbacks, "answer_callback", answer)
+    send = AsyncMock()
+    monkeypatch.setattr(callbacks, "send_message", send)
+
+    callback_query = {
+        "id": "cb1",
+        "data": "chsrc_wl:22222222-2222-2222-2222-222222222222",
+        "from": {"id": 7},
+        "message": {"chat": {"id": 10}, "message_id": 20},
+    }
+    handled = await callbacks._handle_change_source_subpicker(
+        SimpleNamespace(), callback_query
+    )
+
+    assert handled is True
+    rerender.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    alert_text = (answer.await_args.kwargs.get("text") or "").lower()
+    assert "chưa đổi" in alert_text or "không đổi" in alert_text
+    send.assert_awaited_once()
+    clear.assert_awaited_once()
     assert answer.await_args.kwargs.get("show_alert") is True

--- a/backend/tests/test_callbacks_change_source.py
+++ b/backend/tests/test_callbacks_change_source.py
@@ -90,6 +90,18 @@ async def test_change_source_wallet_swaps_to_subpicker(monkeypatch):
         "resolve_transaction_by_callback_id",
         AsyncMock(return_value=expense),
     )
+    wallet_one_id = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+    wallet_two_id = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+    wallets = [
+        SimpleNamespace(id=wallet_one_id, name="MoMo cá nhân", subtype="momo"),
+        SimpleNamespace(id=wallet_two_id, name="Ví ZaloPay", subtype="e_wallet"),
+        SimpleNamespace(
+            id="cccccccc-cccc-cccc-cccc-cccccccccccc",
+            name="Vietcombank",
+            subtype="bank_checking",
+        ),
+    ]
+    monkeypatch.setattr(callbacks, "list_assets", AsyncMock(return_value=wallets))
     edit_markup = AsyncMock()
     monkeypatch.setattr(callbacks, "edit_message_reply_markup", edit_markup)
     monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
@@ -105,11 +117,95 @@ async def test_change_source_wallet_swaps_to_subpicker(monkeypatch):
     edit_markup.assert_awaited_once()
     markup = edit_markup.await_args.kwargs["reply_markup"]
     callbacks_data = [
-        btn["callback_data"]
-        for row in markup["inline_keyboard"]
-        for btn in row
+        btn["callback_data"] for row in markup["inline_keyboard"] for btn in row
     ]
-    assert any(cd.startswith("chsrc_wl:momo") for cd in callbacks_data)
+    assert f"chsrc_wl:{wallet_one_id}" in callbacks_data
+    assert f"chsrc_wl:{wallet_two_id}" in callbacks_data
+    # Bank-typed assets must NOT leak into the wallet sub-picker.
+    assert not any(cd.startswith("chsrc_wl:cccccccc") for cd in callbacks_data)
+    labels = [btn["text"] for row in markup["inline_keyboard"] for btn in row]
+    assert any("MoMo cá nhân" in label for label in labels)
+    assert any("Ví ZaloPay" in label for label in labels)
+
+
+@pytest.mark.asyncio
+async def test_change_source_wallet_alerts_when_user_has_no_wallets(monkeypatch):
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    monkeypatch.setattr(callbacks, "list_assets", AsyncMock(return_value=[]))
+    edit_markup = AsyncMock()
+    monkeypatch.setattr(callbacks, "edit_message_reply_markup", edit_markup)
+    answer = AsyncMock()
+    monkeypatch.setattr(callbacks, "answer_callback", answer)
+
+    await callbacks._handle_change_source(
+        db=SimpleNamespace(),
+        user=SimpleNamespace(id=42),
+        args=["tx-1", "wallet"],
+        callback_id="cb1",
+        chat_id=10,
+        message_id=20,
+    )
+
+    edit_markup.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    assert "ví điện tử" in answer.await_args.kwargs.get("text", "").lower()
+
+
+@pytest.mark.asyncio
+async def test_change_source_subpicker_applies_wallet_asset(monkeypatch):
+    """chsrc_wl:<asset_uuid> resolves to source_type=e_wallet + source_asset_id."""
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    updated = SimpleNamespace(id="tx-1", transaction_type="expense")
+
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_source_edit",
+            "step": "pick_kind",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+
+    monkeypatch.setattr(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    update_expense = AsyncMock(return_value=updated)
+    monkeypatch.setattr(callbacks.expense_service, "update_expense", update_expense)
+    clear = AsyncMock()
+    monkeypatch.setattr(callbacks.wizard_service, "clear", clear)
+    rerender = AsyncMock()
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", rerender)
+    monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
+
+    wallet_uuid = "22222222-2222-2222-2222-222222222222"
+    callback_query = {
+        "id": "cb1",
+        "data": f"chsrc_wl:{wallet_uuid}",
+        "from": {"id": 7},
+        "message": {"chat": {"id": 10}, "message_id": 20},
+    }
+    handled = await callbacks._handle_change_source_subpicker(
+        SimpleNamespace(), callback_query
+    )
+    assert handled is True
+    update_arg = update_expense.await_args.args[3]
+    assert update_arg.source_type == "e_wallet"
+    assert str(update_arg.source_asset_id) == wallet_uuid
+    assert update_arg.source_credit_card_id is None
+    assert update_arg.e_wallet_provider is None
+    clear.assert_awaited_once()
+    rerender.assert_awaited_once()
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_callbacks_change_source.py
+++ b/backend/tests/test_callbacks_change_source.py
@@ -322,15 +322,14 @@ async def test_change_source_subpicker_update_failure_alerts_user(monkeypatch):
     send = AsyncMock()
     monkeypatch.setattr(callbacks, "send_message", send)
 
+    db = SimpleNamespace(rollback=AsyncMock())
     callback_query = {
         "id": "cb1",
         "data": "chsrc_wl:22222222-2222-2222-2222-222222222222",
         "from": {"id": 7},
         "message": {"chat": {"id": 10}, "message_id": 20},
     }
-    handled = await callbacks._handle_change_source_subpicker(
-        SimpleNamespace(), callback_query
-    )
+    handled = await callbacks._handle_change_source_subpicker(db, callback_query)
 
     assert handled is True
     rerender.assert_not_awaited()
@@ -339,5 +338,56 @@ async def test_change_source_subpicker_update_failure_alerts_user(monkeypatch):
     alert_text = (answer.await_args.kwargs.get("text") or "").lower()
     assert "chưa đổi" in alert_text or "không đổi" in alert_text
     send.assert_awaited_once()
+    # PR #948 fix: rollback must precede wizard cleanup so the latter doesn't
+    # crash on PendingRollbackError after an aborted update.
+    db.rollback.assert_awaited_once()
     clear.assert_awaited_once()
-    assert answer.await_args.kwargs.get("show_alert") is True
+
+
+@pytest.mark.asyncio
+async def test_change_source_subpicker_accepts_legacy_wallet_provider(monkeypatch):
+    """Pre-#948 callbacks shipped ``chsrc_wl:momo`` (provider name) rather than
+    an asset UUID. Keep accepting those so older message bubbles still resolve.
+    """
+    expense = SimpleNamespace(id="tx-1", transaction_type="expense")
+    updated = SimpleNamespace(id="tx-1", transaction_type="expense")
+
+    user = SimpleNamespace(
+        id=42,
+        wizard_state={
+            "flow": "transaction_source_edit",
+            "step": "pick_kind",
+            "draft": {"expense_id": "tx-1", "chat_id": 10, "message_id": 20},
+        },
+    )
+
+    monkeypatch.setattr(
+        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+    )
+    monkeypatch.setattr(
+        callbacks,
+        "resolve_transaction_by_callback_id",
+        AsyncMock(return_value=expense),
+    )
+    update_expense = AsyncMock(return_value=updated)
+    monkeypatch.setattr(callbacks.expense_service, "update_expense", update_expense)
+    monkeypatch.setattr(callbacks.wizard_service, "clear", AsyncMock())
+    monkeypatch.setattr(callbacks, "_rerender_transaction_message", AsyncMock())
+    monkeypatch.setattr(callbacks, "answer_callback", AsyncMock())
+
+    callback_query = {
+        "id": "cb1",
+        "data": "chsrc_wl:momo",
+        "from": {"id": 7},
+        "message": {"chat": {"id": 10}, "message_id": 20},
+    }
+    handled = await callbacks._handle_change_source_subpicker(
+        SimpleNamespace(), callback_query
+    )
+
+    assert handled is True
+    update_arg = update_expense.await_args.args[3]
+    assert update_arg.source_type == "e_wallet"
+    assert update_arg.e_wallet_provider == "momo"
+    assert update_arg.source_asset_id is None
+    assert update_arg.source_credit_card_id is None

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -654,3 +654,87 @@ async def test_handle_transaction_callback_routes_txsrc_wallet_prefix():
 
     assert handled is True
     source_handler.assert_awaited_once_with(db, cb)
+
+
+@pytest.mark.asyncio
+async def test_create_expense_failure_alerts_user_and_clears_wizard():
+    """Issue #948 safety net: when ``create_expense`` raises (e.g. DB
+    check-constraint violation on the e_wallet flow), the user must NOT
+    be left staring at a stuck spinner.
+
+    Contract:
+      - ``answer_callback`` fires with ``show_alert=True`` and a friendly
+        Vietnamese message (Bé Tiền tone — no harsh wording).
+      - A chat fallback ``send_message`` follows so the message survives
+        the alert dismiss.
+      - The wizard state is cleared so the user can retry from scratch.
+      - The handler returns ``True`` so the dispatcher stops processing.
+    """
+    user = _user()
+    db = MagicMock()
+    wallet_id = uuid.uuid4()
+
+    answer = AsyncMock()
+    send = AsyncMock()
+    edit_text = AsyncMock()
+    boom = AsyncMock(side_effect=RuntimeError("simulated IntegrityError"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks.expense_service, "create_expense", boom),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()) as wizard_clear,
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_wallet:{wallet_id}")
+        )
+
+    assert handled is True
+    # The picker message is NOT edited on failure — the user gets a fresh
+    # chat message + alert instead.
+    edit_text.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    alert_text = (answer.await_args.kwargs.get("text") or "").lower()
+    # Friendly Bé Tiền tone — never harsh.
+    assert "chưa ghi" in alert_text or "không ghi" in alert_text
+    send.assert_awaited_once()
+    sent_text = send.await_args.args[1].lower()
+    assert "chưa ghi" in sent_text or "không ghi" in sent_text
+    wizard_clear.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_create_expense_failure_does_not_crash_without_chat_id():
+    """If Telegram somehow delivers a callback without a chat (rare —
+    shouldn't happen for inline keyboards but is defensively guarded),
+    the safety net must still alert the user via ``answer_callback``
+    without raising on the missing ``chat_id``."""
+    user = _user()
+    db = MagicMock()
+    wallet_id = uuid.uuid4()
+
+    cb = _callback(f"txsrc_wallet:{wallet_id}")
+    cb["message"] = {}  # no chat key — chat_id resolves to None
+
+    answer = AsyncMock()
+    send = AsyncMock()
+    boom = AsyncMock(side_effect=RuntimeError("boom"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks.expense_service, "create_expense", boom),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(db, cb)
+
+    assert handled is True
+    answer.assert_awaited_once()
+    # No chat to send a fallback into — skip silently rather than crash.
+    send.assert_not_awaited()

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -672,6 +672,7 @@ async def test_create_expense_failure_alerts_user_and_clears_wizard():
     """
     user = _user()
     db = MagicMock()
+    db.rollback = AsyncMock()
     wallet_id = uuid.uuid4()
 
     answer = AsyncMock()
@@ -704,6 +705,9 @@ async def test_create_expense_failure_alerts_user_and_clears_wizard():
     send.assert_awaited_once()
     sent_text = send.await_args.args[1].lower()
     assert "chưa ghi" in sent_text or "không ghi" in sent_text
+    # PR #948 fix: rollback must precede wizard cleanup so the latter
+    # doesn't crash on PendingRollbackError after an aborted insert.
+    db.rollback.assert_awaited_once()
     wizard_clear.assert_awaited_once()
 
 
@@ -715,6 +719,7 @@ async def test_create_expense_failure_does_not_crash_without_chat_id():
     without raising on the missing ``chat_id``."""
     user = _user()
     db = MagicMock()
+    db.rollback = AsyncMock()
     wallet_id = uuid.uuid4()
 
     cb = _callback(f"txsrc_wallet:{wallet_id}")
@@ -738,3 +743,47 @@ async def test_create_expense_failure_does_not_crash_without_chat_id():
     answer.assert_awaited_once()
     # No chat to send a fallback into — skip silently rather than crash.
     send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_wallet_accepts_legacy_provider_name():
+    """Pre-#948 clients shipped ``txsrc_wallet:momo`` (provider name)
+    rather than an asset UUID. Older Telegram message bubbles still
+    carry those callbacks, so the parser must continue routing the
+    provider name onto ``payload.e_wallet_provider`` instead of
+    treating it as a (bogus) asset id."""
+    user = _user()
+    db = MagicMock()
+    expense = _expense()
+
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ) as create,
+        patch.object(
+            callbacks,
+            "resolve_source_label_for_expense",
+            AsyncMock(return_value="Ví điện tử [MoMo]"),
+        ),
+        patch.object(
+            callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})
+        ),
+        patch.object(callbacks, "send_message", AsyncMock()),
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc_wallet:momo")
+        )
+
+    assert handled is True
+    create.assert_awaited_once()
+    payload = create.await_args.args[2]
+    assert payload.source_type == "e_wallet"
+    assert payload.e_wallet_provider == "momo"
+    assert payload.source_asset_id is None

--- a/backend/tests/test_callbacks_source_selection.py
+++ b/backend/tests/test_callbacks_source_selection.py
@@ -2,26 +2,35 @@
 `txsrc_wallet:*`).
 
 Issue #799 reported that after a user typed "+20 tỷ lương" → tapped
-``e_wallet`` → tapped ``ZaloPay`` (callback ``txsrc_wallet:zalopay``),
-the database write succeeded but no confirmation message was ever sent
-back to Telegram. The user was left staring at the source-picker screen
-with no feedback.
+``e_wallet`` → tapped a wallet, the database write succeeded but no
+confirmation message was ever sent back to Telegram. The user was left
+staring at the source-picker screen with no feedback.
+
+Issue #897 follow-up: the wallet picker is now keyed by ``source_asset_id``
+(real user wallet) instead of a hard-coded provider list, mirroring the
+bank-account flow. ``txsrc_wallet:<asset_uuid>`` pins the asset; the
+confirmation renders "Ví điện tử [<asset.name>]" via
+``resolve_source_label_for_expense``.
 
 These tests pin the contract:
-  - The wallet-provider branch MUST call ``edit_message_text`` to
-    replace the picker with a confirmation line.
+  - The wallet-asset branch MUST call ``edit_message_text`` to replace
+    the picker with a confirmation line.
   - It MUST also fire ``answer_callback`` so the user's tap spinner
     clears.
   - The wizard state is cleared after a successful save.
   - A non-wallet source (``txsrc:cash``) follows the same contract.
-  - The intermediate ``txsrc:e_wallet`` tap swaps the keyboard without
-    creating an expense.
+  - The intermediate ``txsrc:e_wallet`` tap swaps the keyboard to list
+    the user's actual wallet assets without creating an expense.
+  - Empty-wallet users get a friendly alert instead of an empty picker.
 """
+
 from __future__ import annotations
 
 import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
+
+from backend.bot.keyboards.transaction_keyboard import transaction_source_keyboard  # noqa: E402
 
 import pytest
 
@@ -73,45 +82,69 @@ def _expense(transaction_type: str = "money_in", amount: float = 20_000_000_000.
     return expense
 
 
+def _wallet_asset(name: str = "MoMo cá nhân", subtype: str = "e_wallet"):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        name=name,
+        subtype=subtype,
+        asset_type="cash",
+        is_active=True,
+    )
+
+
 @pytest.mark.asyncio
-async def test_txsrc_wallet_zalopay_sends_confirmation_message():
-    """The bug: ``txsrc_wallet:zalopay`` wrote to DB but never edited the
-    source-picker message. The user was stuck on the picker screen."""
+async def test_txsrc_wallet_asset_sends_confirmation_with_asset_name():
+    """After tapping a specific wallet asset, the picker is replaced by
+    a confirmation line that includes the asset's display name —
+    "Ví điện tử [<name>]" — rendered via ``resolve_source_label_for_expense``.
+
+    This is the visible contract for Issue #897: the user picked a real
+    wallet (not a provider key), so the bot must echo that wallet back."""
     user = _user()
     db = MagicMock()
     expense = _expense()
+    wallet_id = uuid.uuid4()
 
     edit_text = AsyncMock(return_value={"ok": True})
     answer = AsyncMock()
     send = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ) as create, patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", send
-    ), patch.object(
-        callbacks, "answer_callback", answer
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
-    ) as wizard_clear:
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ) as create,
+        patch.object(
+            callbacks,
+            "resolve_source_label_for_expense",
+            AsyncMock(return_value="Ví điện tử [MoMo cá nhân]"),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()) as wizard_clear,
+    ):
         handled = await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc_wallet:zalopay")
+            db, _callback(f"txsrc_wallet:{wallet_id}")
         )
 
     assert handled is True
     create.assert_awaited_once()
+    payload = create.await_args.args[2]
+    assert payload.source_type == "e_wallet"
+    assert str(payload.source_asset_id) == str(wallet_id)
+    # provider must NOT be set from a hard-coded key — the asset is the truth.
+    assert payload.e_wallet_provider is None
     wizard_clear.assert_awaited_once()
     edit_text.assert_awaited_once()
     edit_kwargs = edit_text.await_args.kwargs
     assert edit_kwargs["chat_id"] == 999
     assert edit_kwargs["message_id"] == 42
     assert "+20,000,000,000" in edit_kwargs["text"]
-    assert "ZaloPay" in edit_kwargs["text"]
+    assert "Ví điện tử [MoMo cá nhân]" in edit_kwargs["text"]
     # No fallback send_message when edit succeeded.
     send.assert_not_awaited()
     answer.assert_awaited_once()
@@ -127,27 +160,32 @@ async def test_txsrc_wallet_falls_back_to_send_when_edit_fails():
     user = _user()
     db = MagicMock()
     expense = _expense()
+    wallet_id = uuid.uuid4()
 
     edit_text = AsyncMock(return_value=None)
     send = AsyncMock()
     answer = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ), patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", send
-    ), patch.object(
-        callbacks, "answer_callback", answer
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ),
+        patch.object(
+            callbacks,
+            "resolve_source_label_for_expense",
+            AsyncMock(return_value="Ví điện tử [ZaloPay nhà]"),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", send),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
     ):
         await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc_wallet:zalopay")
+            db, _callback(f"txsrc_wallet:{wallet_id}")
         )
 
     edit_text.assert_awaited_once()
@@ -155,43 +193,51 @@ async def test_txsrc_wallet_falls_back_to_send_when_edit_fails():
     sent_chat_id, sent_text = send.await_args.args[0], send.await_args.args[1]
     assert sent_chat_id == 999
     assert "+20,000,000,000" in sent_text
-    assert "ZaloPay" in sent_text
+    assert "Ví điện tử [ZaloPay nhà]" in sent_text
     answer.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_txsrc_wallet_uses_provider_label_for_each_wallet():
-    """Every wallet provider gets a friendly label, not the raw key."""
+async def test_txsrc_wallet_uses_asset_name_for_each_wallet():
+    """The asset-keyed flow honours every wallet's own display name —
+    whether it's a named provider asset (MoMo, ZaloPay…) or a generic
+    user-created e_wallet asset. No hardcoded provider-label table."""
     user = _user()
     db = MagicMock()
     expense = _expense()
 
     cases = [
-        ("momo", "Momo"),
-        ("vnpay", "VNPay"),
-        ("zalopay", "ZaloPay"),
-        ("viettelpay", "ViettelPay"),
+        "Ví điện tử [MoMo cá nhân]",
+        "Ví điện tử [VNPay công ty]",
+        "Ví điện tử [ZaloPay vợ]",
+        "Ví điện tử [Ví của bé]",  # user-created generic subtype
     ]
-    for provider, expected_label in cases:
+    for expected_label in cases:
         # Wizard state must look "active" each round because
         # ``wizard_service.clear`` is the production teardown.
         user.wizard_state = _money_in_state()
+        wallet_id = uuid.uuid4()
         edit_text = AsyncMock(return_value={"ok": True})
-        with patch.object(
-            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-        ), patch.object(
-            callbacks.expense_service,
-            "create_expense",
-            AsyncMock(return_value=expense),
-        ), patch.object(
-            callbacks, "edit_message_text", edit_text
-        ), patch.object(
-            callbacks, "answer_callback", AsyncMock()
-        ), patch(
-            "backend.services.wizard_service.clear", AsyncMock()
+        with (
+            patch.object(
+                callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+            ),
+            patch.object(
+                callbacks.expense_service,
+                "create_expense",
+                AsyncMock(return_value=expense),
+            ),
+            patch.object(
+                callbacks,
+                "resolve_source_label_for_expense",
+                AsyncMock(return_value=expected_label),
+            ),
+            patch.object(callbacks, "edit_message_text", edit_text),
+            patch.object(callbacks, "answer_callback", AsyncMock()),
+            patch("backend.services.wizard_service.clear", AsyncMock()),
         ):
             await callbacks._handle_source_selection_callback(
-                db, _callback(f"txsrc_wallet:{provider}")
+                db, _callback(f"txsrc_wallet:{wallet_id}")
             )
         edit_text.assert_awaited_once()
         assert expected_label in edit_text.await_args.kwargs["text"]
@@ -207,20 +253,24 @@ async def test_txsrc_cash_sends_confirmation_message():
 
     edit_text = AsyncMock(return_value={"ok": True})
     answer = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ), patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", AsyncMock()
-    ), patch.object(
-        callbacks, "answer_callback", answer
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ),
+        patch.object(
+            callbacks,
+            "resolve_source_label_for_expense",
+            AsyncMock(return_value="Tiền mặt"),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", AsyncMock()),
+        patch.object(callbacks, "answer_callback", answer),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
     ):
         handled = await callbacks._handle_source_selection_callback(
             db, _callback("txsrc:cash")
@@ -241,45 +291,49 @@ async def test_txsrc_skip_still_sends_confirmation_message():
     expense = _expense()
 
     edit_text = AsyncMock(return_value={"ok": True})
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service,
-        "create_expense",
-        AsyncMock(return_value=expense),
-    ), patch.object(
-        callbacks, "edit_message_text", edit_text
-    ), patch.object(
-        callbacks, "send_message", AsyncMock()
-    ), patch.object(
-        callbacks, "answer_callback", AsyncMock()
-    ), patch(
-        "backend.services.wizard_service.clear", AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks.expense_service,
+            "create_expense",
+            AsyncMock(return_value=expense),
+        ),
+        patch.object(callbacks, "edit_message_text", edit_text),
+        patch.object(callbacks, "send_message", AsyncMock()),
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
     ):
-        await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc:skip")
-        )
+        await callbacks._handle_source_selection_callback(db, _callback("txsrc:skip"))
     edit_text.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_txsrc_e_wallet_swaps_keyboard_without_creating_expense():
-    """The intermediate ``txsrc:e_wallet`` tap just replaces the keyboard
-    with the wallet-provider picker. It must NOT call ``create_expense``."""
+async def test_txsrc_e_wallet_lists_user_wallets_in_keyboard():
+    """The intermediate ``txsrc:e_wallet`` tap swaps the keyboard to a
+    picker listing the user's actual wallet assets — NOT a hardcoded
+    provider list. Each row carries ``txsrc_wallet:<asset_uuid>``.
+
+    The handler must NOT call ``create_expense``: it's just a sub-menu."""
     user = _user()
     db = MagicMock()
+    wallets = [
+        _wallet_asset(name="MoMo cá nhân", subtype="e_wallet"),
+        _wallet_asset(name="ZaloPay vợ", subtype="zalopay"),
+    ]
 
     edit_markup = AsyncMock()
     answer = AsyncMock()
     create = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service, "create_expense", create
-    ), patch.object(
-        callbacks, "edit_message_reply_markup", edit_markup
-    ), patch.object(
-        callbacks, "answer_callback", answer
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_assets", AsyncMock(return_value=wallets)),
+        patch.object(callbacks.expense_service, "create_expense", create),
+        patch.object(callbacks, "edit_message_reply_markup", edit_markup),
+        patch.object(callbacks, "answer_callback", answer),
     ):
         handled = await callbacks._handle_source_selection_callback(
             db, _callback("txsrc:e_wallet")
@@ -289,6 +343,89 @@ async def test_txsrc_e_wallet_swaps_keyboard_without_creating_expense():
     create.assert_not_awaited()
     edit_markup.assert_awaited_once()
     answer.assert_awaited_once()
+    kb = edit_markup.await_args.kwargs["reply_markup"]["inline_keyboard"]
+    # First N rows = one button per wallet asset.
+    labels = [row[0]["text"] for row in kb[: len(wallets)]]
+    assert "MoMo cá nhân" in labels[0]
+    assert "ZaloPay vợ" in labels[1]
+    callback_data = [row[0]["callback_data"] for row in kb[: len(wallets)]]
+    assert callback_data[0] == f"txsrc_wallet:{wallets[0].id}"
+    assert callback_data[1] == f"txsrc_wallet:{wallets[1].id}"
+
+
+@pytest.mark.asyncio
+async def test_txsrc_e_wallet_alerts_when_user_has_no_wallets():
+    """If the user taps "👛 Ví điện tử" but owns no wallet assets, the
+    handler must surface a friendly alert (mirrors the bank-account
+    empty-state at ``txsrc:bank_pick``) — not show an empty keyboard.
+
+    The expense MUST NOT be created in this branch."""
+    user = _user()
+    db = MagicMock()
+
+    answer = AsyncMock()
+    create = AsyncMock()
+    edit_markup = AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_assets", AsyncMock(return_value=[])),
+        patch.object(callbacks.expense_service, "create_expense", create),
+        patch.object(callbacks, "edit_message_reply_markup", edit_markup),
+        patch.object(callbacks, "answer_callback", answer),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:e_wallet")
+        )
+
+    assert handled is True
+    create.assert_not_awaited()
+    edit_markup.assert_not_awaited()
+    answer.assert_awaited_once()
+    assert answer.await_args.kwargs.get("show_alert") is True
+    assert "ví điện tử" in (answer.await_args.kwargs.get("text") or "").lower()
+
+
+@pytest.mark.asyncio
+async def test_txsrc_e_wallet_filters_non_wallet_assets():
+    """``list_assets(asset_type="cash")`` returns ALL cash-family rows
+    (bank_checking, cash, e_wallet, momo…). The handler must filter to
+    wallet-only subtypes before rendering the picker, otherwise the user
+    would see their checking account in the wallet picker."""
+    user = _user()
+    db = MagicMock()
+    mixed = [
+        _wallet_asset(name="VCB checking", subtype="bank_checking"),
+        _wallet_asset(name="Tiền mặt", subtype="cash"),
+        _wallet_asset(name="MoMo cá nhân", subtype="e_wallet"),
+        _wallet_asset(name="ZaloPay vợ", subtype="zalopay"),
+    ]
+
+    edit_markup = AsyncMock()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_assets", AsyncMock(return_value=mixed)),
+        patch.object(callbacks, "edit_message_reply_markup", edit_markup),
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+    ):
+        await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:e_wallet")
+        )
+
+    edit_markup.assert_awaited_once()
+    kb = edit_markup.await_args.kwargs["reply_markup"]["inline_keyboard"]
+    # Only the two wallet assets should appear as picker rows. The trailing
+    # rows are "Back" / "Skip" controls.
+    wallet_rows = [
+        row for row in kb if row and row[0]["callback_data"].startswith("txsrc_wallet:")
+    ]
+    assert len(wallet_rows) == 2
+    labels = [row[0]["text"] for row in wallet_rows]
+    assert "MoMo cá nhân" in labels[0]
+    assert "ZaloPay vợ" in labels[1]
 
 
 @pytest.mark.asyncio
@@ -300,15 +437,16 @@ async def test_stale_wizard_state_does_not_call_create_expense():
 
     create = AsyncMock()
     answer = AsyncMock()
-    with patch.object(
-        callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
-    ), patch.object(
-        callbacks.expense_service, "create_expense", create
-    ), patch.object(
-        callbacks, "answer_callback", answer
+    wallet_id = uuid.uuid4()
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks.expense_service, "create_expense", create),
+        patch.object(callbacks, "answer_callback", answer),
     ):
         handled = await callbacks._handle_source_selection_callback(
-            db, _callback("txsrc_wallet:zalopay")
+            db, _callback(f"txsrc_wallet:{wallet_id}")
         )
 
     assert handled is True
@@ -319,18 +457,31 @@ async def test_stale_wizard_state_does_not_call_create_expense():
 
 @pytest.mark.asyncio
 async def test_txsrc_credit_card_shows_all_cards_for_expense_only():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {"amount": 200000.0, "transaction_type": "expense"},
+        }
+    )
     db = MagicMock()
     cards = [
         SimpleNamespace(id=uuid.uuid4(), bank_name="VCB"),
         SimpleNamespace(id=uuid.uuid4(), bank_name="ACB"),
     ]
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=cards)),          patch.object(callbacks, "edit_message_reply_markup", AsyncMock()) as edit_markup,          patch.object(callbacks, "answer_callback", AsyncMock()):
-        handled = await callbacks._handle_source_selection_callback(db, _callback("txsrc:credit_card"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=cards)),
+        patch.object(
+            callbacks, "edit_message_reply_markup", AsyncMock()
+        ) as edit_markup,
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback("txsrc:credit_card")
+        )
 
     assert handled is True
     kb = edit_markup.await_args.kwargs["reply_markup"]["inline_keyboard"]
@@ -340,17 +491,41 @@ async def test_txsrc_credit_card_shows_all_cards_for_expense_only():
 
 @pytest.mark.asyncio
 async def test_txsrc_card_select_confirmation_mentions_bank_name():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {
+                "amount": 200000.0,
+                "transaction_type": "expense",
+                "merchant": "test",
+            },
+        }
+    )
     db = MagicMock()
     expense = _expense(transaction_type="expense", amount=200000.0)
     card_id = uuid.uuid4()
     card = SimpleNamespace(id=card_id, bank_name="MSB")
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[card])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)),          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})) as edit_text,          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
-        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[card])),
+        patch.object(
+            callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)
+        ),
+        patch.object(
+            callbacks, "resolve_source_label_for_expense", AsyncMock(return_value=None)
+        ),
+        patch.object(
+            callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})
+        ) as edit_text,
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_card:{card_id}")
+        )
 
     assert handled is True
     assert "Thẻ tín dụng MSB" in edit_text.await_args.kwargs["text"]
@@ -358,16 +533,44 @@ async def test_txsrc_card_select_confirmation_mentions_bank_name():
 
 @pytest.mark.asyncio
 async def test_txsrc_card_select_creates_expense_with_credit_card_source():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {
+                "amount": 200000.0,
+                "transaction_type": "expense",
+                "merchant": "test",
+            },
+        }
+    )
     db = MagicMock()
     expense = _expense(transaction_type="expense", amount=200000.0)
     card_id = uuid.uuid4()
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[SimpleNamespace(id=card_id, bank_name="VCB")])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)) as create,          patch.object(callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})),          patch.object(callbacks, "answer_callback", AsyncMock()),          patch("backend.services.wizard_service.clear", AsyncMock()):
-        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(
+            callbacks,
+            "list_credit_cards",
+            AsyncMock(return_value=[SimpleNamespace(id=card_id, bank_name="VCB")]),
+        ),
+        patch.object(
+            callbacks.expense_service, "create_expense", AsyncMock(return_value=expense)
+        ) as create,
+        patch.object(
+            callbacks, "resolve_source_label_for_expense", AsyncMock(return_value=None)
+        ),
+        patch.object(
+            callbacks, "edit_message_text", AsyncMock(return_value={"ok": True})
+        ),
+        patch.object(callbacks, "answer_callback", AsyncMock()),
+        patch("backend.services.wizard_service.clear", AsyncMock()),
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_card:{card_id}")
+        )
 
     assert handled is True
     payload = create.await_args.args[2]
@@ -377,26 +580,43 @@ async def test_txsrc_card_select_creates_expense_with_credit_card_source():
 
 @pytest.mark.asyncio
 async def test_txsrc_card_select_rejects_unknown_card_id():
-    user = _user(state={
-        "flow": "transaction_source_select",
-        "step": "source_type",
-        "draft": {"amount": 200000.0, "transaction_type": "expense", "merchant": "test"},
-    })
+    user = _user(
+        state={
+            "flow": "transaction_source_select",
+            "step": "source_type",
+            "draft": {
+                "amount": 200000.0,
+                "transaction_type": "expense",
+                "merchant": "test",
+            },
+        }
+    )
     db = MagicMock()
     card_id = uuid.uuid4()
-    with patch.object(callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)),          patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[])),          patch.object(callbacks.expense_service, "create_expense", AsyncMock()) as create,          patch.object(callbacks, "answer_callback", AsyncMock()) as answer:
-        handled = await callbacks._handle_source_selection_callback(db, _callback(f"txsrc_card:{card_id}"))
+    with (
+        patch.object(
+            callbacks, "get_user_by_telegram_id", AsyncMock(return_value=user)
+        ),
+        patch.object(callbacks, "list_credit_cards", AsyncMock(return_value=[])),
+        patch.object(
+            callbacks.expense_service, "create_expense", AsyncMock()
+        ) as create,
+        patch.object(callbacks, "answer_callback", AsyncMock()) as answer,
+    ):
+        handled = await callbacks._handle_source_selection_callback(
+            db, _callback(f"txsrc_card:{card_id}")
+        )
 
     assert handled is True
     create.assert_not_awaited()
     answer.assert_awaited_once()
     assert "không hợp lệ" in (answer.await_args.kwargs.get("text") or "").lower()
 
-from backend.bot.keyboards.transaction_keyboard import transaction_source_keyboard
 
 def test_tx_source_keyboard_expense_includes_credit_card():
     kb = transaction_source_keyboard("expense")["inline_keyboard"]
     assert any(btn["callback_data"] == "txsrc:credit_card" for row in kb for btn in row)
+
 
 def test_tx_source_keyboard_money_in_excludes_credit_card():
     kb = transaction_source_keyboard("money_in")["inline_keyboard"]
@@ -407,6 +627,24 @@ def test_tx_source_keyboard_money_in_excludes_credit_card():
 async def test_handle_transaction_callback_routes_txsrc_bank_prefix():
     db = MagicMock()
     cb = _callback(f"txsrc_bank:{uuid.uuid4()}")
+    with patch.object(
+        callbacks,
+        "_handle_source_selection_callback",
+        AsyncMock(return_value=True),
+    ) as source_handler:
+        handled = await callbacks.handle_transaction_callback(db, cb)
+
+    assert handled is True
+    source_handler.assert_awaited_once_with(db, cb)
+
+
+@pytest.mark.asyncio
+async def test_handle_transaction_callback_routes_txsrc_wallet_prefix():
+    """Regression: ``txsrc_wallet:<uuid>`` must hit the source-selection
+    handler — not fall through to the generic callback dispatcher.
+    Otherwise the user's wallet tap silently no-ops."""
+    db = MagicMock()
+    cb = _callback(f"txsrc_wallet:{uuid.uuid4()}")
     with patch.object(
         callbacks,
         "_handle_source_selection_callback",

--- a/backend/tests/test_expense_enhancement.py
+++ b/backend/tests/test_expense_enhancement.py
@@ -3,6 +3,7 @@
 Covers the new source-resolution / warning logic and transaction-type
 filtering introduced by issue #562 without requiring a real database.
 """
+
 from __future__ import annotations
 
 import uuid
@@ -86,6 +87,66 @@ async def test_resolve_source_asset_inferrs_wallet_provider_and_warns_for_expens
     assert result.source_type == "e_wallet"
     assert result.e_wallet_provider == "momo"
     assert result.warning == {"insufficient_balance": True, "balance": 50000.0}
+
+
+@pytest.mark.asyncio
+async def test_resolve_source_asset_rejects_non_wallet_subtype_for_e_wallet_source():
+    """PR #948 P2 fix: if the caller pins ``source_type=e_wallet`` to an
+    asset whose ``subtype`` is anything other than a wallet provider (or
+    the generic ``e_wallet`` subtype), the resolver MUST reject it.
+    Otherwise we'd silently persist a mismatched source — the dashboard
+    would render the wrong label and the source resolver would pick up
+    a bogus subtype downstream."""
+    user_id = uuid.uuid4()
+    bank_asset = _asset(
+        user_id=user_id,
+        current_value="500000",
+        subtype="bank_checking",
+    )
+    db = _db(get_result=bank_asset)
+
+    with pytest.raises(ValueError):
+        await expense_service.resolve_source_asset_for_payload(
+            db,
+            user_id,
+            ExpenseCreate(
+                amount=100_000,
+                source_asset_id=bank_asset.id,
+                source_type="e_wallet",
+                transaction_type="expense",
+            ),
+        )
+
+
+@pytest.mark.asyncio
+async def test_resolve_source_asset_accepts_generic_e_wallet_subtype():
+    """Wallet assets created by the cash wizard carry the generic
+    ``subtype='e_wallet'`` (no provider hint). These are valid e_wallet
+    sources — the resolver must let them through without inferring a
+    bogus provider."""
+    user_id = uuid.uuid4()
+    wallet = _asset(
+        user_id=user_id,
+        current_value="200000",
+        subtype="e_wallet",
+    )
+    db = _db(get_result=wallet)
+
+    result = await expense_service.resolve_source_asset_for_payload(
+        db,
+        user_id,
+        ExpenseCreate(
+            amount=100_000,
+            source_asset_id=wallet.id,
+            source_type="e_wallet",
+            transaction_type="expense",
+        ),
+    )
+
+    assert result.source_asset_id == wallet.id
+    assert result.source_type == "e_wallet"
+    # Generic-subtype wallet has no provider hint — must not fabricate one.
+    assert result.e_wallet_provider is None
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_signed_transaction_parser.py
+++ b/backend/tests/test_signed_transaction_parser.py
@@ -182,3 +182,84 @@ def test_duoc_money_in_invalid_date_falls_back_silently() -> None:
     assert parsed is not None
     assert parsed["amount"] == 500_000
     assert "expense_date" not in parsed
+
+
+# ---------------------------------------------------------------------------
+# Keyword-less date fast-path — the user can lead the message with a bare
+# ``dd/mm/yyyy`` date and the Tier-1 parsers MUST still record the date.
+# This is the bug the screenshot showed: ``14/05/2026 ăn gà kfc 120k`` was
+# logged with today's date because the sign/amount-led matchers fired on
+# the date digits before the date extractor saw them.
+# ---------------------------------------------------------------------------
+
+
+def test_signed_expense_with_leading_year_bearing_date() -> None:
+    parsed = _parse_signed_transaction("14/05/2026 -1tr ăn tối")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 1_000_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "ăn tối"
+
+
+def test_amount_led_expense_with_leading_year_bearing_date() -> None:
+    """The exact screenshot bug: no sign, leading date, then amount+merchant."""
+    parsed = _parse_signed_transaction("14/05/2026 120k cà phê")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 120_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "cà phê"
+
+
+def test_signed_money_in_with_leading_year_bearing_date() -> None:
+    parsed = _parse_signed_transaction("14/05/2026 +5tr thưởng")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "money_in"
+    assert parsed["amount"] == 5_000_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "thưởng"
+
+
+def test_signed_expense_with_trailing_year_bearing_date() -> None:
+    parsed = _parse_signed_transaction("-50k cà phê 02/06/2026")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 50_000
+    assert parsed["expense_date"] == "2026-06-02"
+    assert "02/06" not in parsed["merchant"]
+    assert parsed["merchant"] == "cà phê"
+
+
+def test_amount_led_expense_with_leading_bare_dd_mm() -> None:
+    """Leading ``dd/mm`` (no year) with day>12 is unambiguously a date."""
+    parsed = _parse_signed_transaction("14/05 120k cà phê")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "expense"
+    assert parsed["amount"] == 120_000
+    assert parsed["expense_date"] is not None
+    assert parsed["expense_date"].endswith("-05-14")
+    assert parsed["merchant"] == "cà phê"
+
+
+def test_duoc_money_in_with_leading_year_bearing_date() -> None:
+    parsed = _parse_duoc_money_in("14/05/2026 được bố cho 500k")
+    assert parsed is not None
+    assert parsed["transaction_type"] == "money_in"
+    assert parsed["amount"] == 500_000
+    assert parsed["expense_date"] == "2026-05-14"
+    assert "14/05" not in parsed["merchant"]
+    assert parsed["merchant"] == "bố cho"
+
+
+def test_ratio_shape_not_parsed_as_transaction() -> None:
+    """``1/2 ổ bánh mì 50k`` must NOT be parsed as a 1-Feb expense — the
+    Mode 2 guard (day>12 OR month>12) keeps ratios untouched."""
+    parsed = _parse_signed_transaction("1/2 ổ bánh mì 50k")
+    # Even if the parser does record this as an expense, the expense_date
+    # MUST NOT be set from the leading "1/2".
+    if parsed is not None:
+        assert "expense_date" not in parsed

--- a/backend/tests/test_transaction_date_extractor.py
+++ b/backend/tests/test_transaction_date_extractor.py
@@ -87,3 +87,150 @@ def test_strip_span_handles_mid_text_phrase() -> None:
 
 def test_strip_span_empty_input() -> None:
     assert strip_span("", (0, 0)) == ""
+
+
+# ---------------------------------------------------------------------------
+# Mode 1 — year-bearing date sitting anywhere in the message. The explicit
+# year disambiguates from ratios; lookarounds keep the regex out of digit
+# runs like phone numbers.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        # Leading year-bearing date — the original screenshot bug.
+        ("14/05/2026 ăn gà kfc 120k", date(2026, 5, 14)),
+        # Mid-message year-bearing.
+        ("ăn tối 1tr 16/05/2026", date(2026, 5, 16)),
+        # Trailing year-bearing.
+        ("-50k cà phê 02/06/2026", date(2026, 6, 2)),
+        # Dash separator.
+        ("14-05-2026 ăn tối 100k", date(2026, 5, 14)),
+        # Dot separator.
+        ("14.05.2026 ăn tối 100k", date(2026, 5, 14)),
+        # 2-digit year.
+        ("14/05/26 ăn tối 100k", date(2026, 5, 14)),
+        # Money-in shape with leading date.
+        ("15/01/2026 +5tr thưởng tết", date(2026, 1, 15)),
+    ],
+)
+def test_extract_year_bearing_anywhere(text: str, expected: date) -> None:
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None, f"expected a date in {text!r}"
+    assert result.value == expected
+
+
+def test_year_bearing_invalid_returns_none() -> None:
+    # Year-bearing but invalid (31 Feb) → None, caller defaults to today.
+    assert extract_transaction_date("31/02/2026 ăn tối", today=_TODAY) is None
+
+
+def test_year_bearing_inside_digit_run_ignored() -> None:
+    # A phone number must NOT be parsed as a date — lookarounds prevent
+    # the regex from biting into the middle of a digit run.
+    assert extract_transaction_date("gọi 0902/05/2026", today=_TODAY) is None
+
+
+def test_year_bearing_span_covers_only_token() -> None:
+    text = "ăn tối 1tr 16/05/2026"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    start, end = result.span
+    assert text[start:end] == "16/05/2026"
+
+
+def test_keyword_beats_year_bearing_when_both_present() -> None:
+    # Mode 0 wins over Mode 1 because the keyword is the most
+    # authoritative shape.
+    text = "ăn tối ngày 16/05 hôm 25/12/2025 quên"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    assert result.value == date(2026, 5, 16)
+
+
+# ---------------------------------------------------------------------------
+# Mode 2 — leading bare ``dd/mm`` followed by more content, disambiguated
+# by ``day > 12 OR month > 12``. Conservative on purpose: ratios like
+# ``1/2 ổ bánh mì`` or ``12/3 phần`` stay untouched.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "text,expected_month,expected_day",
+    [
+        ("14/05 ăn gà 120k", 5, 14),  # day > 12
+        ("25/06 cà phê 50k", 6, 25),  # day > 12
+        ("31/01 tiền lương 5tr", 1, 31),  # day > 12
+    ],
+)
+def test_extract_leading_bare_dd_mm_when_disambiguated(
+    text: str, expected_month: int, expected_day: int
+) -> None:
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None, f"expected a date in {text!r}"
+    assert result.value.month == expected_month
+    assert result.value.day == expected_day
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        # Both <=12 → ambiguous (could be a ratio). Bail out rather than
+        # risk parsing "1/2 ổ bánh mì 50k" as 1 Feb.
+        "1/2 ổ bánh mì 50k",
+        "12/3 phần pizza 50k",
+        "5/6 ly nước 30k",
+        # Leading dd/mm with NOTHING after — not a transaction shape.
+        "14/05",
+    ],
+)
+def test_leading_bare_dd_mm_rejected_when_ambiguous(text: str) -> None:
+    assert extract_transaction_date(text, today=_TODAY) is None
+
+
+def test_leading_bare_dd_mm_span_covers_only_token() -> None:
+    text = "14/05 ăn gà 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    start, end = result.span
+    assert text[start:end] == "14/05"
+
+
+def test_leading_bare_dd_mm_defaults_to_today_year() -> None:
+    text = "14/05 ăn gà 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    assert result.value.year == _TODAY.year
+
+
+# ---------------------------------------------------------------------------
+# Strip-span integration — the leading-date and trailing-date variants
+# must leave clean merchant text behind.
+# ---------------------------------------------------------------------------
+
+
+def test_strip_span_removes_leading_year_bearing_date() -> None:
+    text = "14/05/2026 ăn gà kfc 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    assert "14/05" not in stripped
+    assert stripped == "ăn gà kfc 120k"
+
+
+def test_strip_span_removes_trailing_year_bearing_date() -> None:
+    text = "-50k cà phê 02/06/2026"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    assert "02/06" not in stripped
+    assert stripped == "-50k cà phê"
+
+
+def test_strip_span_removes_leading_bare_dd_mm() -> None:
+    text = "14/05 ăn gà 120k"
+    result = extract_transaction_date(text, today=_TODAY)
+    assert result is not None
+    stripped = strip_span(text, result.span)
+    assert stripped == "ăn gà 120k"

--- a/backend/wealth/amount_parser.py
+++ b/backend/wealth/amount_parser.py
@@ -44,7 +44,14 @@ _AMOUNT_RE = re.compile(
     (?P<int>\d{1,3}(?:[.,]\d{3})+|\d+)            # 1,000,000 or 1000000
     (?:[.,](?P<frac>\d+))?                        # optional .5 or ,5
     \s*
-    (?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)?
+    (?:(?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)
+       (?!(?!rưỡi|ruoi)[^\W\d_]))?                # a unit must not be the prefix of a
+                                                  # word: the "tr" in "trên", the "k"
+                                                  # in "kem", the "d" in "do" are NOT
+                                                  # units. ``[^\W\d_]`` is "a letter";
+                                                  # the inner ``(?!rưỡi|ruoi)`` still
+                                                  # lets a glued half-word through
+                                                  # ("3trrưỡi" = 3.5 triệu).
     (?:\s*(?P<sub>\d+))?                          # "25tr320" or "1 tỷ 500" sub-amount
     (?:\s*(?P<half>rưỡi|ruoi))?                   # "rưỡi" → +0.5 of unit
     \s*
@@ -174,7 +181,8 @@ _LABELED_AMOUNT_RE = re.compile(
     (?:^|(?<=\s))
     (?P<num>\d{1,3}(?:[.,]\d{3})+|\d+(?:[.,]\d+)?)
     \s*
-    (?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)?
+    (?:(?P<unit>tỷ|ty|tỉ|triệu|trieu|tr|nghìn|nghin|ngàn|ngan|k|đ|d|vnđ|vnd)
+       (?!(?!rưỡi|ruoi)[^\W\d_]))?                # see _AMOUNT_RE: unit ≠ word prefix
     (?:\s*(?P<sub>\d+))?
     (?:\s*(?P<half>rưỡi|ruoi))?
     """,

--- a/betien-admin/src/main.jsx
+++ b/betien-admin/src/main.jsx
@@ -5,9 +5,14 @@ import App from './App';
 import { AuthProvider } from './context/AuthContext';
 import './styles.css';
 
+// SPA is served at both / (legacy bookmarks) and /admin/ (canonical, matches
+// Cloudflare ingress). Detect at runtime so React Router treats /admin/login
+// as /login instead of falling through to the catch-all `*` route.
+const routerBasename = window.location.pathname.startsWith('/admin') ? '/admin' : '/';
+
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={routerBasename}>
       <AuthProvider>
         <App />
       </AuthProvider>

--- a/tests/test_message_money_in_fastpath.py
+++ b/tests/test_message_money_in_fastpath.py
@@ -11,6 +11,50 @@ from types import SimpleNamespace
 import pytest
 
 from backend.bot.handlers import message as message_handler
+from backend.bot.handlers.message import _parse_duoc_money_in
+
+
+class TestDuocMoneyInAmountScaling:
+    """Regression for the ×1,000,000 money-in scaling bug.
+
+    "Vừa được cho 199999 trên momo" was booked as 199,999,000,000đ because
+    the amount regex matched "199999 tr" — the "tr" of "trên" — and read it
+    as the triệu unit. A unit abbreviation must never glue onto the prefix
+    of an ordinary word.
+    """
+
+    def test_word_starting_with_unit_does_not_inflate_amount(self):
+        # The exact message from the bug report. "199999" carries no real
+        # unit, so the strict được-fast-path declines (returns None) and the
+        # message falls through to the intent pipeline — crucially it is NOT
+        # booked as 199,999,000,000đ.
+        assert _parse_duoc_money_in("Vừa được cho 199999 trên momo") is None
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "được bố cho 100 trên bàn",  # "tr" in "trên"
+            "được mẹ cho 50 kem",  # "k" in "kem"
+        ],
+    )
+    def test_unit_prefixed_words_never_booked(self, text):
+        assert _parse_duoc_money_in(text) is None
+
+    @pytest.mark.parametrize(
+        "text,expected_amount",
+        [
+            # Real units must still parse — the fix is surgical.
+            ("được bố cho 500k", 500_000.0),
+            ("được lì xì 50 ngàn", 50_000.0),
+            ("được thưởng 2tr", 2_000_000.0),
+            ("được bố cho 1.000.000", 1_000_000.0),
+        ],
+    )
+    def test_real_units_still_record(self, text, expected_amount):
+        parsed = _parse_duoc_money_in(text)
+        assert parsed is not None, f"fast-path declined a real money-in: {text!r}"
+        assert parsed["amount"] == expected_amount
+        assert parsed["transaction_type"] == "money_in"
 
 
 @pytest.mark.asyncio

--- a/tests/test_phase_4_2_5/test_admin_spa_fallback.py
+++ b/tests/test_phase_4_2_5/test_admin_spa_fallback.py
@@ -130,7 +130,7 @@ def dual_mount_app(tmp_path: Path) -> TestClient:
     async def ping():
         return {"ok": True}
 
-    @app.get("/admin", include_in_schema=False)
+    @app.api_route("/admin", methods=["GET", "HEAD"], include_in_schema=False)
     async def admin_redirect():
         return RedirectResponse(url="/admin/", status_code=308)
 
@@ -155,6 +155,14 @@ def test_admin_trailing_slash_serves_spa(dual_mount_app: TestClient):
 
 def test_admin_bare_redirects_to_trailing_slash(dual_mount_app: TestClient):
     resp = dual_mount_app.get("/admin")
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/admin/"
+
+
+def test_admin_bare_head_also_redirects(dual_mount_app: TestClient):
+    # `curl -I` and uptime probes use HEAD — must see the redirect, not fall
+    # through to the static mount and 404.
+    resp = dual_mount_app.head("/admin")
     assert resp.status_code == 308
     assert resp.headers["location"] == "/admin/"
 

--- a/tests/test_phase_4_2_5/test_admin_spa_fallback.py
+++ b/tests/test_phase_4_2_5/test_admin_spa_fallback.py
@@ -103,3 +103,100 @@ def test_no_accept_header_does_not_fall_back(spa_app: TestClient):
     # Plain HTTP clients (curl with no -H) get a clean 404, not HTML.
     resp = spa_app.get("/nope", headers={"Accept": "application/json"})
     assert resp.status_code == 404
+
+
+# --------------------------------------------------------------------------
+# Dual-mount regression — issue: /admin/ canonical URL must serve the SPA,
+# not 404. main.py mounts SPAStaticFiles at both /admin and / and redirects
+# bare /admin → /admin/. These tests mirror that wiring.
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def dual_mount_app(tmp_path: Path) -> TestClient:
+    static_dir = tmp_path / "admin"
+    static_dir.mkdir()
+    (static_dir / "index.html").write_text("<html>admin spa</html>")
+    (static_dir / "favicon.ico").write_bytes(b"\x00")
+    assets_dir = static_dir / "assets"
+    assets_dir.mkdir()
+    (assets_dir / "index.js").write_text("console.log('app')")
+
+    from fastapi.responses import RedirectResponse
+
+    app = FastAPI()
+
+    @app.get("/api/v1/ping")
+    async def ping():
+        return {"ok": True}
+
+    @app.get("/admin", include_in_schema=False)
+    async def admin_redirect():
+        return RedirectResponse(url="/admin/", status_code=308)
+
+    app.mount(
+        "/admin",
+        SPAStaticFiles(directory=str(static_dir), html=True),
+        name="admin-spa-prefix",
+    )
+    app.mount(
+        "/", SPAStaticFiles(directory=str(static_dir), html=True), name="admin-spa"
+    )
+    return TestClient(app, follow_redirects=False)
+
+
+def test_admin_trailing_slash_serves_spa(dual_mount_app: TestClient):
+    # Canonical URL — must work for both browser AND curl-style requests.
+    for accept in (BROWSER_ACCEPT, "*/*", "application/json"):
+        resp = dual_mount_app.get("/admin/", headers={"Accept": accept})
+        assert resp.status_code == 200, f"accept={accept}: {resp.status_code}"
+        assert "admin spa" in resp.text, f"accept={accept}: {resp.text!r}"
+
+
+def test_admin_bare_redirects_to_trailing_slash(dual_mount_app: TestClient):
+    resp = dual_mount_app.get("/admin")
+    assert resp.status_code == 308
+    assert resp.headers["location"] == "/admin/"
+
+
+def test_admin_subpath_browser_navigation_serves_index(dual_mount_app: TestClient):
+    for path in ("/admin/login", "/admin/users", "/admin/anything/deep"):
+        resp = dual_mount_app.get(path, headers={"Accept": BROWSER_ACCEPT})
+        assert resp.status_code == 200, f"{path}: {resp.status_code}"
+        assert "admin spa" in resp.text
+
+
+def test_admin_real_asset_served_directly(dual_mount_app: TestClient):
+    # SPA build references /assets/* at root — but ALSO must resolve
+    # under /admin/assets/* so an /admin/-based index.html can load them.
+    resp = dual_mount_app.get("/admin/assets/index.js")
+    assert resp.status_code == 200
+    assert "console.log" in resp.text
+
+    resp = dual_mount_app.get("/assets/index.js")
+    assert resp.status_code == 200
+    assert "console.log" in resp.text
+
+
+def test_admin_api_not_swallowed(dual_mount_app: TestClient):
+    # Real API route still wins over SPA mounts.
+    resp = dual_mount_app.get("/api/v1/ping")
+    assert resp.status_code == 200
+    assert resp.json() == {"ok": True}
+
+    # Unknown API path keeps real 404, even with browser Accept.
+    resp = dual_mount_app.get(
+        "/api/v1/unknown", headers={"Accept": BROWSER_ACCEPT}
+    )
+    assert resp.status_code == 404
+    assert "admin spa" not in resp.text
+
+
+def test_admin_subpath_missing_asset_keeps_404(dual_mount_app: TestClient):
+    # Browsers fetching <script>/<link>/<img> under /admin/ never send
+    # text/html — must get a real 404 instead of HTML masquerading as JS.
+    resp = dual_mount_app.get(
+        "/admin/assets/missing.js", headers={"Accept": "*/*"}
+    )
+    assert resp.status_code == 404
+    assert "admin spa" not in resp.text


### PR DESCRIPTION
## Release 1.4.4.12 (11th prod release)

Merge `main` → `prod`.

### Commits included (main ahead of prod)

- 1c1e116 Merge PR #951 (claude/fix-wallet-picker-p2-948)
- 4bb6ef0 fix(source): address PR #948 P2 review follow-ups
- 953efa0 Merge PR #949 (claude/festive-wozniak-rM02D)
- 6ec1d3c fix(source): unstuck wallet source picker (#948)
- 4846fb8 Merge PR #945 (claude/magical-franklin-ozW3Z)
- 644d4b2 Merge PR #946 (claude/laughing-knuth-6Rk0G)
- e940c32 Merge PR #947 (claude/compassionate-carson-hJfhg)
- 53807da fix(nlu): recognise leading bare dates in transaction inputs
- 867de7d fix(source): show user's real e-wallet assets in source picker
- 7c8d374 Fix /admin SPA basename and HEAD redirect
- 23a2161 fix(admin): serve SPA at /admin/ (canonical URL) in addition to /
- 7f95f83 Merge PR #944 (claude/money-in-amount-scaling-3jA93)
- 855f040 fix(money): stop unit abbreviation from matching a word prefix

### Theme

Bug fixes:
- Wallet source picker: unstuck flow + show user's real e-wallet assets + P2 review follow-ups (rollback on insert failure, legacy `txsrc_wallet:<provider>` / `chsrc_wl:<provider>` callback back-compat, subtype validation in `resolve_source_asset_for_payload`, mini-app `e_wallet_asset:<id>` source serialization)
- NLU: recognise leading bare dates in transaction inputs
- Admin SPA: serve at canonical `/admin/` URL + HEAD redirect fix
- Money formatting: prevent unit abbreviation from matching a word prefix

### Test plan
- [ ] Operator review of diff on GitHub
- [ ] Merge via GitHub UI (no fast-forward push from CLI)
- [ ] Post-merge smoke test on prod


---
_Generated by [Claude Code](https://claude.ai/code/session_013xTdCA9aeC9ekTr2NDa3cw)_