### PR TITLE
feat(admin): feedback explorer subpage with full filtering + CSV export

### DIFF
--- a/backend/api/admin/feedback.py
+++ b/backend/api/admin/feedback.py
@@ -1,0 +1,444 @@
+from __future__ import annotations
+
+import csv
+import io
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request, Response
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import String, cast, func, or_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.api.admin.analytics import DEFAULT_TENANT_ID, PERIOD_DAYS, VN_TZ
+from backend.api.admin.deps import get_current_admin
+from backend.database import get_db
+from backend.feedback.models.feedback import (
+    FEEDBACK_STATUS_ACTIONED,
+    FEEDBACK_STATUS_DISMISSED,
+    FEEDBACK_STATUS_NEW,
+    FEEDBACK_STATUS_REVIEWING,
+    Feedback,
+)
+from backend.feedback.services.classifier import (
+    VALID_CATEGORIES,
+    VALID_PRIORITIES,
+    VALID_SENTIMENTS,
+)
+from backend.models.admin_user import AdminUser
+from backend.models.user import User
+from backend.services.admin_audit import log_action
+from backend.utils.pii import mask_name
+
+router = APIRouter(prefix="/feedback", tags=["admin-feedback"])
+
+# "all" surfaces every feedback ever recorded — the default the operator
+# requested ("show mọi feedback từ trước đến giờ"). The narrower windows
+# reuse the shared PERIOD_DAYS map so behaviour stays identical to the rest
+# of the admin portal.
+_RANGE_RE = r"^(7d|14d|30d|90d|custom|all)$"
+FEEDBACK_STATUSES = {
+    FEEDBACK_STATUS_NEW,
+    FEEDBACK_STATUS_REVIEWING,
+    FEEDBACK_STATUS_ACTIONED,
+    FEEDBACK_STATUS_DISMISSED,
+}
+SORT_KEYS = {"newest", "oldest"}
+# Hard cap on a single CSV export so one operator cannot stream the entire
+# table into memory. Mirrors the twin-metrics export contract (X-* headers).
+CSV_ROW_CAP = 50_000
+CSV_COLUMNS = [
+    "id",
+    "created_at",
+    "user_id",
+    "category",
+    "sentiment",
+    "priority",
+    "status",
+    "trigger",
+    "classification_confidence",
+    "onboarding_emoji_signal",
+    "first_responded_at",
+    "content",
+]
+
+
+class FeedbackListItem(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: str
+    user_id: str
+    display_name: str
+    telegram_id: int | None = None
+    content: str
+    category: str | None = None
+    sentiment: str | None = None
+    priority: str | None = None
+    status: str
+    trigger: str
+    classification_confidence: float | None = None
+    onboarding_emoji_signal: str | None = None
+    created_at: str
+    first_responded_at: str | None = None
+
+
+class FeedbackListResponse(BaseModel):
+    total: int
+    limit: int
+    offset: int
+    items: list[FeedbackListItem]
+
+
+def _admin_tenant_id(admin: AdminUser) -> int:
+    return admin.tenant_id or DEFAULT_TENANT_ID
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_window(
+    period: str, start_date: date | None, end_date: date | None
+) -> tuple[datetime | None, datetime | None, str]:
+    """Translate the requested period into a UTC half-open window.
+
+    ``all`` returns ``(None, None)`` so no time predicate is applied — the
+    operator sees every feedback ever recorded. Custom ranges are anchored to
+    Vietnam-time midnight (the timezone the operator picks dates in) before
+    being converted to UTC, matching the twin-metrics window helper.
+    """
+    if period == "all":
+        return None, None, "all"
+    if period == "custom" and start_date and end_date:
+        start = datetime.combine(start_date, time.min, tzinfo=VN_TZ).astimezone(
+            timezone.utc
+        )
+        end = datetime.combine(
+            end_date + timedelta(days=1), time.min, tzinfo=VN_TZ
+        ).astimezone(timezone.utc)
+        if end <= start:
+            end = start + timedelta(days=1)
+        return start, end, f"custom:{start_date.isoformat()}:{end_date.isoformat()}"
+    days = PERIOD_DAYS.get(period, 30)
+    return _now() - timedelta(days=days), _now(), period
+
+
+def _parse_user_id(user_id: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(user_id)
+    except (ValueError, AttributeError) as exc:
+        raise HTTPException(status_code=422, detail="Invalid user_id") from exc
+
+
+def _build_filters(
+    tenant_id: int,
+    *,
+    start: datetime | None,
+    end: datetime | None,
+    category: str | None,
+    sentiment: str | None,
+    priority: str | None,
+    status_: str | None,
+    user_uuid: uuid.UUID | None,
+    search: str | None,
+) -> list:
+    """Tenant-scoped predicate list shared by the list, count and CSV queries.
+
+    Feedback has no ``tenant_id`` column, so isolation is enforced by joining
+    to ``users`` and pinning ``User.tenant_id`` — an operator can never read
+    another tenant's feedback. Soft-deleted users are excluded for parity with
+    every other admin view.
+    """
+    filters = [User.tenant_id == tenant_id, User.deleted_at.is_(None)]
+    if start is not None:
+        filters.append(Feedback.created_at >= start)
+    if end is not None:
+        filters.append(Feedback.created_at < end)
+    if category:
+        filters.append(Feedback.category == category)
+    if sentiment:
+        filters.append(Feedback.sentiment == sentiment)
+    if priority:
+        filters.append(Feedback.priority == priority)
+    if status_:
+        filters.append(Feedback.status == status_)
+    if user_uuid is not None:
+        filters.append(Feedback.user_id == user_uuid)
+    if search:
+        pattern = f"%{search.strip()}%"
+        filters.append(
+            or_(
+                Feedback.content.ilike(pattern),
+                cast(Feedback.user_id, String).ilike(pattern),
+            )
+        )
+    return filters
+
+
+def _validate_enums(
+    category: str | None,
+    sentiment: str | None,
+    priority: str | None,
+    status_: str | None,
+    sort: str,
+) -> None:
+    if category is not None and category not in VALID_CATEGORIES:
+        raise HTTPException(status_code=422, detail="Invalid category")
+    if sentiment is not None and sentiment not in VALID_SENTIMENTS:
+        raise HTTPException(status_code=422, detail="Invalid sentiment")
+    if priority is not None and priority not in VALID_PRIORITIES:
+        raise HTTPException(status_code=422, detail="Invalid priority")
+    if status_ is not None and status_ not in FEEDBACK_STATUSES:
+        raise HTTPException(status_code=422, detail="Invalid status")
+    if sort not in SORT_KEYS:
+        raise HTTPException(status_code=422, detail="Invalid sort")
+
+
+def _order_by(sort: str):
+    # id is the deterministic tie-breaker so paging never repeats or skips a
+    # row when many feedbacks share a created_at timestamp.
+    if sort == "oldest":
+        return Feedback.created_at.asc(), Feedback.id.asc()
+    return Feedback.created_at.desc(), Feedback.id.desc()
+
+
+def _row_to_item(row) -> FeedbackListItem:
+    return FeedbackListItem(
+        id=str(row.id),
+        user_id=str(row.user_id),
+        display_name=mask_name(row.display_name or row.telegram_handle),
+        telegram_id=row.telegram_id,
+        content=row.content,
+        category=row.category,
+        sentiment=row.sentiment,
+        priority=row.priority,
+        status=row.status,
+        trigger=row.trigger,
+        classification_confidence=(
+            float(row.classification_confidence)
+            if row.classification_confidence is not None
+            else None
+        ),
+        onboarding_emoji_signal=row.onboarding_emoji_signal,
+        created_at=row.created_at.isoformat(),
+        first_responded_at=(
+            row.first_responded_at.isoformat() if row.first_responded_at else None
+        ),
+    )
+
+
+@router.get("", response_model=FeedbackListResponse)
+async def list_feedback(
+    request: Request,
+    period: str = Query(default="all", pattern=_RANGE_RE),
+    start_date: date | None = Query(default=None),
+    end_date: date | None = Query(default=None),
+    category: str | None = Query(default=None, max_length=50),
+    sentiment: str | None = Query(default=None, max_length=20),
+    priority: str | None = Query(default=None, max_length=20),
+    status: str | None = Query(default=None, max_length=20),
+    user_id: str | None = Query(default=None, max_length=64),
+    search: str | None = Query(default=None, max_length=200),
+    sort: str = Query(default="newest"),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+    admin: AdminUser = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db),
+) -> FeedbackListResponse:
+    _validate_enums(category, sentiment, priority, status, sort)
+    user_uuid = _parse_user_id(user_id) if user_id else None
+    tenant_id = _admin_tenant_id(admin)
+    start, end, label = _parse_window(period, start_date, end_date)
+
+    filters = _build_filters(
+        tenant_id,
+        start=start,
+        end=end,
+        category=category,
+        sentiment=sentiment,
+        priority=priority,
+        status_=status,
+        user_uuid=user_uuid,
+        search=search,
+    )
+
+    total_stmt = (
+        select(func.count())
+        .select_from(Feedback)
+        .join(User, User.id == Feedback.user_id)
+        .where(*filters)
+    )
+    list_stmt = (
+        select(
+            Feedback.id,
+            Feedback.user_id,
+            Feedback.content,
+            Feedback.category,
+            Feedback.sentiment,
+            Feedback.priority,
+            Feedback.status,
+            Feedback.trigger,
+            Feedback.classification_confidence,
+            Feedback.onboarding_emoji_signal,
+            Feedback.created_at,
+            Feedback.first_responded_at,
+            User.display_name,
+            User.telegram_handle,
+            User.telegram_id,
+        )
+        .join(User, User.id == Feedback.user_id)
+        .where(*filters)
+        .order_by(*_order_by(sort))
+        .limit(limit)
+        .offset(offset)
+    )
+
+    total = await db.scalar(total_stmt)
+    rows = (await db.execute(list_stmt)).all()
+    items = [_row_to_item(row) for row in rows]
+
+    await log_action(
+        db,
+        admin.id,
+        "feedback_list",
+        target_type="feedback",
+        payload={
+            "period": label,
+            "category": category,
+            "sentiment": sentiment,
+            "priority": priority,
+            "status": status,
+            "user_id": str(user_uuid) if user_uuid else None,
+            "search": bool(search),
+            "limit": limit,
+            "offset": offset,
+            "returned": len(items),
+        },
+        request=request,
+    )
+    await db.commit()
+
+    return FeedbackListResponse(
+        total=int(total or 0), limit=limit, offset=offset, items=items
+    )
+
+
+@router.get("/export.csv")
+async def export_feedback_csv(
+    request: Request,
+    period: str = Query(default="all", pattern=_RANGE_RE),
+    start_date: date | None = Query(default=None),
+    end_date: date | None = Query(default=None),
+    category: str | None = Query(default=None, max_length=50),
+    sentiment: str | None = Query(default=None, max_length=20),
+    priority: str | None = Query(default=None, max_length=20),
+    status: str | None = Query(default=None, max_length=20),
+    user_id: str | None = Query(default=None, max_length=64),
+    search: str | None = Query(default=None, max_length=200),
+    sort: str = Query(default="newest"),
+    admin: AdminUser = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db),
+) -> Response:
+    _validate_enums(category, sentiment, priority, status, sort)
+    user_uuid = _parse_user_id(user_id) if user_id else None
+    tenant_id = _admin_tenant_id(admin)
+    start, end, label = _parse_window(period, start_date, end_date)
+
+    filters = _build_filters(
+        tenant_id,
+        start=start,
+        end=end,
+        category=category,
+        sentiment=sentiment,
+        priority=priority,
+        status_=status,
+        user_uuid=user_uuid,
+        search=search,
+    )
+
+    total = int(
+        await db.scalar(
+            select(func.count())
+            .select_from(Feedback)
+            .join(User, User.id == Feedback.user_id)
+            .where(*filters)
+        )
+        or 0
+    )
+    rows = (
+        await db.execute(
+            select(
+                Feedback.id,
+                Feedback.created_at,
+                Feedback.user_id,
+                Feedback.category,
+                Feedback.sentiment,
+                Feedback.priority,
+                Feedback.status,
+                Feedback.trigger,
+                Feedback.classification_confidence,
+                Feedback.onboarding_emoji_signal,
+                Feedback.first_responded_at,
+                Feedback.content,
+            )
+            .join(User, User.id == Feedback.user_id)
+            .where(*filters)
+            .order_by(*_order_by(sort))
+            .limit(CSV_ROW_CAP)
+        )
+    ).all()
+
+    # csv.writer handles quoting/escaping for content that contains commas,
+    # quotes or newlines — far safer than hand-joining strings.
+    buffer = io.StringIO()
+    writer = csv.writer(buffer)
+    writer.writerow(CSV_COLUMNS)
+    for row in rows:
+        writer.writerow(
+            [
+                str(row.id),
+                row.created_at.isoformat() if row.created_at else "",
+                str(row.user_id),
+                row.category or "",
+                row.sentiment or "",
+                row.priority or "",
+                row.status or "",
+                row.trigger or "",
+                row.classification_confidence
+                if row.classification_confidence is not None
+                else "",
+                row.onboarding_emoji_signal or "",
+                row.first_responded_at.isoformat() if row.first_responded_at else "",
+                row.content or "",
+            ]
+        )
+
+    truncated = total > len(rows)
+    await log_action(
+        db,
+        admin.id,
+        "feedback_export",
+        target_type="feedback",
+        payload={
+            "period": label,
+            "category": category,
+            "sentiment": sentiment,
+            "priority": priority,
+            "status": status,
+            "user_id": str(user_uuid) if user_uuid else None,
+            "search": bool(search),
+            "rows_returned": len(rows),
+            "rows_total": total,
+            "truncated": truncated,
+        },
+        request=request,
+        commit=True,
+    )
+
+    headers = {
+        "Content-Disposition": "attachment; filename=feedback-export.csv",
+        "X-Rows-Returned": str(len(rows)),
+        "X-Rows-Total": str(total),
+        "X-Truncated": "true" if truncated else "false",
+    }
+    return Response(buffer.getvalue(), media_type="text/csv", headers=headers)

--- a/backend/main.py
+++ b/backend/main.py
@@ -18,6 +18,7 @@ from backend.api.admin import (
     analytics as admin_analytics,
     audit as admin_audit,
     auth as admin_auth,
+    feedback as admin_feedback,
     licenses as admin_licenses,
     twin_metrics as admin_twin_metrics,
     users as admin_users,
@@ -324,6 +325,7 @@ app.include_router(admin_audit.router, prefix="/api/admin")
 app.include_router(admin_users.router, prefix="/api/admin")
 app.include_router(admin_licenses.router, prefix="/api/admin")
 app.include_router(admin_twin_metrics.router, prefix="/api/admin")
+app.include_router(admin_feedback.router, prefix="/api/admin")
 app.include_router(miniapp_routes.router)  # No /api/v1 prefix — Mini App URL is public
 
 

--- a/betien-admin/scripts/test-admin-dashboard.mjs
+++ b/betien-admin/scripts/test-admin-dashboard.mjs
@@ -2,17 +2,27 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import {
   buildAdminDashboardPath,
+  buildFeedbackQueryParams,
   buildStatusChangeBody,
   buildUsersQueryParams,
+  categoryClasses,
+  feedbackStatusClasses,
+  formatConfidence,
   formatTier,
   formatValue,
   getFeatureBarWidthPct,
   getRetentionCellPresentation,
+  isUuid,
   latestDauWindow,
+  optionLabel,
+  priorityClasses,
+  sentimentClasses,
   statusClasses,
   statusLabel,
   toDatedChartData,
 } from '../src/utils/adminDashboardUtils.js';
+
+const SAMPLE_UUID = 'a1b2c3d4-e5f6-4a7b-8c9d-0e1f2a3b4c5d';
 
 test('API client path builder encodes params and drops empty filters', () => {
   assert.equal(
@@ -78,4 +88,94 @@ test('KPI formatter supports empty state, percent, USD, and vi-VN numbers', () =
   assert.equal(formatValue(42.42, 'percent'), '42.4%');
   assert.equal(formatValue(1.234, 'usd'), '$1.23');
   assert.equal(formatValue(1234567, 'number'), '1.234.567');
+});
+
+test('feedback query builder maps UI state onto the backend snake_case contract', () => {
+  assert.deepEqual(
+    buildFeedbackQueryParams({
+      period: '30d',
+      category: 'bug',
+      sentiment: 'negative',
+      priority: 'high',
+      status: 'new',
+      userId: SAMPLE_UUID,
+      search: 'app crash',
+      sort: 'oldest',
+      limit: 50,
+      offset: 100,
+    }),
+    {
+      period: '30d',
+      start_date: undefined,
+      end_date: undefined,
+      category: 'bug',
+      sentiment: 'negative',
+      priority: 'high',
+      status: 'new',
+      user_id: SAMPLE_UUID,
+      search: 'app crash',
+      sort: 'oldest',
+      limit: 50,
+      offset: 100,
+    },
+  );
+});
+
+test('feedback query builder applies defaults for period, sort, limit, and offset', () => {
+  const params = buildFeedbackQueryParams();
+  assert.equal(params.period, 'all');
+  assert.equal(params.sort, 'newest');
+  assert.equal(params.limit, 50);
+  assert.equal(params.offset, 0);
+});
+
+test('feedback query builder only forwards custom dates when the custom period is active', () => {
+  const ranged = buildFeedbackQueryParams({ period: '7d', startDate: '2026-01-01', endDate: '2026-01-31' });
+  assert.equal(ranged.start_date, undefined);
+  assert.equal(ranged.end_date, undefined);
+
+  const custom = buildFeedbackQueryParams({ period: 'custom', startDate: '2026-01-01', endDate: '2026-01-31' });
+  assert.equal(custom.start_date, '2026-01-01');
+  assert.equal(custom.end_date, '2026-01-31');
+});
+
+test('feedback path builder drops empty filters so unused params never hit the wire', () => {
+  assert.equal(
+    buildAdminDashboardPath('/feedback', buildFeedbackQueryParams({ category: 'praise', userId: SAMPLE_UUID })),
+    `/feedback?period=all&category=praise&user_id=${SAMPLE_UUID}&sort=newest&limit=50&offset=0`,
+  );
+});
+
+test('isUuid accepts full UUIDs (trimmed) and rejects partial or malformed ids', () => {
+  assert.equal(isUuid(SAMPLE_UUID), true);
+  assert.equal(isUuid(`  ${SAMPLE_UUID}  `), true);
+  assert.equal(isUuid('not-a-uuid'), false);
+  assert.equal(isUuid('a1b2c3d4'), false);
+  assert.equal(isUuid(''), false);
+  assert.equal(isUuid(null), false);
+});
+
+test('optionLabel resolves labels, falls back to raw value, and renders an em dash when empty', () => {
+  const options = [{ value: 'bug', label: 'Bug' }, { value: 'praise', label: 'Praise' }];
+  assert.equal(optionLabel(options, 'bug'), 'Bug');
+  assert.equal(optionLabel(options, 'unmapped'), 'unmapped');
+  assert.equal(optionLabel(options, ''), '—');
+  assert.equal(optionLabel(options, null), '—');
+});
+
+test('formatConfidence renders an em dash for null and rounds ratios to whole percent', () => {
+  assert.equal(formatConfidence(null), '—');
+  assert.equal(formatConfidence(undefined), '—');
+  assert.equal(formatConfidence(0.873), '87%');
+  assert.equal(formatConfidence(1), '100%');
+  assert.equal(formatConfidence(0), '0%');
+});
+
+test('feedback badge color maps cover every backend enum value', () => {
+  assert.match(categoryClasses.bug, /burgundy/);
+  assert.match(sentimentClasses.negative, /burgundy/);
+  assert.match(sentimentClasses.positive, /sage/);
+  assert.match(priorityClasses.high, /burgundy/);
+  assert.match(feedbackStatusClasses.new, /gold/);
+  assert.match(feedbackStatusClasses.actioned, /sage/);
 });

--- a/betien-admin/src/App.jsx
+++ b/betien-admin/src/App.jsx
@@ -2,6 +2,7 @@ import { Navigate, Route, Routes } from 'react-router-dom';
 import ProtectedRoute from './components/ProtectedRoute';
 import ChangePasswordPage from './pages/ChangePasswordPage';
 import DashboardPage from './pages/DashboardPage';
+import FeedbackPage from './pages/FeedbackPage';
 import LoginPage from './pages/LoginPage';
 
 export default function App() {
@@ -13,6 +14,7 @@ export default function App() {
       </Route>
       <Route element={<ProtectedRoute />}>
         <Route path="/" element={<DashboardPage />} />
+        <Route path="/feedback" element={<FeedbackPage />} />
       </Route>
       <Route path="*" element={<Navigate to="/" replace />} />
     </Routes>

--- a/betien-admin/src/api/adminDashboard.js
+++ b/betien-admin/src/api/adminDashboard.js
@@ -1,5 +1,10 @@
 import { apiFetch } from './client';
-import { buildAdminDashboardPath, buildStatusChangeBody, buildUsersQueryParams } from '../utils/adminDashboardUtils';
+import {
+  buildAdminDashboardPath,
+  buildFeedbackQueryParams,
+  buildStatusChangeBody,
+  buildUsersQueryParams,
+} from '../utils/adminDashboardUtils';
 
 export function getOverview(period) {
   return apiFetch(buildAdminDashboardPath('/stats/overview', { period }));
@@ -71,6 +76,14 @@ export function getTwinDeltaDistribution(params = {}) {
 
 export function getTwinDeltaCsvUrl(params = {}) {
   return buildAdminDashboardPath('/twin-metrics/delta-distribution.csv', params);
+}
+
+export function getFeedbackList(params = {}) {
+  return apiFetch(buildAdminDashboardPath('/feedback', buildFeedbackQueryParams(params)));
+}
+
+export function getFeedbackCsvUrl(params = {}) {
+  return buildAdminDashboardPath('/feedback/export.csv', buildFeedbackQueryParams(params));
 }
 
 export function invalidateTwinCache(sections = []) {

--- a/betien-admin/src/components/Header.jsx
+++ b/betien-admin/src/components/Header.jsx
@@ -1,4 +1,5 @@
-import { CalendarDays, LogOut, RefreshCcw, ShieldCheck } from 'lucide-react';
+import { CalendarDays, LayoutDashboard, LogOut, MessageSquareText, RefreshCcw, ShieldCheck } from 'lucide-react';
+import { NavLink } from 'react-router-dom';
 import { DATE_RANGES, useDateRange } from '../context/DateRangeContext';
 import { useAuth } from '../context/AuthContext';
 
@@ -10,24 +11,82 @@ const dateFormatter = new Intl.DateTimeFormat('vi-VN', {
   timeZone: 'Asia/Ho_Chi_Minh',
 });
 
-export default function Header() {
-  const { admin, logout } = useAuth();
+const NAV_ITEMS = [
+  { to: '/', label: 'Dashboard', icon: LayoutDashboard, end: true },
+  { to: '/feedback', label: 'Feedback', icon: MessageSquareText, end: false },
+];
+
+// The date-range buttons + Refresh read DateRangeContext, so they only render on
+// pages wrapped in DateRangeProvider (the dashboard). Isolating them in a nested
+// component keeps the hook out of Header's top level so subpages without the
+// provider (e.g. /feedback) can reuse the same chrome via showDateControls=false.
+function DateRangeControls() {
   const { range, setRange, refresh } = useDateRange();
+  return (
+    <>
+      <div className="grid grid-cols-4 rounded-full border border-hairline bg-porcelain p-1 text-xs font-medium text-ink-500" aria-label="Chọn khoảng thời gian">
+        {DATE_RANGES.map((item) => (
+          <button
+            key={item.value}
+            type="button"
+            onClick={() => setRange(item.value)}
+            className={`rounded-full px-3 py-1.5 transition ${range === item.value ? 'bg-ink-900 text-white' : 'hover:bg-gold-50 hover:text-ink-900'}`}
+            aria-pressed={range === item.value}
+          >
+            {item.value}
+          </button>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={refresh}
+        className="inline-flex items-center justify-center gap-2 rounded-full border border-hairline bg-porcelain px-4 py-2 text-sm font-medium text-ink-900 transition hover:border-gold hover:text-gold"
+        aria-label="Refresh dashboard data"
+      >
+        <RefreshCcw className="h-4 w-4" aria-hidden="true" />
+        Refresh
+      </button>
+    </>
+  );
+}
+
+export default function Header({ showDateControls = true }) {
+  const { admin, logout } = useAuth();
 
   return (
     <header className="sticky top-0 z-20 border-b border-hairline bg-paper/95 backdrop-blur">
       <div className="mx-auto flex max-w-7xl flex-col gap-4 px-4 py-4 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:px-8">
-        <div className="flex items-center gap-3">
-          <div className="flex h-11 w-11 items-center justify-center rounded-full border border-gold bg-gold-50 font-display text-lg font-semibold text-gold">
-            B
+        <div className="flex flex-wrap items-center gap-x-6 gap-y-3">
+          <div className="flex items-center gap-3">
+            <div className="flex h-11 w-11 items-center justify-center rounded-full border border-gold bg-gold-50 font-display text-lg font-semibold text-gold">
+              B
+            </div>
+            <div>
+              <p className="font-display text-xl font-semibold leading-none text-ink-900">Bé Tiền Ops</p>
+              <p className="mt-1 flex items-center gap-1 text-xs text-ink-500">
+                <ShieldCheck className="h-3.5 w-3.5 text-sage" aria-hidden="true" />
+                Admin Observability · {admin?.full_name || admin?.email}
+              </p>
+            </div>
           </div>
-          <div>
-            <p className="font-display text-xl font-semibold leading-none text-ink-900">Bé Tiền Ops</p>
-            <p className="mt-1 flex items-center gap-1 text-xs text-ink-500">
-              <ShieldCheck className="h-3.5 w-3.5 text-sage" aria-hidden="true" />
-              Admin Observability · {admin?.full_name || admin?.email}
-            </p>
-          </div>
+
+          <nav className="flex items-center gap-1 rounded-full border border-hairline bg-porcelain p-1 text-sm font-medium text-ink-500" aria-label="Khu vực quản trị">
+            {NAV_ITEMS.map((item) => {
+              const Icon = item.icon;
+              return (
+                <NavLink
+                  key={item.to}
+                  to={item.to}
+                  end={item.end}
+                  className={({ isActive }) => `inline-flex items-center gap-1.5 rounded-full px-3 py-1.5 transition ${isActive ? 'bg-ink-900 text-white' : 'hover:bg-gold-50 hover:text-ink-900'}`}
+                >
+                  <Icon className="h-4 w-4" aria-hidden="true" />
+                  {item.label}
+                </NavLink>
+              );
+            })}
+          </nav>
         </div>
 
         <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
@@ -36,29 +95,7 @@ export default function Header() {
             <span>{dateFormatter.format(new Date())}</span>
           </div>
 
-          <div className="grid grid-cols-4 rounded-full border border-hairline bg-porcelain p-1 text-xs font-medium text-ink-500" aria-label="Chọn khoảng thời gian">
-            {DATE_RANGES.map((item) => (
-              <button
-                key={item.value}
-                type="button"
-                onClick={() => setRange(item.value)}
-                className={`rounded-full px-3 py-1.5 transition ${range === item.value ? 'bg-ink-900 text-white' : 'hover:bg-gold-50 hover:text-ink-900'}`}
-                aria-pressed={range === item.value}
-              >
-                {item.value}
-              </button>
-            ))}
-          </div>
-
-          <button
-            type="button"
-            onClick={refresh}
-            className="inline-flex items-center justify-center gap-2 rounded-full border border-hairline bg-porcelain px-4 py-2 text-sm font-medium text-ink-900 transition hover:border-gold hover:text-gold"
-            aria-label="Refresh dashboard data"
-          >
-            <RefreshCcw className="h-4 w-4" aria-hidden="true" />
-            Refresh
-          </button>
+          {showDateControls ? <DateRangeControls /> : null}
 
           <button
             type="button"

--- a/betien-admin/src/pages/FeedbackPage.jsx
+++ b/betien-admin/src/pages/FeedbackPage.jsx
@@ -1,0 +1,458 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Download,
+  Filter,
+  MessageSquareText,
+  RotateCcw,
+  Search,
+  X,
+} from 'lucide-react';
+import Header from '../components/Header';
+import MetricShell from '../components/MetricShell';
+import { getApiBase, getStoredToken } from '../api/client';
+import { getFeedbackCsvUrl, getFeedbackList } from '../api/adminDashboard';
+import {
+  categoryClasses,
+  feedbackCategoryOptions,
+  feedbackPeriodOptions,
+  feedbackPriorityOptions,
+  feedbackSentimentOptions,
+  feedbackSortOptions,
+  feedbackStatusClasses,
+  feedbackStatusOptions,
+  formatConfidence,
+  formatDateTime,
+  formatNumber,
+  isUuid,
+  optionLabel,
+  priorityClasses,
+  sentimentClasses,
+  shortId,
+} from '../utils/adminDashboardUtils';
+
+const PAGE_SIZE = 50;
+
+export default function FeedbackPage() {
+  return (
+    <main className="min-h-screen bg-paper font-body text-ink-900">
+      <Header showDateControls={false} />
+      <div className="mx-auto max-w-7xl space-y-6 px-4 py-6 sm:px-6 lg:px-8">
+        <FeedbackExplorer />
+      </div>
+    </main>
+  );
+}
+
+function FeedbackExplorer() {
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [userIdInput, setUserIdInput] = useState('');
+  const [userId, setUserId] = useState('');
+  const [period, setPeriod] = useState('all');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [category, setCategory] = useState('');
+  const [sentiment, setSentiment] = useState('');
+  const [priority, setPriority] = useState('');
+  const [status, setStatus] = useState('');
+  const [sort, setSort] = useState('newest');
+  const [page, setPage] = useState(0);
+  const [payload, setPayload] = useState({ total: 0, items: [] });
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [selected, setSelected] = useState(null);
+  const [exporting, setExporting] = useState(false);
+  const [exportNote, setExportNote] = useState('');
+
+  const trimmedUserId = userIdInput.trim();
+  const userIdInvalid = trimmedUserId !== '' && !isUuid(trimmedUserId);
+  const customIncomplete = period === 'custom' && (!startDate || !endDate);
+
+  // Debounce free-text search so each keystroke doesn't hit the API.
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setSearch(searchInput.trim());
+      setPage(0);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [searchInput]);
+
+  // The user_id box only forwards a value once it is a complete UUID — the
+  // backend 422s on malformed ids. Partial matches still work via the search
+  // box (which scans user_id substrings server-side).
+  useEffect(() => {
+    const timer = window.setTimeout(() => {
+      setUserId(isUuid(trimmedUserId) ? trimmedUserId : '');
+      setPage(0);
+    }, 300);
+    return () => window.clearTimeout(timer);
+  }, [trimmedUserId]);
+
+  const filterParams = useMemo(
+    () => ({ period, startDate, endDate, category, sentiment, priority, status, userId, search, sort }),
+    [period, startDate, endDate, category, sentiment, priority, status, userId, search, sort],
+  );
+
+  useEffect(() => {
+    // A custom range with a missing endpoint would silently fall back to "all"
+    // server-side; skip the call until the operator picks both dates.
+    if (customIncomplete) {
+      setLoading(false);
+      return undefined;
+    }
+    let alive = true;
+    async function loadFeedback() {
+      setLoading(true);
+      setError('');
+      try {
+        const next = await getFeedbackList({ ...filterParams, limit: PAGE_SIZE, offset: page * PAGE_SIZE });
+        if (alive) setPayload(next);
+      } catch (err) {
+        if (alive) setError(err.message || 'Không tải được feedback.');
+      } finally {
+        if (alive) setLoading(false);
+      }
+    }
+    loadFeedback();
+    return () => {
+      alive = false;
+    };
+  }, [filterParams, page, customIncomplete]);
+
+  const items = payload.items || [];
+  const total = payload.total || 0;
+  const pageCount = Math.max(Math.ceil(total / PAGE_SIZE), 1);
+  const canPrev = page > 0;
+  const canNext = page + 1 < pageCount;
+  const activeFilterCount =
+    (category ? 1 : 0) +
+    (sentiment ? 1 : 0) +
+    (priority ? 1 : 0) +
+    (status ? 1 : 0) +
+    (period !== 'all' ? 1 : 0) +
+    (userId ? 1 : 0) +
+    (search ? 1 : 0);
+
+  function updateFilter(setter) {
+    return (event) => {
+      setter(event.target.value);
+      setPage(0);
+    };
+  }
+
+  function selectPeriod(value) {
+    setPeriod(value);
+    setPage(0);
+  }
+
+  function resetFilters() {
+    setSearchInput('');
+    setSearch('');
+    setUserIdInput('');
+    setUserId('');
+    setPeriod('all');
+    setStartDate('');
+    setEndDate('');
+    setCategory('');
+    setSentiment('');
+    setPriority('');
+    setStatus('');
+    setSort('newest');
+    setPage(0);
+  }
+
+  async function exportCsv() {
+    setExporting(true);
+    setExportNote('');
+    try {
+      const token = getStoredToken();
+      const response = await fetch(`${getApiBase()}${getFeedbackCsvUrl(filterParams)}`, {
+        headers: token ? { Authorization: `Bearer ${token}` } : {},
+      });
+      if (!response.ok) throw new Error('Export thất bại. Thử lại sau.');
+      const truncated = response.headers.get('X-Truncated') === 'true';
+      const rowsReturned = response.headers.get('X-Rows-Returned');
+      const rowsTotal = response.headers.get('X-Rows-Total');
+      const blob = await response.blob();
+      const objectUrl = URL.createObjectURL(blob);
+      const link = document.createElement('a');
+      link.href = objectUrl;
+      link.download = 'feedback-export.csv';
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(objectUrl);
+      if (truncated) {
+        setExportNote(`Đã xuất ${rowsReturned}/${rowsTotal} dòng (đạt giới hạn). Thu hẹp bộ lọc để xuất trọn bộ.`);
+      }
+    } catch (err) {
+      setExportNote(err.message || 'Export thất bại.');
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <MetricShell eyebrow="Voice of customer" title="Feedback explorer">
+      <p className="-mt-2 mb-4 flex items-center gap-2 text-xs text-ink-500">
+        <MessageSquareText className="h-3.5 w-3.5 text-gold" aria-hidden="true" />
+        Toàn bộ feedback từ trước đến giờ — lọc theo thời gian, phân loại, hoặc user ID.
+      </p>
+
+      <div className="mb-4 space-y-3">
+        <div className="flex flex-col gap-3 lg:flex-row">
+          <div className="relative min-w-0 flex-1">
+            <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-ink-500" aria-hidden="true" />
+            <input
+              value={searchInput}
+              onChange={(event) => setSearchInput(event.target.value)}
+              placeholder="Tìm trong nội dung feedback hoặc user ID..."
+              className="w-full rounded-full border border-hairline bg-paper py-2 pl-10 pr-4 text-sm text-ink-900 placeholder:text-ink-500"
+              aria-label="Tìm kiếm feedback"
+            />
+          </div>
+          <div className="min-w-0 flex-1 lg:max-w-xs">
+            <input
+              value={userIdInput}
+              onChange={(event) => setUserIdInput(event.target.value)}
+              placeholder="Lọc theo user ID (UUID đầy đủ)"
+              className={`w-full rounded-full border bg-paper px-4 py-2 font-mono text-xs text-ink-900 placeholder:font-body placeholder:text-ink-500 ${userIdInvalid ? 'border-burgundy/50' : 'border-hairline'}`}
+              aria-label="Lọc theo user ID"
+              aria-invalid={userIdInvalid}
+            />
+            {userIdInvalid ? (
+              <p className="mt-1 pl-4 text-[11px] text-burgundy">Nhập UUID đầy đủ để lọc chính xác (hoặc dùng ô tìm kiếm cho khớp một phần).</p>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {feedbackPeriodOptions.map((item) => (
+            <button
+              key={item.value}
+              type="button"
+              onClick={() => selectPeriod(item.value)}
+              className={`rounded-full border px-3 py-1.5 text-xs font-medium transition ${period === item.value ? 'border-ink-900 bg-ink-900 text-white' : 'border-hairline bg-paper text-ink-500 hover:bg-gold-50 hover:text-ink-900'}`}
+              aria-pressed={period === item.value}
+            >
+              {item.label}
+            </button>
+          ))}
+          {period === 'custom' ? (
+            <div className="flex flex-wrap items-center gap-2">
+              <input
+                type="date"
+                value={startDate}
+                max={endDate || undefined}
+                onChange={updateFilter(setStartDate)}
+                className="rounded-full border border-hairline bg-paper px-3 py-1.5 text-xs text-ink-900"
+                aria-label="Từ ngày"
+              />
+              <span className="text-xs text-ink-500">→</span>
+              <input
+                type="date"
+                value={endDate}
+                min={startDate || undefined}
+                onChange={updateFilter(setEndDate)}
+                className="rounded-full border border-hairline bg-paper px-3 py-1.5 text-xs text-ink-900"
+                aria-label="Đến ngày"
+              />
+            </div>
+          ) : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Select label="Category" value={category} options={feedbackCategoryOptions} onChange={updateFilter(setCategory)} />
+          <Select label="Sentiment" value={sentiment} options={feedbackSentimentOptions} onChange={updateFilter(setSentiment)} />
+          <Select label="Priority" value={priority} options={feedbackPriorityOptions} onChange={updateFilter(setPriority)} />
+          <Select label="Status" value={status} options={feedbackStatusOptions} onChange={updateFilter(setStatus)} />
+          <Select label="Sort" value={sort} options={feedbackSortOptions} onChange={updateFilter(setSort)} />
+          {activeFilterCount > 0 ? (
+            <button
+              type="button"
+              onClick={resetFilters}
+              className="inline-flex items-center gap-1.5 rounded-full border border-hairline bg-paper px-3 py-2 text-xs font-medium text-ink-700 transition hover:border-gold hover:text-gold"
+            >
+              <RotateCcw className="h-3.5 w-3.5" aria-hidden="true" />
+              Reset ({activeFilterCount})
+            </button>
+          ) : null}
+          <button
+            type="button"
+            onClick={exportCsv}
+            disabled={exporting || customIncomplete}
+            className="ml-auto inline-flex items-center gap-2 rounded-full border border-hairline bg-paper px-3 py-2 text-xs font-semibold text-ink-700 transition hover:bg-gold-50 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Download className="h-3.5 w-3.5" aria-hidden="true" />
+            {exporting ? 'Đang xuất...' : 'Export CSV'}
+          </button>
+        </div>
+        {exportNote ? (
+          <p className="rounded-2xl border border-orange/30 bg-orange/10 px-3 py-2 text-xs leading-5 text-orange">{exportNote}</p>
+        ) : null}
+      </div>
+
+      {error ? <p className="mb-3 rounded-2xl border border-burgundy/30 bg-burgundy/10 p-3 text-sm text-burgundy" role="alert">{error}</p> : null}
+
+      <div className="overflow-x-auto rounded-2xl border border-hairline">
+        <table className="min-w-full divide-y divide-hairline text-sm">
+          <thead className="bg-paper text-left text-[11px] uppercase tracking-[0.16em] text-ink-500">
+            <tr>
+              <th className="px-4 py-3">Thời gian</th>
+              <th className="px-4 py-3">User</th>
+              <th className="px-4 py-3">Nội dung</th>
+              <th className="hidden px-4 py-3 md:table-cell">Phân loại</th>
+              <th className="hidden px-4 py-3 lg:table-cell">Sentiment</th>
+              <th className="hidden px-4 py-3 lg:table-cell">Ưu tiên</th>
+              <th className="px-4 py-3">Trạng thái</th>
+              <th className="hidden px-4 py-3 text-right xl:table-cell">Độ tin cậy</th>
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-hairline bg-porcelain">
+            {loading ? (
+              <FeedbackRowsSkeleton />
+            ) : customIncomplete ? (
+              <tr>
+                <td colSpan="8" className="px-4 py-10 text-center text-ink-500">
+                  <span className="inline-flex items-center gap-2"><Filter className="h-4 w-4" aria-hidden="true" /> Chọn cả ngày bắt đầu và kết thúc để lọc theo khoảng tùy chọn.</span>
+                </td>
+              </tr>
+            ) : items.length === 0 ? (
+              <tr><td colSpan="8" className="px-4 py-10 text-center text-ink-500">Không có feedback khớp bộ lọc.</td></tr>
+            ) : (
+              items.map((item) => (
+                <tr key={item.id} className="cursor-pointer align-top transition hover:bg-gold-50/50" onClick={() => setSelected(item)}>
+                  <td className="whitespace-nowrap px-4 py-3 font-mono text-xs text-ink-500">{formatDateTime(item.created_at)}</td>
+                  <td className="max-w-[160px] px-4 py-3">
+                    <p className="truncate font-medium text-ink-900">{item.display_name || '—'}</p>
+                    <p className="truncate font-mono text-[11px] text-ink-500">{shortId(item.user_id)}</p>
+                    {item.telegram_id ? <p className="truncate font-mono text-[11px] text-ink-500">tg:{item.telegram_id}</p> : null}
+                  </td>
+                  <td className="max-w-[320px] px-4 py-3">
+                    <p className="line-clamp-2 text-ink-900">{item.content}</p>
+                    <p className="mt-1 text-[11px] text-ink-500">{item.trigger}</p>
+                  </td>
+                  <td className="hidden px-4 py-3 md:table-cell"><Badge value={item.category} options={feedbackCategoryOptions} classes={categoryClasses} /></td>
+                  <td className="hidden px-4 py-3 lg:table-cell"><Badge value={item.sentiment} options={feedbackSentimentOptions} classes={sentimentClasses} /></td>
+                  <td className="hidden px-4 py-3 lg:table-cell"><Badge value={item.priority} options={feedbackPriorityOptions} classes={priorityClasses} /></td>
+                  <td className="px-4 py-3"><Badge value={item.status} options={feedbackStatusOptions} classes={feedbackStatusClasses} /></td>
+                  <td className="hidden px-4 py-3 text-right font-mono text-xs text-ink-500 xl:table-cell">{formatConfidence(item.classification_confidence)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-4 flex flex-col gap-3 text-sm text-ink-500 sm:flex-row sm:items-center sm:justify-between">
+        <p>{formatNumber(total)} feedback · trang {page + 1}/{pageCount}</p>
+        <div className="flex gap-2">
+          <button type="button" disabled={!canPrev} onClick={() => setPage((value) => Math.max(value - 1, 0))} className="inline-flex items-center gap-1 rounded-full border border-hairline px-3 py-2 disabled:cursor-not-allowed disabled:opacity-40">
+            <ChevronLeft className="h-4 w-4" /> Trước
+          </button>
+          <button type="button" disabled={!canNext} onClick={() => setPage((value) => value + 1)} className="inline-flex items-center gap-1 rounded-full border border-hairline px-3 py-2 disabled:cursor-not-allowed disabled:opacity-40">
+            Sau <ChevronRight className="h-4 w-4" />
+          </button>
+        </div>
+      </div>
+
+      {selected ? <FeedbackDetailModal item={selected} onClose={() => setSelected(null)} /> : null}
+    </MetricShell>
+  );
+}
+
+function FeedbackDetailModal({ item, onClose }) {
+  useEffect(() => {
+    function onKeyDown(event) {
+      if (event.key === 'Escape') onClose();
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center bg-ink-900/45 p-4 sm:items-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Chi tiết feedback"
+      onClick={onClose}
+    >
+      <div
+        className="max-h-[92vh] w-full max-w-2xl overflow-y-auto rounded-[2rem] border border-hairline bg-porcelain p-5 shadow-2xl"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="mb-4 flex items-start justify-between gap-3">
+          <div>
+            <p className="text-[10px] font-semibold uppercase tracking-[0.2em] text-gold">Feedback detail</p>
+            <h3 className="mt-1 font-display text-2xl font-semibold text-ink-900">{item.display_name || shortId(item.user_id)}</h3>
+            <p className="font-mono text-xs text-ink-500">{item.user_id}{item.telegram_id ? ` · tg:${item.telegram_id}` : ''}</p>
+          </div>
+          <button type="button" onClick={onClose} className="rounded-full border border-hairline p-2 text-ink-500 hover:text-ink-900" aria-label="Đóng chi tiết feedback">
+            <X className="h-5 w-5" />
+          </button>
+        </div>
+
+        <div className="mb-4 flex flex-wrap gap-2">
+          <Badge value={item.category} options={feedbackCategoryOptions} classes={categoryClasses} />
+          <Badge value={item.sentiment} options={feedbackSentimentOptions} classes={sentimentClasses} />
+          <Badge value={item.priority} options={feedbackPriorityOptions} classes={priorityClasses} />
+          <Badge value={item.status} options={feedbackStatusOptions} classes={feedbackStatusClasses} />
+        </div>
+
+        <div className="rounded-2xl border border-hairline bg-paper p-4">
+          <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-ink-500">Nội dung</p>
+          <p className="mt-2 whitespace-pre-wrap text-sm leading-6 text-ink-900">{item.content}</p>
+        </div>
+
+        <div className="mt-4 grid gap-3 sm:grid-cols-2">
+          <DetailTile label="Thời gian" value={formatDateTime(item.created_at)} />
+          <DetailTile label="Phản hồi đầu tiên" value={item.first_responded_at ? formatDateTime(item.first_responded_at) : 'Chưa phản hồi'} />
+          <DetailTile label="Trigger" value={item.trigger || '—'} />
+          <DetailTile label="Độ tin cậy phân loại" value={formatConfidence(item.classification_confidence)} />
+          <DetailTile label="Tín hiệu emoji onboarding" value={item.onboarding_emoji_signal || '—'} />
+          <DetailTile label="Feedback ID" value={item.id} mono />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DetailTile({ label, value, mono = false }) {
+  return (
+    <div className="rounded-2xl border border-hairline bg-paper p-4">
+      <p className="text-[10px] font-semibold uppercase tracking-[0.16em] text-ink-500">{label}</p>
+      <p className={`mt-2 break-words text-sm font-medium text-ink-900 ${mono ? 'font-mono text-xs' : ''}`}>{value}</p>
+    </div>
+  );
+}
+
+function Badge({ value, options, classes }) {
+  if (value === undefined || value === null || value === '') return <span className="text-ink-500">—</span>;
+  return (
+    <span className={`whitespace-nowrap rounded-full border px-2.5 py-1 text-xs font-semibold ${classes[value] || 'border-ink-100 bg-ink-100 text-ink-500'}`}>
+      {optionLabel(options, value)}
+    </span>
+  );
+}
+
+function Select({ label, value, options, onChange }) {
+  return (
+    <label>
+      <span className="sr-only">{label}</span>
+      <select value={value} onChange={onChange} className="rounded-full border border-hairline bg-paper px-3 py-2 text-sm text-ink-900">
+        {options.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+      </select>
+    </label>
+  );
+}
+
+function FeedbackRowsSkeleton() {
+  return Array.from({ length: 8 }).map((_, index) => (
+    <tr key={index}>
+      <td colSpan="8" className="px-4 py-3"><div className="h-9 animate-pulse rounded-xl bg-ink-100" /></td>
+    </tr>
+  ));
+}

--- a/betien-admin/src/utils/adminDashboardUtils.js
+++ b/betien-admin/src/utils/adminDashboardUtils.js
@@ -107,3 +107,150 @@ export function statusLabel(value) {
   if (value === 'at_risk') return 'At risk';
   return value ? value.charAt(0).toUpperCase() + value.slice(1) : '—';
 }
+
+// ---------------------------------------------------------------------------
+// Feedback explorer (admin → /feedback subpage)
+// ---------------------------------------------------------------------------
+// Option values MUST mirror the backend contracts:
+//   period       → backend/api/admin/feedback.py::_RANGE_RE
+//   category     → backend/feedback/services/classifier.py::VALID_CATEGORIES
+//   sentiment    → ::VALID_SENTIMENTS
+//   priority     → ::VALID_PRIORITIES
+//   status       → backend/feedback/models/feedback.py::FEEDBACK_STATUS_*
+//   sort         → backend/api/admin/feedback.py::SORT_KEYS
+
+export const feedbackPeriodOptions = [
+  { value: 'all', label: 'Tất cả' },
+  { value: '7d', label: '7 ngày' },
+  { value: '14d', label: '14 ngày' },
+  { value: '30d', label: '30 ngày' },
+  { value: '90d', label: '90 ngày' },
+  { value: 'custom', label: 'Tùy chọn' },
+];
+
+export const feedbackCategoryOptions = [
+  { value: '', label: 'All categories' },
+  { value: 'bug', label: 'Bug' },
+  { value: 'complaint', label: 'Complaint' },
+  { value: 'suggestion', label: 'Suggestion' },
+  { value: 'question', label: 'Question' },
+  { value: 'praise', label: 'Praise' },
+  { value: 'other', label: 'Other' },
+];
+
+export const feedbackSentimentOptions = [
+  { value: '', label: 'All sentiment' },
+  { value: 'positive', label: 'Positive' },
+  { value: 'neutral', label: 'Neutral' },
+  { value: 'negative', label: 'Negative' },
+];
+
+export const feedbackPriorityOptions = [
+  { value: '', label: 'All priority' },
+  { value: 'high', label: 'High' },
+  { value: 'medium', label: 'Medium' },
+  { value: 'low', label: 'Low' },
+];
+
+export const feedbackStatusOptions = [
+  { value: '', label: 'All status' },
+  { value: 'new', label: 'New' },
+  { value: 'reviewing', label: 'Reviewing' },
+  { value: 'actioned', label: 'Actioned' },
+  { value: 'dismissed', label: 'Dismissed' },
+];
+
+export const feedbackSortOptions = [
+  { value: 'newest', label: 'Newest first' },
+  { value: 'oldest', label: 'Oldest first' },
+];
+
+export const feedbackStatusClasses = {
+  new: 'bg-gold-50 text-gold border-gold/20',
+  reviewing: 'bg-orange/10 text-orange border-orange/20',
+  actioned: 'bg-sage/10 text-sage border-sage/20',
+  dismissed: 'bg-ink-100 text-ink-500 border-ink-100',
+};
+
+export const sentimentClasses = {
+  positive: 'bg-sage/10 text-sage border-sage/20',
+  neutral: 'bg-ink-100 text-ink-500 border-ink-100',
+  negative: 'bg-burgundy/10 text-burgundy border-burgundy/20',
+};
+
+export const priorityClasses = {
+  high: 'bg-burgundy/10 text-burgundy border-burgundy/20',
+  medium: 'bg-orange/10 text-orange border-orange/20',
+  low: 'bg-ink-100 text-ink-500 border-ink-100',
+};
+
+export const categoryClasses = {
+  bug: 'bg-burgundy/10 text-burgundy border-burgundy/20',
+  complaint: 'bg-orange/10 text-orange border-orange/20',
+  suggestion: 'bg-gold-50 text-gold border-gold/20',
+  question: 'bg-ink-100 text-ink-700 border-ink-100',
+  praise: 'bg-sage/10 text-sage border-sage/20',
+  other: 'bg-ink-100 text-ink-500 border-ink-100',
+};
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function isUuid(value) {
+  return typeof value === 'string' && UUID_RE.test(value.trim());
+}
+
+export function optionLabel(options, value) {
+  if (value === undefined || value === null || value === '') return '—';
+  return options.find((item) => item.value === value)?.label || value;
+}
+
+export function formatDateTime(value) {
+  if (!value) return '—';
+  return new Intl.DateTimeFormat('vi-VN', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+    timeZone: 'Asia/Ho_Chi_Minh',
+  }).format(new Date(value));
+}
+
+export function formatConfidence(value) {
+  if (value === undefined || value === null) return '—';
+  return `${Math.round(Number(value) * 100)}%`;
+}
+
+// Maps the explorer's UI state onto the backend query contract. Custom dates
+// are only forwarded when the custom period is active; buildAdminDashboardPath
+// drops every undefined/empty value so unused filters never hit the wire.
+export function buildFeedbackQueryParams({
+  period = 'all',
+  startDate,
+  endDate,
+  category,
+  sentiment,
+  priority,
+  status,
+  userId,
+  search,
+  sort = 'newest',
+  limit = 50,
+  offset = 0,
+} = {}) {
+  const isCustom = period === 'custom';
+  return {
+    period,
+    start_date: isCustom ? startDate : undefined,
+    end_date: isCustom ? endDate : undefined,
+    category,
+    sentiment,
+    priority,
+    status,
+    user_id: userId,
+    search,
+    sort,
+    limit,
+    offset,
+  };
+}

--- a/tests/test_phase_4_4/test_admin_feedback.py
+++ b/tests/test_phase_4_4/test_admin_feedback.py
@@ -1,0 +1,567 @@
+"""Admin feedback browser — unit tests.
+
+Covers the operator-facing "all feedback" subpage added to the admin portal:
+
+- ``_parse_window`` — ``all`` applies no time predicate, ``custom`` anchors to
+  VN_TZ midnight, named periods reuse the shared PERIOD_DAYS map
+- ``_parse_user_id`` — UUID parse + 422 on garbage
+- ``_validate_enums`` — 422 on bad category/sentiment/priority/status/sort
+- ``_build_filters`` — tenant isolation via JOIN to users (Feedback has no
+  tenant_id), soft-deleted users excluded, every filter predicate present
+- ``_row_to_item`` — PII masking (mask_name) + safe float/None coercion
+- ``_order_by`` — newest/oldest deterministic tie-breaker
+- ``GET /feedback`` — returns total + items, audits, commits
+- ``GET /feedback/export.csv`` — RFC-4180 escaping, X-* headers, truncation
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import sys
+import uuid
+from datetime import date, datetime, time, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import pytest
+from fastapi import HTTPException
+from sqlalchemy.dialects import postgresql
+
+from backend.api.admin import feedback as fb
+from backend.api.admin.analytics import VN_TZ
+
+
+# ---------- helpers ----------------------------------------------------------
+
+
+def _compile_sql(stmt) -> str:
+    return str(
+        stmt.compile(
+            dialect=postgresql.dialect(),
+            compile_kwargs={"literal_binds": True},
+        )
+    )
+
+
+def _compile_filters(filters) -> str:
+    return " ".join(_compile_sql(f) for f in filters)
+
+
+def _make_row(**overrides):
+    """A SimpleNamespace shaped like the list-query result row."""
+    base = dict(
+        id=uuid.UUID("11111111-1111-1111-1111-111111111111"),
+        user_id=uuid.UUID("22222222-2222-2222-2222-222222222222"),
+        content="App rất tốt",
+        category="praise",
+        sentiment="positive",
+        priority="low",
+        status="new",
+        trigger="passive_command",
+        classification_confidence=0.91,
+        onboarding_emoji_signal=None,
+        created_at=datetime(2026, 6, 1, 9, 30, tzinfo=timezone.utc),
+        first_responded_at=None,
+        display_name="Nguyễn Văn An",
+        telegram_handle="annguyen",
+        telegram_id=12345,
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _make_csv_row(**overrides):
+    """A SimpleNamespace shaped like the CSV-query result row."""
+    base = dict(
+        id=uuid.UUID("33333333-3333-3333-3333-333333333333"),
+        created_at=datetime(2026, 6, 2, 10, 0, tzinfo=timezone.utc),
+        user_id=uuid.UUID("44444444-4444-4444-4444-444444444444"),
+        category="bug",
+        sentiment="negative",
+        priority="high",
+        status="reviewing",
+        trigger="passive_command",
+        classification_confidence=0.77,
+        onboarding_emoji_signal=None,
+        first_responded_at=None,
+        content="Bình thường",
+    )
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeDB:
+    """Returns a queued scalar then queued execute rows; records commits."""
+
+    def __init__(self, *, scalar=0, rows=None):
+        self._scalar = scalar
+        self._rows = rows or []
+        self.executed = []
+        self.commits = 0
+
+    async def scalar(self, stmt):
+        self.executed.append(("scalar", stmt))
+        return self._scalar
+
+    async def execute(self, stmt):
+        self.executed.append(("execute", stmt))
+        return _FakeResult(self._rows)
+
+    async def commit(self):
+        self.commits += 1
+
+
+def _admin(tenant_id=7, admin_id=42):
+    return SimpleNamespace(id=admin_id, tenant_id=tenant_id)
+
+
+def _patch_log(monkeypatch):
+    calls: list[dict] = []
+
+    async def fake_log(db, admin_id, action, **kwargs):
+        calls.append({"admin_id": admin_id, "action": action, **kwargs})
+        return SimpleNamespace(id=1)
+
+    monkeypatch.setattr(fb, "log_action", fake_log)
+    return calls
+
+
+# ---------- _parse_window ----------------------------------------------------
+
+
+def test_parse_window_all_applies_no_time_predicate():
+    start, end, label = fb._parse_window("all", None, None)
+    assert start is None
+    assert end is None
+    assert label == "all"
+
+
+def test_parse_window_custom_anchored_to_vn_tz_midnight():
+    start, end, label = fb._parse_window(
+        "custom", date(2026, 5, 1), date(2026, 5, 7)
+    )
+    expected_start = datetime.combine(
+        date(2026, 5, 1), time.min, tzinfo=VN_TZ
+    ).astimezone(timezone.utc)
+    # end is half-open: start of the day AFTER end_date
+    expected_end = datetime.combine(
+        date(2026, 5, 8), time.min, tzinfo=VN_TZ
+    ).astimezone(timezone.utc)
+    assert start == expected_start
+    assert end == expected_end
+    # 00:00 ICT == 17:00 UTC the previous day — proves we did not use naive UTC.
+    assert start.hour == 17
+    assert label == "custom:2026-05-01:2026-05-07"
+
+
+def test_parse_window_custom_single_day_is_one_day_wide():
+    start, end, _ = fb._parse_window("custom", date(2026, 5, 1), date(2026, 5, 1))
+    assert end - start == timedelta(days=1)
+
+
+def test_parse_window_named_period_uses_period_days():
+    before = fb._now()
+    start, end, label = fb._parse_window("7d", None, None)
+    after = fb._now()
+    assert label == "7d"
+    # end ~ now, start ~ now - 7d (allow for the tiny window between _now calls)
+    assert before - timedelta(days=7) - timedelta(seconds=1) <= start
+    assert start <= after - timedelta(days=7) + timedelta(seconds=1)
+    assert before - timedelta(seconds=1) <= end <= after + timedelta(seconds=1)
+
+
+def test_parse_window_custom_without_dates_falls_back_to_default_days():
+    # "custom" with missing dates must not crash — falls through to 30d default.
+    start, end, label = fb._parse_window("custom", None, None)
+    assert start is not None and end is not None
+    assert label == "custom"
+    assert timedelta(days=29) < (end - start) < timedelta(days=31)
+
+
+# ---------- _parse_user_id ---------------------------------------------------
+
+
+def test_parse_user_id_accepts_valid_uuid():
+    raw = "22222222-2222-2222-2222-222222222222"
+    assert fb._parse_user_id(raw) == uuid.UUID(raw)
+
+
+@pytest.mark.parametrize("bad", ["not-a-uuid", "123", "", "  "])
+def test_parse_user_id_rejects_garbage(bad):
+    with pytest.raises(HTTPException) as exc:
+        fb._parse_user_id(bad)
+    assert exc.value.status_code == 422
+    assert exc.value.detail == "Invalid user_id"
+
+
+# ---------- _validate_enums --------------------------------------------------
+
+
+def test_validate_enums_accepts_valid_and_none():
+    # None means "no filter" — must never raise.
+    fb._validate_enums(None, None, None, None, "newest")
+    fb._validate_enums("bug", "negative", "high", "new", "oldest")
+
+
+@pytest.mark.parametrize(
+    "args,detail",
+    [
+        (("nope", None, None, None, "newest"), "Invalid category"),
+        ((None, "meh", None, None, "newest"), "Invalid sentiment"),
+        ((None, None, "urgent", None, "newest"), "Invalid priority"),
+        ((None, None, None, "open", "newest"), "Invalid status"),
+        ((None, None, None, None, "sideways"), "Invalid sort"),
+    ],
+)
+def test_validate_enums_rejects_bad_values(args, detail):
+    with pytest.raises(HTTPException) as exc:
+        fb._validate_enums(*args)
+    assert exc.value.status_code == 422
+    assert exc.value.detail == detail
+
+
+# ---------- _build_filters ---------------------------------------------------
+
+
+def test_build_filters_always_scopes_to_tenant_and_excludes_deleted():
+    filters = fb._build_filters(
+        7,
+        start=None,
+        end=None,
+        category=None,
+        sentiment=None,
+        priority=None,
+        status_=None,
+        user_uuid=None,
+        search=None,
+    )
+    sql = _compile_filters(filters)
+    # Tenant isolation is non-negotiable: an operator may never read another
+    # tenant's feedback, and soft-deleted users are excluded for parity.
+    assert "users.tenant_id = 7" in sql
+    assert "users.deleted_at IS NULL" in sql
+    # With the "all" window no created_at predicate is emitted.
+    assert "feedbacks.created_at" not in sql
+
+
+def test_build_filters_includes_every_predicate_when_supplied():
+    start = datetime(2026, 5, 1, tzinfo=timezone.utc)
+    end = datetime(2026, 5, 8, tzinfo=timezone.utc)
+    uid = uuid.UUID("22222222-2222-2222-2222-222222222222")
+    filters = fb._build_filters(
+        1,
+        start=start,
+        end=end,
+        category="bug",
+        sentiment="negative",
+        priority="high",
+        status_="new",
+        user_uuid=uid,
+        search="crash",
+    )
+    sql = _compile_filters(filters)
+    assert "feedbacks.created_at >=" in sql
+    assert "feedbacks.created_at <" in sql
+    assert "feedbacks.category = 'bug'" in sql
+    assert "feedbacks.sentiment = 'negative'" in sql
+    assert "feedbacks.priority = 'high'" in sql
+    assert "feedbacks.status = 'new'" in sql
+    assert "feedbacks.user_id = " in sql
+    # Free-text search hits content OR the (cast) user_id, never silently
+    # ignored, and is wrapped as a LIKE pattern.
+    assert "%crash%" in sql
+    assert "feedbacks.content ILIKE" in sql
+
+
+def test_build_filters_search_is_trimmed():
+    filters = fb._build_filters(
+        1,
+        start=None,
+        end=None,
+        category=None,
+        sentiment=None,
+        priority=None,
+        status_=None,
+        user_uuid=None,
+        search="  spaced  ",
+    )
+    sql = _compile_filters(filters)
+    assert "%spaced%" in sql
+    assert "% spaced %" not in sql
+
+
+# ---------- _order_by --------------------------------------------------------
+
+
+def test_order_by_newest_is_descending_with_id_tiebreaker():
+    clauses = fb._order_by("newest")
+    sql = " ".join(_compile_sql(c) for c in clauses)
+    assert "feedbacks.created_at DESC" in sql
+    assert "feedbacks.id DESC" in sql
+
+
+def test_order_by_oldest_is_ascending_with_id_tiebreaker():
+    clauses = fb._order_by("oldest")
+    sql = " ".join(_compile_sql(c) for c in clauses)
+    assert "feedbacks.created_at ASC" in sql
+    assert "feedbacks.id ASC" in sql
+
+
+# ---------- _row_to_item -----------------------------------------------------
+
+
+def test_row_to_item_masks_display_name():
+    item = fb._row_to_item(_make_row(display_name="Nguyễn Văn An"))
+    # PII never leaves the building in the clear.
+    assert item.display_name == "Nguyễn V. A."
+    assert item.user_id == "22222222-2222-2222-2222-222222222222"
+    assert item.classification_confidence == pytest.approx(0.91)
+
+
+def test_row_to_item_falls_back_to_handle_then_em_dash():
+    item = fb._row_to_item(_make_row(display_name=None, telegram_handle="annguyen"))
+    assert item.display_name == "annguyen"
+    blank = fb._row_to_item(
+        _make_row(display_name=None, telegram_handle=None)
+    )
+    assert blank.display_name == "—"
+
+
+def test_row_to_item_handles_null_confidence_and_timestamps():
+    item = fb._row_to_item(
+        _make_row(classification_confidence=None, first_responded_at=None)
+    )
+    assert item.classification_confidence is None
+    assert item.first_responded_at is None
+    assert item.created_at == "2026-06-01T09:30:00+00:00"
+
+
+# ---------- GET /feedback ----------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_returns_total_items_and_audits(monkeypatch):
+    calls = _patch_log(monkeypatch)
+    db = _FakeDB(scalar=2, rows=[_make_row(), _make_row()])
+
+    resp = await fb.list_feedback(
+        request=None,
+        period="all",
+        start_date=None,
+        end_date=None,
+        category=None,
+        sentiment=None,
+        priority=None,
+        status=None,
+        user_id=None,
+        search=None,
+        sort="newest",
+        limit=50,
+        offset=0,
+        admin=_admin(),
+        db=db,
+    )
+
+    assert resp.total == 2
+    assert resp.limit == 50
+    assert resp.offset == 0
+    assert len(resp.items) == 2
+    assert resp.items[0].display_name == "Nguyễn V. A."
+    # Exactly one count + one list query, and the request is audited + committed.
+    assert [kind for kind, _ in db.executed] == ["scalar", "execute"]
+    assert db.commits == 1
+    assert calls and calls[0]["action"] == "feedback_list"
+    assert calls[0]["payload"]["returned"] == 2
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_tenant_scopes_both_queries(monkeypatch):
+    _patch_log(monkeypatch)
+    db = _FakeDB(scalar=0, rows=[])
+
+    await fb.list_feedback(
+        request=None,
+        period="all",
+        start_date=None,
+        end_date=None,
+        category=None,
+        sentiment=None,
+        priority=None,
+        status=None,
+        user_id=None,
+        search=None,
+        sort="newest",
+        limit=50,
+        offset=0,
+        admin=_admin(tenant_id=7),
+        db=db,
+    )
+
+    for _, stmt in db.executed:
+        assert "users.tenant_id = 7" in _compile_sql(stmt)
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_rejects_bad_enum_before_touching_db(monkeypatch):
+    calls = _patch_log(monkeypatch)
+    db = _FakeDB(scalar=0, rows=[])
+
+    with pytest.raises(HTTPException) as exc:
+        await fb.list_feedback(
+            request=None,
+            period="all",
+            start_date=None,
+            end_date=None,
+            category="bogus",
+            sentiment=None,
+            priority=None,
+            status=None,
+            user_id=None,
+            search=None,
+            sort="newest",
+            limit=50,
+            offset=0,
+            admin=_admin(),
+            db=db,
+        )
+    assert exc.value.status_code == 422
+    # Fail fast: no query, no audit, no commit on a malformed request.
+    assert db.executed == []
+    assert db.commits == 0
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_list_feedback_rejects_bad_user_id(monkeypatch):
+    _patch_log(monkeypatch)
+    db = _FakeDB(scalar=0, rows=[])
+    with pytest.raises(HTTPException) as exc:
+        await fb.list_feedback(
+            request=None,
+            period="all",
+            start_date=None,
+            end_date=None,
+            category=None,
+            sentiment=None,
+            priority=None,
+            status=None,
+            user_id="not-a-uuid",
+            search=None,
+            sort="newest",
+            limit=50,
+            offset=0,
+            admin=_admin(),
+            db=db,
+        )
+    assert exc.value.status_code == 422
+    assert db.executed == []
+
+
+# ---------- GET /feedback/export.csv -----------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_export_csv_escapes_content_and_sets_headers(monkeypatch):
+    calls = _patch_log(monkeypatch)
+    nasty = 'has, comma "quote" and\nnewline'
+    db = _FakeDB(scalar=1, rows=[_make_csv_row(content=nasty)])
+
+    resp = await fb.export_feedback_csv(
+        request=None,
+        period="all",
+        start_date=None,
+        end_date=None,
+        category=None,
+        sentiment=None,
+        priority=None,
+        status=None,
+        user_id=None,
+        search=None,
+        sort="newest",
+        admin=_admin(),
+        db=db,
+    )
+
+    assert resp.media_type == "text/csv"
+    assert resp.headers["X-Rows-Returned"] == "1"
+    assert resp.headers["X-Rows-Total"] == "1"
+    assert resp.headers["X-Truncated"] == "false"
+    assert "attachment" in resp.headers["Content-Disposition"]
+
+    # Round-trip through the csv reader: the nasty content survives intact,
+    # proving quoting/escaping is correct (no column bleed / CSV injection).
+    text = resp.body.decode("utf-8")
+    parsed = list(csv.reader(io.StringIO(text)))
+    assert parsed[0] == fb.CSV_COLUMNS
+    assert parsed[1][fb.CSV_COLUMNS.index("content")] == nasty
+    assert parsed[1][fb.CSV_COLUMNS.index("category")] == "bug"
+
+    # Export is an exfiltration-sensitive action and must be audited + committed.
+    assert calls and calls[0]["action"] == "feedback_export"
+    assert calls[0]["commit"] is True
+
+
+@pytest.mark.asyncio
+async def test_export_csv_marks_truncated_when_total_exceeds_returned(monkeypatch):
+    calls = _patch_log(monkeypatch)
+    # scalar (total) is larger than the number of rows returned -> truncated.
+    db = _FakeDB(scalar=5, rows=[_make_csv_row(), _make_csv_row()])
+
+    resp = await fb.export_feedback_csv(
+        request=None,
+        period="all",
+        start_date=None,
+        end_date=None,
+        category=None,
+        sentiment=None,
+        priority=None,
+        status=None,
+        user_id=None,
+        search=None,
+        sort="newest",
+        admin=_admin(),
+        db=db,
+    )
+
+    assert resp.headers["X-Rows-Total"] == "5"
+    assert resp.headers["X-Rows-Returned"] == "2"
+    assert resp.headers["X-Truncated"] == "true"
+    assert calls[0]["payload"]["truncated"] is True
+
+
+@pytest.mark.asyncio
+async def test_export_csv_tenant_scopes_query(monkeypatch):
+    _patch_log(monkeypatch)
+    db = _FakeDB(scalar=0, rows=[])
+
+    await fb.export_feedback_csv(
+        request=None,
+        period="all",
+        start_date=None,
+        end_date=None,
+        category=None,
+        sentiment=None,
+        priority=None,
+        status=None,
+        user_id=None,
+        search=None,
+        sort="newest",
+        admin=_admin(tenant_id=3),
+        db=db,
+    )
+
+    for _, stmt in db.executed:
+        assert "users.tenant_id = 3" in _compile_sql(stmt)


### PR DESCRIPTION
## What & why

Surfaces **every piece of user feedback** in the admin portal on a dedicated `/feedback` subpage, with filters by **time range, classification, and user id** — fulfilling the request to make the full voice-of-customer history browsable for ops.

## Backend — `backend/api/admin/feedback.py`

- **`GET /api/admin/feedback`** — paginated list (limit 1–200, default 50) with filters:
  - `period` (`7d` / `14d` / `30d` / `90d` / `custom` / `all`, default `all`) + `start_date` / `end_date` for custom ranges
  - `category`, `sentiment`, `priority`, `status` (validated against backend enums → `422` on bad input)
  - `user_id` (full UUID, `422` on malformed)
  - `search` — free-text ILIKE over feedback content **and** `user_id` substring
  - `sort` (`newest` / `oldest`, with `id` tie-breaker)
- **`GET /api/admin/feedback/export.csv`** — CSV honoring the same filters, capped at **50k rows** with `X-Truncated` / `X-Rows-Returned` / `X-Rows-Total` response headers so the UI can warn on truncation.
- **Security & multi-tenancy:** tenant-scoped via JOIN to `User` (`tenant_id` + `deleted_at IS NULL`) because the feedback table has no `tenant_id` column; behind `get_current_admin`; PII masked via `mask_name`; every call recorded with `log_action`. Transaction boundary owned by the router (commit), service flushes only — per the layer contract.

## Frontend — `betien-admin`

- **`FeedbackPage`** — debounced search + user-id box (client-side UUID validation so we never round-trip a `422`; partial matches fall back to the forgiving `search` param), period pills with a custom date range, category / sentiment / priority / status / sort selects, pagination, reset, CSV export with a truncation note, and a detail modal (Esc / click-outside to close, no extra fetch).
- **`Header`** gains a Dashboard / Feedback nav and a `showDateControls` prop so the subpage reuses the chrome without `DateRangeProvider`.
- **API client** gains `getFeedbackList` + `getFeedbackCsvUrl`; **utils** gain the feedback option lists, badge color maps, `isUuid`, `optionLabel`, `formatConfidence`, `formatDateTime`, and `buildFeedbackQueryParams`.

## Tests

- **Backend:** 31 pytest cases — filtering, validation, tenant isolation, PII masking, CSV headers/truncation, audit logging. ✅ `31 passed`
- **Frontend:** 9 new `node:test` cases for the feedback utils — query mapping, custom-date gating, defaults, UUID validation, label/confidence formatting, badge color coverage. ✅ `15 passed` total
- `npm run build` ✅ · changed/added frontend files lint clean (0 warnings)

https://claude.ai/code/session_01AG8JPm6zhE76dQz3jzUMY5

---
_Generated by [Claude Code](https://claude.ai/code/session_01AG8JPm6zhE76dQz3jzUMY5)_