### PR TITLE
feat(credit-card): add soft-delete flow with two-tap confirm

### DIFF
--- a/alembic/versions/20260608_credit_card_soft_delete.py
+++ b/alembic/versions/20260608_credit_card_soft_delete.py
@@ -1,0 +1,63 @@
+"""soft-delete column for credit_cards
+
+Adds ``credit_cards.deleted_at`` so the bot can hide a card from the
+spending menu and the NLU source-matcher without losing the row — the
+existing ``expenses.source_credit_card_id`` FK rows (history,
+debt-balance ledger) must keep resolving even after the user removes
+the card.
+
+The unique ``(user_id, bank_name)`` constraint is converted to a
+partial unique index that only applies to live rows, so a user can
+re-add the same bank after deleting it.
+
+Revision ID: 20260608ccsoftdel
+Revises: 20260605relaxwalletck
+Create Date: 2026-06-08
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260608ccsoftdel"
+down_revision = "20260605relaxwalletck"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "credit_cards",
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.drop_constraint(
+        "uq_credit_cards_user_bank_name", "credit_cards", type_="unique"
+    )
+    op.create_index(
+        "uq_credit_cards_user_bank_name_active",
+        "credit_cards",
+        ["user_id", "bank_name"],
+        unique=True,
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+    op.create_index(
+        "idx_credit_cards_user_active",
+        "credit_cards",
+        ["user_id"],
+        postgresql_where=sa.text("deleted_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_credit_cards_user_active", table_name="credit_cards")
+    op.drop_index(
+        "uq_credit_cards_user_bank_name_active", table_name="credit_cards"
+    )
+    op.create_unique_constraint(
+        "uq_credit_cards_user_bank_name",
+        "credit_cards",
+        ["user_id", "bank_name"],
+    )
+    op.drop_column("credit_cards", "deleted_at")

--- a/backend/bot/handlers/callbacks.py
+++ b/backend/bot/handlers/callbacks.py
@@ -409,6 +409,37 @@ async def handle_transaction_callback(
         await undo_credit_card_create(db, chat_id, user, data.split(":")[-1])
         await answer_callback(callback_query["id"])
         return True
+    if (
+        data == "expense:credit:del"
+        or data.startswith("expense:credit:del:pick:")
+        or data.startswith("expense:credit:del:confirm:")
+    ):
+        from backend.bot.handlers.credit_card_entry import (
+            confirm_credit_card_delete,
+            show_credit_card_delete_confirm,
+            show_credit_card_delete_picker,
+        )
+
+        from_user = callback_query.get("from") or {}
+        telegram_id = from_user.get("id")
+        message = callback_query.get("message") or {}
+        chat_id = message.get("chat", {}).get("id")
+        user = await get_user_by_telegram_id(db, telegram_id) if telegram_id else None
+        if not user or chat_id is None:
+            await answer_callback(callback_query["id"])
+            return True
+        if data == "expense:credit:del":
+            await show_credit_card_delete_picker(db, chat_id, user)
+        elif data.startswith("expense:credit:del:pick:"):
+            await show_credit_card_delete_confirm(
+                db, chat_id, user, data[len("expense:credit:del:pick:"):]
+            )
+        else:
+            await confirm_credit_card_delete(
+                db, chat_id, user, data[len("expense:credit:del:confirm:"):]
+            )
+        await answer_callback(callback_query["id"])
+        return True
 
     if (
         data.startswith("chsrc_bk:")

--- a/backend/bot/handlers/credit_card_entry.py
+++ b/backend/bot/handlers/credit_card_entry.py
@@ -7,11 +7,21 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from backend.bot.formatters.money import format_money_full
 from backend.schemas.credit_card import CreditCardCreate
 from backend.services import wizard_service
-from backend.services.credit_card_service import create_credit_card, delete_credit_card, list_credit_cards
+from backend.services.credit_card_service import (
+    create_credit_card,
+    delete_credit_card,
+    get_credit_card,
+    list_credit_cards,
+)
 from backend.services.dashboard_service import get_user_by_telegram_id
 from backend.services.telegram_service import send_message
 
 FLOW_CREDIT_CARD_ADD = "credit_card_add"
+
+CB_CREDIT_ADD = "expense:credit:add"
+CB_CREDIT_DELETE_PICKER = "expense:credit:del"
+CB_CREDIT_DELETE_PICK_PREFIX = "expense:credit:del:pick:"
+CB_CREDIT_DELETE_CONFIRM_PREFIX = "expense:credit:del:confirm:"
 
 
 def _credit_card_footer_keyboard(card_id: str) -> dict:
@@ -41,16 +51,22 @@ async def show_credit_cards_list(db: AsyncSession, chat_id: int, user) -> None:
             )
         text = "\n".join(lines)
 
+    keyboard_rows = [
+        [{"text": "➕ Thêm thẻ tín dụng", "callback_data": CB_CREDIT_ADD}],
+    ]
+    if cards:
+        # Only surface delete when there's actually something to remove
+        # — keeps the empty-state focused on the primary "Thêm" action.
+        keyboard_rows.append(
+            [{"text": "🗑️ Xóa thẻ tín dụng", "callback_data": CB_CREDIT_DELETE_PICKER}]
+        )
+    keyboard_rows.append([{"text": "Quay về", "callback_data": "menu:expenses"}])
+
     await send_message(
         chat_id=chat_id,
         text=text,
         parse_mode="Markdown",
-        reply_markup={
-            "inline_keyboard": [
-                [{"text": "➕ Thêm thẻ tín dụng", "callback_data": "expense:credit:add"}],
-                [{"text": "Quay về", "callback_data": "menu:expenses"}],
-            ]
-        },
+        reply_markup={"inline_keyboard": keyboard_rows},
     )
 
 
@@ -150,6 +166,120 @@ async def handle_credit_card_text_input(db: AsyncSession, message: dict) -> bool
         return True
 
     return False
+
+
+async def show_credit_card_delete_picker(
+    db: AsyncSession, chat_id: int, user
+) -> None:
+    """List live cards as buttons so the user can pick which to remove.
+
+    Falls back to a friendly message when nothing remains — the entry
+    point is suppressed in the list view, but a stale callback (e.g.
+    user tapped "Xóa" then deleted from another device) shouldn't
+    crash.
+    """
+    cards = await list_credit_cards(db, user.id)
+    if not cards:
+        await send_message(
+            chat_id=chat_id,
+            text="Bạn chưa có thẻ tín dụng nào để xóa.",
+            reply_markup={
+                "inline_keyboard": [
+                    [{"text": "◀️ Quay lại", "callback_data": "menu:expenses:credit_cards"}],
+                ]
+            },
+        )
+        return
+
+    rows = [
+        [{
+            "text": f"💳 {card.bank_name}",
+            "callback_data": f"{CB_CREDIT_DELETE_PICK_PREFIX}{card.id}",
+        }]
+        for card in cards
+    ]
+    rows.append([{"text": "◀️ Quay lại", "callback_data": "menu:expenses:credit_cards"}])
+    await send_message(
+        chat_id=chat_id,
+        text="🗑️ <b>Chọn thẻ tín dụng muốn xóa:</b>",
+        parse_mode="HTML",
+        reply_markup={"inline_keyboard": rows},
+    )
+
+
+async def show_credit_card_delete_confirm(
+    db: AsyncSession, chat_id: int, user, card_id: str
+) -> None:
+    """Two-tap guard before the irreversible (to the user) soft-delete."""
+    from uuid import UUID
+
+    try:
+        parsed_id = UUID(card_id)
+    except ValueError:
+        await send_message(chat_id=chat_id, text="Không tìm thấy thẻ này.")
+        return
+    card = await get_credit_card(db, user.id, parsed_id)
+    if card is None:
+        await send_message(
+            chat_id=chat_id,
+            text="Thẻ này không còn trong danh sách. Bạn quay lại chọn thẻ khác nhé.",
+            reply_markup={
+                "inline_keyboard": [
+                    [{"text": "◀️ Quay lại", "callback_data": CB_CREDIT_DELETE_PICKER}],
+                ]
+            },
+        )
+        return
+
+    await send_message(
+        chat_id=chat_id,
+        text=(
+            f"🗑️ <b>Xác nhận xóa thẻ {card.bank_name}?</b>\n\n"
+            "Thẻ sẽ được gỡ khỏi danh sách và không hiển thị khi ghi chi tiêu mới.\n"
+            "Lịch sử chi tiêu đã ghi nhận trên thẻ này vẫn được giữ nguyên."
+        ),
+        parse_mode="HTML",
+        reply_markup={
+            "inline_keyboard": [
+                [{
+                    "text": "🗑️ Xóa thật",
+                    "callback_data": f"{CB_CREDIT_DELETE_CONFIRM_PREFIX}{card.id}",
+                }],
+                [{
+                    "text": "❌ Không, giữ lại",
+                    "callback_data": CB_CREDIT_DELETE_PICKER,
+                }],
+            ]
+        },
+    )
+
+
+async def confirm_credit_card_delete(
+    db: AsyncSession, chat_id: int, user, card_id: str
+) -> None:
+    """Perform the soft-delete and bounce back to the (now-updated) list."""
+    from uuid import UUID
+
+    try:
+        parsed_id = UUID(card_id)
+    except ValueError:
+        await send_message(chat_id=chat_id, text="Không tìm thấy thẻ này.")
+        return
+    card = await delete_credit_card(db, user.id, parsed_id)
+    if card is None:
+        await send_message(
+            chat_id=chat_id,
+            text="Thẻ này đã được xóa trước đó rồi 🤔",
+        )
+    else:
+        await send_message(
+            chat_id=chat_id,
+            text=f"✅ Đã xóa thẻ <b>{card.bank_name}</b> khỏi danh sách.",
+            parse_mode="HTML",
+        )
+    # Refresh the list so the user sees the updated state immediately
+    # — saves one extra tap and confirms the action visually.
+    await show_credit_cards_list(db, chat_id, user)
 
 
 async def undo_credit_card_create(db: AsyncSession, chat_id: int, user, card_id: str) -> None:

--- a/backend/bot/handlers/message.py
+++ b/backend/bot/handlers/message.py
@@ -138,6 +138,7 @@ async def _extract_credit_card_source(db: AsyncSession, user_id, text: str) -> t
         select(CreditCard).where(
             CreditCard.user_id == user_id,
             func.lower(CreditCard.bank_name) == bank.lower(),
+            CreditCard.deleted_at.is_(None),
         )
     )
     card = row.scalar_one_or_none()

--- a/backend/models/credit_card.py
+++ b/backend/models/credit_card.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import datetime
 from decimal import Decimal
 
-from sqlalchemy import DateTime, Index, Integer, Numeric, String, UniqueConstraint
+from sqlalchemy import DateTime, Index, Integer, Numeric, String
 from sqlalchemy.dialects.postgresql import UUID
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -26,8 +26,22 @@ class CreditCard(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow, onupdate=datetime.utcnow
     )
+    deleted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     __table_args__ = (
-        UniqueConstraint("user_id", "bank_name", name="uq_credit_cards_user_bank_name"),
+        Index(
+            "uq_credit_cards_user_bank_name_active",
+            "user_id",
+            "bank_name",
+            unique=True,
+            postgresql_where=("deleted_at IS NULL"),
+        ),
         Index("idx_credit_cards_user_created", "user_id", "created_at"),
+        Index(
+            "idx_credit_cards_user_active",
+            "user_id",
+            postgresql_where=("deleted_at IS NULL"),
+        ),
     )

--- a/backend/profile/handlers/profile_menu.py
+++ b/backend/profile/handlers/profile_menu.py
@@ -907,7 +907,12 @@ async def _expense_source_options(user_id: Any, db: AsyncSession) -> list[tuple[
 
     cards = (
         await db.execute(
-            select(CreditCard).where(CreditCard.user_id == user_id).order_by(CreditCard.created_at.asc())
+            select(CreditCard)
+            .where(
+                CreditCard.user_id == user_id,
+                CreditCard.deleted_at.is_(None),
+            )
+            .order_by(CreditCard.created_at.asc())
         )
     ).scalars().all()
     for card in cards:

--- a/backend/services/credit_card_service.py
+++ b/backend/services/credit_card_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid
+from datetime import datetime
 from decimal import Decimal
 
 from sqlalchemy import func, select
@@ -13,12 +14,17 @@ from backend.schemas.credit_card import CreditCardCreate, CreditCardUpdate
 async def create_credit_card(
     db: AsyncSession, user_id: uuid.UUID, data: CreditCardCreate
 ) -> CreditCard:
-    """Create a credit card for a user with case-insensitive bank-name uniqueness."""
+    """Create a credit card for a user with case-insensitive bank-name uniqueness.
+
+    Soft-deleted rows are excluded from the duplicate check, so a user
+    who removed a card can re-add the same bank later.
+    """
     normalized_name = data.bank_name.strip()
     existing = await db.execute(
         select(CreditCard).where(
             CreditCard.user_id == user_id,
             func.lower(CreditCard.bank_name) == normalized_name.lower(),
+            CreditCard.deleted_at.is_(None),
         )
     )
     if existing.scalar_one_or_none() is not None:
@@ -37,10 +43,18 @@ async def create_credit_card(
 
 
 async def list_credit_cards(db: AsyncSession, user_id: uuid.UUID) -> list[CreditCard]:
-    """Return all credit cards of a user, newest first."""
+    """Return all live credit cards of a user, newest first.
+
+    Soft-deleted rows are filtered out — they only stay around so
+    historical expenses referencing ``source_credit_card_id`` can still
+    resolve the bank name on the confirmation card.
+    """
     rows = await db.execute(
         select(CreditCard)
-        .where(CreditCard.user_id == user_id)
+        .where(
+            CreditCard.user_id == user_id,
+            CreditCard.deleted_at.is_(None),
+        )
         .order_by(CreditCard.created_at.desc())
     )
     return list(rows.scalars().all())
@@ -49,12 +63,13 @@ async def list_credit_cards(db: AsyncSession, user_id: uuid.UUID) -> list[Credit
 async def get_credit_card(
     db: AsyncSession, user_id: uuid.UUID, card_id: uuid.UUID
 ) -> CreditCard | None:
-    """Return a single credit card by id if it belongs to the user."""
+    """Return a single live credit card by id if it belongs to the user."""
     return (
         await db.execute(
             select(CreditCard).where(
                 CreditCard.id == card_id,
                 CreditCard.user_id == user_id,
+                CreditCard.deleted_at.is_(None),
             )
         )
     ).scalar_one_or_none()
@@ -63,9 +78,16 @@ async def get_credit_card(
 async def delete_credit_card(
     db: AsyncSession, user_id: uuid.UUID, card_id: uuid.UUID
 ) -> CreditCard | None:
+    """Soft-delete the card.
+
+    The row is kept so historical expenses' ``source_credit_card_id``
+    FK still resolves; ``deleted_at`` hides it from the menu, NLU
+    matcher, and profile picker. Returns the deleted card or ``None``
+    if no live card matched.
+    """
     card = await get_credit_card(db, user_id, card_id)
     if card is None:
         return None
-    await db.delete(card)
+    card.deleted_at = datetime.utcnow()
     await db.flush()
     return card

--- a/backend/tests/test_credit_card_entry_handler.py
+++ b/backend/tests/test_credit_card_entry_handler.py
@@ -1,3 +1,4 @@
+import uuid
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -5,7 +6,7 @@ import pytest
 
 
 @pytest.mark.asyncio
-async def test_show_credit_cards_list_has_buttons(monkeypatch):
+async def test_show_credit_cards_list_empty_state_omits_delete_button(monkeypatch):
     from backend.bot.handlers import credit_card_entry
 
     sent = {}
@@ -22,7 +23,41 @@ async def test_show_credit_cards_list_has_buttons(monkeypatch):
     await credit_card_entry.show_credit_cards_list(db=None, chat_id=1, user=SimpleNamespace(id=1))
     rows = sent["reply_markup"]["inline_keyboard"]
     assert rows[0][0]["callback_data"] == "expense:credit:add"
-    assert rows[1][0]["callback_data"] == "menu:expenses"
+    # No delete button when there are no cards — keeps the empty state clean
+    callbacks = [btn["callback_data"] for row in rows for btn in row]
+    assert "expense:credit:del" not in callbacks
+    assert rows[-1][0]["callback_data"] == "menu:expenses"
+
+
+@pytest.mark.asyncio
+async def test_show_credit_cards_list_with_cards_includes_delete_button(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    sent = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.list_credit_cards",
+        AsyncMock(return_value=[
+            SimpleNamespace(
+                id=uuid.uuid4(),
+                bank_name="MSB",
+                credit_limit=10_000_000,
+                debt_balance=1_500_000,
+                closing_date=20,
+            )
+        ]),
+    )
+
+    await credit_card_entry.show_credit_cards_list(db=None, chat_id=1, user=SimpleNamespace(id=1))
+    rows = sent["reply_markup"]["inline_keyboard"]
+    callbacks = [btn["callback_data"] for row in rows for btn in row]
+    assert "expense:credit:add" in callbacks
+    assert "expense:credit:del" in callbacks
+    assert "menu:expenses" in callbacks
 
 
 @pytest.mark.asyncio
@@ -54,3 +89,194 @@ async def test_credit_card_wizard_happy_path(monkeypatch):
     assert await credit_card_entry.handle_credit_card_text_input(None, {**msg, "text": "100tr"})
     assert await credit_card_entry.handle_credit_card_text_input(None, {**msg, "text": "20"})
     assert any("Đã thêm thẻ tín dụng thành công" in s for s in sent)
+
+
+@pytest.mark.asyncio
+async def test_delete_picker_lists_cards_as_buttons(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    card_id = uuid.uuid4()
+    sent = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.list_credit_cards",
+        AsyncMock(return_value=[SimpleNamespace(id=card_id, bank_name="MSB")]),
+    )
+
+    await credit_card_entry.show_credit_card_delete_picker(
+        db=None, chat_id=1, user=SimpleNamespace(id=1)
+    )
+    rows = sent["reply_markup"]["inline_keyboard"]
+    assert rows[0][0]["callback_data"] == f"expense:credit:del:pick:{card_id}"
+    assert "MSB" in rows[0][0]["text"]
+    assert rows[-1][0]["callback_data"] == "menu:expenses:credit_cards"
+
+
+@pytest.mark.asyncio
+async def test_delete_picker_empty_state(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    sent = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.list_credit_cards",
+        AsyncMock(return_value=[]),
+    )
+
+    await credit_card_entry.show_credit_card_delete_picker(
+        db=None, chat_id=1, user=SimpleNamespace(id=1)
+    )
+    assert "chưa có thẻ" in sent["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_delete_confirm_shows_two_tap_keyboard(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    card_id = uuid.uuid4()
+    sent = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.get_credit_card",
+        AsyncMock(return_value=SimpleNamespace(id=card_id, bank_name="MSB")),
+    )
+
+    await credit_card_entry.show_credit_card_delete_confirm(
+        db=None, chat_id=1, user=SimpleNamespace(id=1), card_id=str(card_id)
+    )
+    rows = sent["reply_markup"]["inline_keyboard"]
+    assert rows[0][0]["text"] == "🗑️ Xóa thật"
+    assert rows[0][0]["callback_data"] == f"expense:credit:del:confirm:{card_id}"
+    assert rows[1][0]["text"] == "❌ Không, giữ lại"
+    assert rows[1][0]["callback_data"] == "expense:credit:del"
+    assert "MSB" in sent["text"]
+
+
+@pytest.mark.asyncio
+async def test_delete_confirm_rejects_invalid_card_id(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    sent = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+
+    await credit_card_entry.show_credit_card_delete_confirm(
+        db=None, chat_id=1, user=SimpleNamespace(id=1), card_id="not-a-uuid"
+    )
+    assert "Không tìm thấy" in sent["text"]
+
+
+@pytest.mark.asyncio
+async def test_delete_confirm_card_already_deleted(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    card_id = uuid.uuid4()
+    sent = {}
+
+    async def fake_send_message(**kwargs):
+        sent.update(kwargs)
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.get_credit_card",
+        AsyncMock(return_value=None),
+    )
+
+    await credit_card_entry.show_credit_card_delete_confirm(
+        db=None, chat_id=1, user=SimpleNamespace(id=1), card_id=str(card_id)
+    )
+    assert "không còn" in sent["text"].lower()
+
+
+@pytest.mark.asyncio
+async def test_confirm_credit_card_delete_soft_deletes_and_refreshes(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    card_id = uuid.uuid4()
+    sent: list[dict] = []
+
+    async def fake_send_message(**kwargs):
+        sent.append(dict(kwargs))
+
+    delete_mock = AsyncMock(return_value=SimpleNamespace(bank_name="MSB"))
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.delete_credit_card", delete_mock
+    )
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.list_credit_cards",
+        AsyncMock(return_value=[]),
+    )
+
+    await credit_card_entry.confirm_credit_card_delete(
+        db=None, chat_id=1, user=SimpleNamespace(id=1), card_id=str(card_id)
+    )
+    delete_mock.assert_awaited_once()
+    # First message confirms the deletion, second message re-renders the list
+    assert any("Đã xóa thẻ" in m["text"] for m in sent)
+    assert any("Thẻ tín dụng" in m["text"] for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_confirm_credit_card_delete_idempotent(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    card_id = uuid.uuid4()
+    sent: list[dict] = []
+
+    async def fake_send_message(**kwargs):
+        sent.append(dict(kwargs))
+
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.delete_credit_card",
+        AsyncMock(return_value=None),
+    )
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.list_credit_cards",
+        AsyncMock(return_value=[]),
+    )
+
+    await credit_card_entry.confirm_credit_card_delete(
+        db=None, chat_id=1, user=SimpleNamespace(id=1), card_id=str(card_id)
+    )
+    assert any("đã được xóa" in m["text"].lower() for m in sent)
+
+
+@pytest.mark.asyncio
+async def test_confirm_credit_card_delete_rejects_invalid_uuid(monkeypatch):
+    from backend.bot.handlers import credit_card_entry
+
+    sent: list[dict] = []
+
+    async def fake_send_message(**kwargs):
+        sent.append(dict(kwargs))
+
+    delete_mock = AsyncMock()
+    monkeypatch.setattr(credit_card_entry, "send_message", fake_send_message)
+    monkeypatch.setattr(
+        "backend.bot.handlers.credit_card_entry.delete_credit_card", delete_mock
+    )
+
+    await credit_card_entry.confirm_credit_card_delete(
+        db=None, chat_id=1, user=SimpleNamespace(id=1), card_id="not-a-uuid"
+    )
+    # Must not even attempt the DB call when the id is malformed —
+    # callback data comes from the wire, treat it as untrusted input.
+    delete_mock.assert_not_awaited()
+    assert "Không tìm thấy" in sent[0]["text"]

--- a/tests/test_credit_card_service.py
+++ b/tests/test_credit_card_service.py
@@ -94,3 +94,49 @@ async def test_get_credit_card_not_found():
     db = FakeDB([None])
     got = await credit_card_service.get_credit_card(db, uuid.uuid4(), uuid.uuid4())
     assert got is None
+
+
+@pytest.mark.asyncio
+async def test_delete_credit_card_sets_deleted_at_instead_of_hard_delete():
+    """Soft delete: mutate the row and flush — never call ``db.delete``."""
+    card = SimpleNamespace(
+        id=uuid.uuid4(),
+        user_id=uuid.uuid4(),
+        bank_name="MSB",
+        deleted_at=None,
+    )
+    db = FakeDB([card])
+
+    got = await credit_card_service.delete_credit_card(db, card.user_id, card.id)
+
+    assert got is card
+    assert got.deleted_at is not None
+    assert db.flushed is True
+
+
+@pytest.mark.asyncio
+async def test_delete_credit_card_returns_none_when_missing():
+    db = FakeDB([None])
+    got = await credit_card_service.delete_credit_card(db, uuid.uuid4(), uuid.uuid4())
+    assert got is None
+
+
+@pytest.mark.asyncio
+async def test_create_credit_card_allows_reusing_bank_name_after_soft_delete():
+    """Soft-deleted rows must NOT block re-adding the same bank."""
+    # ``None`` here means the uniqueness query found no live (non-deleted)
+    # match — even if a soft-deleted row exists, the service's WHERE clause
+    # filters it out, so the create proceeds.
+    db = FakeDB([None])
+    user_id = uuid.uuid4()
+    data = CreditCardCreate(
+        bank_name="MSB",
+        credit_limit=5_000_000,
+        closing_date=15,
+        debt_balance=0,
+    )
+
+    got = await credit_card_service.create_credit_card(db, user_id, data)
+
+    assert got.bank_name == "MSB"
+    assert db.flushed is True


### PR DESCRIPTION
## Summary

Adds a delete-credit-card capability to the **Chi tiêu → Thẻ tín dụng** menu so users can remove a card they no longer use, without losing any history.

- New button `🗑️ Xóa thẻ tín dụng` appears under `➕ Thêm thẻ tín dụng` only when the user actually has cards (empty state stays clean).
- Flow: picker → two-tap confirm (`🗑️ Xóa thật` / `❌ Không, giữ lại`) → soft-delete → list re-renders so the user sees the new state immediately.
- Per CLAUDE.md ("never hard-delete user data"), delete sets `deleted_at` instead of removing the row. Historical expense attribution (`expense_source_resolver`) stays intact.
- Uniqueness on `bank_name` becomes a partial unique index over live rows — so a user can re-add a previously deleted bank without hitting a duplicate.

## Changes

- **Migration** `20260608_credit_card_soft_delete.py`: adds `deleted_at`, swaps `uq_credit_cards_user_bank_name` for partial unique `uq_credit_cards_user_bank_name_active` + supporting `idx_credit_cards_user_active`.
- **Model** `backend/models/credit_card.py`: `deleted_at` column + partial unique index.
- **Service** `backend/services/credit_card_service.py`: list/get filter soft-deleted rows; `delete_credit_card` sets `deleted_at` and `flush`es (no `db.delete`).
- **Handler** `backend/bot/handlers/credit_card_entry.py`: new `show_credit_card_delete_picker`, `show_credit_card_delete_confirm`, `confirm_credit_card_delete`; list now toggles the delete button by presence.
- **Callbacks** `backend/bot/handlers/callbacks.py`: `expense:credit:del` / `:del:pick:<id>` / `:del:confirm:<id>` dispatch.
- **NLU + profile picker** filter soft-deleted cards; expense source resolver stays unfiltered to preserve historical labels.

## Test plan

- [x] `pytest tests/test_credit_card_service.py` — 7/7 pass (new: soft-delete sets `deleted_at`, idempotency, bank-name reuse after delete).
- [x] `pytest backend/tests/test_credit_card_entry_handler.py` — 10/11 pass; the 1 failing test (`test_credit_card_wizard_happy_path`) was already broken on `main` and is unrelated to this change.
- [x] `pytest backend/tests/test_expense_source_resolver.py` — 26/27 pass; the 1 failure is also pre-existing on `main`.
- [ ] Manual smoke on Telegram: add card → delete → re-add same bank name → confirm list reflects each step.
- [ ] Run `alembic upgrade head` on staging to validate the partial-index migration.

https://claude.ai/code/session_01DVBgHKmWECjvzbY9MTBXzq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DVBgHKmWECjvzbY9MTBXzq)_