### PR TITLE
feat(founding): token-free founding via src_&lt;source&gt; deep-link

### DIFF
--- a/backend/bot/handlers/onboarding_v2.py
+++ b/backend/bot/handlers/onboarding_v2.py
@@ -175,14 +175,26 @@ async def handle_start(
     """Route a /start command into the v2 onboarding flow.
 
     ``payload`` is whatever followed ``/start `` (Telegram deep-link
-    payload). We support ``invite_<token>`` to redeem invite codes.
+    payload). Two payload shapes carry founding-member acquisition:
+
+      * ``invite_<token>`` — legacy single-use invite codes (kept for the
+        links already distributed via the CSV batch).
+      * ``src_<source>`` — token-free shared link. One link can be posted
+        in a group; it only attributes the channel (``src_friends`` …) and
+        does NOT gate access. Founding seats are granted to the first 50
+        users who onboard, regardless of payload.
     """
-    # Redeem invite (if any) BEFORE creating the session so the welcome
-    # banner reflects founding-member status.
+    # Resolve founding membership (if any) BEFORE creating the session so
+    # the welcome banner reflects founding-member status.
     founding_banner_text: str | None = None
     if payload and payload.startswith("invite_"):
         token = payload[len("invite_") :]
         founding_banner_text = await _redeem_invite(db, user, token)
+    else:
+        # Token-free path: ``src_<source>`` attributes the channel; a bare
+        # /start (no payload) still claims a founding seat if one is left.
+        source = payload[len("src_") :] if payload and payload.startswith("src_") else None
+        founding_banner_text = await _claim_founding(db, user, source)
 
     # Resume / start the session.
     session = await onboarding_service.start_or_resume(db, user.id)
@@ -249,6 +261,56 @@ async def _redeem_invite(db: AsyncSession, user: User, token: str) -> str | None
         "founding_member_activated",
         user_id=user.id,
         properties={"sequence": assignment.sequence, "source": invite.source},
+    )
+    return f"{source_prefix}\n\n{banner}" if source_prefix else banner
+
+
+async def _claim_founding(
+    db: AsyncSession, user: User, source: str | None
+) -> str | None:
+    """Token-free founding claim for the ``src_<source>`` / bare-/start path.
+
+    Attributes the channel (if ``source`` is one of the known
+    acquisition sources) and grants the next founding seat to the first
+    50 onboarders. Returns banner text to render, or None when there is
+    no special copy (e.g. cohort full and no source prefix).
+    """
+    await founding_member_service.record_source(db, user, source)
+
+    copy = onboarding_service.load_copy()
+    source_variants = copy.get("source_variants") or {}
+    source_prefix: str | None = None
+    variant = source_variants.get(user.acquisition_source)
+    if variant:
+        source_prefix = variant.get("prefix")
+
+    from backend.services.founding.founding_member_service import (
+        FoundingCapReachedError,
+    )
+
+    # Newly founding only if the user had no sequence before this call.
+    was_founding = user.founding_member_sequence is not None
+    try:
+        assignment = await founding_member_service.assign_sequence(db, user)
+    except FoundingCapReachedError:
+        # Cohort full — no founding banner for organic onboarders, but we
+        # still greet them with the source-aware prefix when present.
+        return source_prefix
+
+    if was_founding:
+        # Returning founding member re-running /start — banner already
+        # shown on their first visit; just the source prefix (if any).
+        return source_prefix
+
+    founding_copy = _load_founding_copy()
+    banner = founding_copy["banner"].format(sequence=assignment.sequence)
+    analytics.track(
+        "founding_member_activated",
+        user_id=user.id,
+        properties={
+            "sequence": assignment.sequence,
+            "source": user.acquisition_source,
+        },
     )
     return f"{source_prefix}\n\n{banner}" if source_prefix else banner
 

--- a/backend/services/founding/founding_member_service.py
+++ b/backend/services/founding/founding_member_service.py
@@ -54,6 +54,20 @@ class FoundingCapReachedError(RuntimeError):
 FOUNDING_COHORT_CAP = 50
 
 
+# Canonical list of soft-launch acquisition sources (Phase 4.1, Story C.1).
+# Lives here so the onboarding handler can validate a ``src_<source>``
+# deep-link payload against it and the distribution script can re-export
+# it as ``SOURCES``. Order is significant for the script's round-robin
+# distribution.
+FOUNDING_SOURCES: tuple[str, ...] = (
+    "friends",
+    "personal_fb",
+    "vn_finance_community",
+    "direct_msg",
+    "tg_finance_groups",
+)
+
+
 async def assign_sequence(db: AsyncSession, user: User) -> FoundingAssignment:
     """Atomically grant the next founding sequence to ``user``.
 
@@ -130,6 +144,21 @@ async def mark_invite_redeemed(
     if user.acquisition_source is None:
         user.acquisition_source = invite.source
     await db.flush()
+
+
+async def record_source(db: AsyncSession, user: User, source: str | None) -> None:
+    """Attribute ``user`` to an acquisition ``source`` (idempotent).
+
+    Used by the token-free ``src_<source>`` deep-link path: a single
+    shared link carries the channel that converted the user without
+    burning a one-time invite. Unknown/empty sources are ignored, and
+    we never clobber a source already set (first touch wins).
+    """
+    if not source or source not in FOUNDING_SOURCES:
+        return
+    if user.acquisition_source is None:
+        user.acquisition_source = source
+        await db.flush()
 
 
 async def list_founding_members(db: AsyncSession) -> list[User]:

--- a/docs/current/soft-launch-runbook.md
+++ b/docs/current/soft-launch-runbook.md
@@ -75,19 +75,29 @@
 
 ---
 
-## 4. Founding member — sinh 50 invite (T-3 → T-1)
+## 4. Founding member — model mới: token-free, source-tracked (T-3 → T-1)
 
-- [ ] Chạy `scripts/soft_launch_acquisition.py --batch soft-launch-2026-06`
-- [ ] Verify đúng **50 row**, **10/source × 5 source**, tất cả `grants_founding_status=TRUE`:
-      ```sql
-      SELECT COUNT(*), source FROM invite_codes
-      WHERE batch_name='soft-launch-2026-06' GROUP BY source;
-      ```
-- [ ] Test redeem 1 invite (account sạch) → banner Founding Member `#1` + 50% trọn đời;
-      DB set `redeemed_by_user_id`, `redeemed_at`
-- [ ] **Race test:** redeem 5 invite song song → sequence 1–5 distinct, không trùng/nhảy số
-- [ ] CSV invite chuyển sang folder private, **KHÔNG commit vào git**;
-      operator mở 3 row random ở trình duyệt ẩn danh để kiểm
+> **Đổi từ "token một lần" → "first 50 onboard = Founding".** Không cần sinh
+> 50 token nữa. Chỉ cần **5 link cố định** `t.me/BeTienBot?start=src_<source>`
+> (1 link/kênh, dùng lại thoải mái). 50 suất được trao tự động cho 50 người
+> onboard đầu tiên (advisory-lock race-safe, cap 50). `src_<source>` chỉ ghi
+> attribution kênh vào `users.acquisition_source` cho `/cohort_stats`.
+
+- [ ] Soạn sẵn 5 link kênh và dán vào đúng message ở mục 6.3:
+      `src_friends`, `src_personal_fb`, `src_vn_finance_community`,
+      `src_direct_msg`, `src_tg_finance_groups`
+- [ ] Test onboard 1 account sạch qua `src_friends` → banner Founding Member
+      `#1` + 50% trọn đời; DB set `users.founding_member_sequence`,
+      `acquisition_source='friends'`
+- [ ] **Race test:** onboard 5 account song song → sequence 1–5 distinct,
+      không trùng/nhảy số (advisory lock `pg_advisory_xact_lock`)
+- [ ] Verify cap: onboard người thứ 51 → vẫn vào được, KHÔNG nhận banner
+      Founding (cohort đầy), vẫn lưu `acquisition_source` cho cohort tracking
+
+> **Backward-compat (tuỳ chọn):** nếu cần phát link token một lần cho một đợt
+> riêng, `scripts/soft_launch_acquisition.py --batch <name>` vẫn sinh
+> `invite_codes` + CSV; link `invite_<token>` vẫn redeem được. CSV token là
+> **nhạy cảm**, chuyển sang folder private, **KHÔNG commit vào git**.
 
 ---
 
@@ -124,13 +134,25 @@ trong `founding-promise.md`. (Chi tiết & corner case: xem `founding-promise.md
 | `direct_msg` | 10 | DM người đã quan tâm trước đó | Cá nhân, follow-up |
 | `tg_finance_groups` | 10 | Group Telegram tài chính | Ngắn, đúng trọng tâm |
 
-**Cadence (tránh dồn 50 người vào cùng lúc, để kịp triage):**
-- Ngày 1 sáng: 15 invite · Ngày 1 chiều: 15 · Ngày 2 sáng: 10 · Ngày 2 chiều: 10
+**Cadence (tránh dồn 50 người vào cùng lúc, để kịp triage):** vì link
+`src_<source>` dùng lại được, điều tiết bằng **thời điểm đăng/nhắn từng kênh**
+(stagger), không phải bằng số token phát ra. Gợi ý rải theo nhịp ~15 / 15 / 10 /
+10 người qua 2 ngày — group post (kênh C, E) đăng sau cùng vì khó kiểm soát lượt.
 
 ### 6.3 Seeding messages (operator copy-paste — KHÔNG phải in-app string)
 
-> Tất cả đều warm, không hype, không "CFO". Mỗi link kèm đúng source:
-> `t.me/BeTienBot?start=invite_<token>`
+> Tất cả đều warm, không hype, không "CFO". Mỗi kênh dùng **một link cố
+> định kèm đúng source** (không phải token một lần):
+> `t.me/BeTienBot?start=src_<source>` —
+> ví dụ `src_friends`, `src_personal_fb`, `src_vn_finance_community`,
+> `src_direct_msg`, `src_tg_finance_groups`.
+>
+> Link `src_<source>` **không giới hạn lượt dùng**: dán nguyên một link vào
+> group cũng được, nhiều người cùng bấm vẫn nhận đúng attribution kênh để
+> `/cohort_stats` đo sạch. **50 suất Founding Member được trao tự động cho 50
+> người onboard đầu tiên** (race-safe, đếm theo thứ tự hoàn tất `/start`),
+> không phụ thuộc token. Link `invite_<token>` cũ vẫn redeem được (backward
+> compatible) cho các link đã phát trước đó.
 
 **A. `friends` — nhắn tay bạn bè thân**
 ```
@@ -185,7 +207,7 @@ Ai muốn thử & góp ý: 👉 [invite link]
 
 ### 6.4 Checklist trước khi gửi mỗi đợt seeding
 
-- [ ] Link đúng `source` tương ứng (để `/cohort_stats` đo sạch theo kênh)
+- [ ] Dán đúng link `src_<source>` của kênh (để `/cohort_stats` đo sạch theo kênh)
 - [ ] Người Việt đọc lại 1 lượt — nghe tự nhiên, không sượng, không "CFO"
 - [ ] Founder đọc cuối cùng trước khi post
 - [ ] Không hứa gì ngoài cam kết ở 6.1

--- a/scripts/soft_launch_acquisition.py
+++ b/scripts/soft_launch_acquisition.py
@@ -47,19 +47,16 @@ from sqlalchemy import select
 
 from backend.database import get_session_factory
 from backend.models.invite_code import InviteCode
+from backend.services.founding.founding_member_service import FOUNDING_SOURCES
 
 logger = logging.getLogger(__name__)
 
 
-# 5 sources from Phase 4.1 spec (Story C.1). Order is significant: the
-# distribution loop assigns sources round-robin from this list.
-SOURCES: tuple[str, ...] = (
-    "friends",
-    "personal_fb",
-    "vn_finance_community",
-    "direct_msg",
-    "tg_finance_groups",
-)
+# 5 sources from Phase 4.1 spec (Story C.1). Canonical list lives in
+# ``founding_member_service`` so the onboarding handler validates the
+# token-free ``src_<source>`` deep-link against the same tuple. Order is
+# significant: the distribution loop assigns sources round-robin.
+SOURCES: tuple[str, ...] = FOUNDING_SOURCES
 
 DEFAULT_BOT_USERNAME = "BeTienBot"
 DEFAULT_COUNT = 50

--- a/tests/test_phase_4_1/test_epic_c.py
+++ b/tests/test_phase_4_1/test_epic_c.py
@@ -453,6 +453,226 @@ async def test_mark_invite_redeemed_preserves_prior_acquisition_source():
 
 
 # ====================================================================
+# Token-free founding — record_source (src_<source> deep-link path)
+# ====================================================================
+
+
+def test_founding_sources_is_canonical_for_script():
+    """The script re-exports the service tuple — they must be identical so
+    the onboarding handler validates ``src_<source>`` against the same set
+    the distribution script round-robins over."""
+    from backend.services.founding.founding_member_service import FOUNDING_SOURCES
+    from scripts.soft_launch_acquisition import SOURCES
+
+    assert SOURCES is FOUNDING_SOURCES
+    assert FOUNDING_SOURCES == (
+        "friends",
+        "personal_fb",
+        "vn_finance_community",
+        "direct_msg",
+        "tg_finance_groups",
+    )
+
+
+@pytest.mark.asyncio
+async def test_record_source_sets_known_source():
+    from backend.services.founding import founding_member_service
+
+    user = _make_user(seq=None, founding=False)
+    db = _FakeFoundingDB(max_sequence=None)
+
+    await founding_member_service.record_source(db, user, "tg_finance_groups")
+
+    assert user.acquisition_source == "tg_finance_groups"
+    assert db.flush_count == 1
+
+
+@pytest.mark.asyncio
+async def test_record_source_ignores_unknown_source():
+    """A bogus ``src_<x>`` payload (typo / tampering) must not write a
+    junk source — only the 5 known channels are accepted."""
+    from backend.services.founding import founding_member_service
+
+    user = _make_user(seq=None, founding=False)
+    db = _FakeFoundingDB(max_sequence=None)
+
+    await founding_member_service.record_source(db, user, "spam_channel")
+
+    assert user.acquisition_source is None
+    assert db.flush_count == 0
+
+
+@pytest.mark.asyncio
+async def test_record_source_ignores_none():
+    """Bare /start (no payload) carries no source — nothing to record."""
+    from backend.services.founding import founding_member_service
+
+    user = _make_user(seq=None, founding=False)
+    db = _FakeFoundingDB(max_sequence=None)
+
+    await founding_member_service.record_source(db, user, None)
+
+    assert user.acquisition_source is None
+    assert db.flush_count == 0
+
+
+@pytest.mark.asyncio
+async def test_record_source_preserves_prior_source():
+    """First touch wins — a later src_ link must not overwrite the
+    channel that originally converted the user."""
+    from backend.services.founding import founding_member_service
+
+    user = _make_user(seq=None, founding=False)
+    user.acquisition_source = "friends"
+    db = _FakeFoundingDB(max_sequence=None)
+
+    await founding_member_service.record_source(db, user, "personal_fb")
+
+    assert user.acquisition_source == "friends"
+    assert db.flush_count == 0
+
+
+# ====================================================================
+# _claim_founding — token-free orchestration in onboarding_v2 handler
+# ====================================================================
+
+
+def _patch_claim_deps(monkeypatch, *, assignment=None, cap=False):
+    """Patch the handler collaborators so _claim_founding runs in isolation.
+
+    Returns a list that records analytics.track calls.
+    """
+    from backend.bot.handlers import onboarding_v2
+    from backend.services.founding import founding_member_service
+
+    monkeypatch.setattr(
+        onboarding_v2.onboarding_service,
+        "load_copy",
+        lambda: {
+            "source_variants": {
+                "friends": {"prefix": "PREFIX_FRIENDS"},
+            }
+        },
+    )
+    monkeypatch.setattr(
+        onboarding_v2, "_load_founding_copy", lambda: {"banner": "BANNER #{sequence}"}
+    )
+
+    async def _fake_assign(db, user):  # noqa: ANN001
+        if cap:
+            from backend.services.founding.founding_member_service import (
+                FoundingCapReachedError,
+            )
+
+            raise FoundingCapReachedError()
+        user.is_founding_member = True
+        user.founding_member_sequence = assignment.sequence
+        return assignment
+
+    monkeypatch.setattr(founding_member_service, "assign_sequence", _fake_assign)
+
+    tracked: list[dict] = []
+    monkeypatch.setattr(
+        onboarding_v2.analytics,
+        "track",
+        lambda event, **kw: tracked.append({"event": event, **kw}),
+    )
+    return tracked
+
+
+@pytest.mark.asyncio
+async def test_claim_founding_grants_seat_with_source_prefix(monkeypatch):
+    from types import SimpleNamespace
+
+    from backend.bot.handlers import onboarding_v2
+
+    assignment = SimpleNamespace(sequence=3)
+    tracked = _patch_claim_deps(monkeypatch, assignment=assignment)
+
+    user = _make_user(seq=None, founding=False)
+    db = _FakeFoundingDB(max_sequence=None)
+
+    text = await onboarding_v2._claim_founding(db, user, "friends")
+
+    assert user.acquisition_source == "friends"
+    assert "PREFIX_FRIENDS" in text
+    assert "BANNER #3" in text
+    assert tracked and tracked[0]["event"] == "founding_member_activated"
+    assert tracked[0]["properties"]["source"] == "friends"
+
+
+@pytest.mark.asyncio
+async def test_claim_founding_bare_start_grants_seat_without_prefix(monkeypatch):
+    """No payload → no source prefix, but still a founding seat + banner."""
+    from types import SimpleNamespace
+
+    from backend.bot.handlers import onboarding_v2
+
+    assignment = SimpleNamespace(sequence=1)
+    tracked = _patch_claim_deps(monkeypatch, assignment=assignment)
+
+    user = _make_user(seq=None, founding=False)
+    db = _FakeFoundingDB(max_sequence=None)
+
+    text = await onboarding_v2._claim_founding(db, user, None)
+
+    assert user.acquisition_source is None
+    assert text == "BANNER #1"
+    assert tracked[0]["properties"]["source"] is None
+
+
+@pytest.mark.asyncio
+async def test_claim_founding_cap_reached_shows_prefix_only_no_banner(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+
+    tracked = _patch_claim_deps(monkeypatch, cap=True)
+
+    user = _make_user(seq=None, founding=False)
+    db = _FakeFoundingDB(max_sequence=None)
+
+    text = await onboarding_v2._claim_founding(db, user, "friends")
+
+    # Source still attributed; banner suppressed (organic user past cap).
+    assert user.acquisition_source == "friends"
+    assert text == "PREFIX_FRIENDS"
+    assert tracked == []
+
+
+@pytest.mark.asyncio
+async def test_claim_founding_cap_reached_bare_start_returns_none(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+
+    _patch_claim_deps(monkeypatch, cap=True)
+
+    user = _make_user(seq=None, founding=False)
+    db = _FakeFoundingDB(max_sequence=None)
+
+    text = await onboarding_v2._claim_founding(db, user, None)
+
+    assert text is None
+
+
+@pytest.mark.asyncio
+async def test_claim_founding_returning_member_no_duplicate_banner(monkeypatch):
+    """A user who already holds a sequence re-running /start must not get a
+    second banner or a duplicate analytics event."""
+    from types import SimpleNamespace
+
+    from backend.bot.handlers import onboarding_v2
+
+    assignment = SimpleNamespace(sequence=5)
+    tracked = _patch_claim_deps(monkeypatch, assignment=assignment)
+
+    user = _make_user(seq=5)  # already founding
+    db = _FakeFoundingDB(max_sequence=None)
+
+    text = await onboarding_v2._claim_founding(db, user, "friends")
+
+    assert text == "PREFIX_FRIENDS"  # prefix only, no banner
+    assert tracked == []
+
+
+# ====================================================================
 # D.1 — Zalo channel feature flag
 # ====================================================================
 


### PR DESCRIPTION
## Tóm tắt

Chuyển founding-member acquisition sang mô hình **"bỏ token, giữ source"**: một link chia sẻ duy nhất cho mỗi kênh thay vì 50 token một-lần. Giải quyết bài toán "không thể phân phối token cho từng người khi chỉ gửi 1 message vào group", đồng thời vẫn giữ được attribution để `/cohort_stats` biết kênh nào convert.

### Thay đổi cốt lõi

- **Token-free deep-link**: `t.me/BeTienBot?start=src_<source>` (ví dụ `src_friends`). Link dùng được không giới hạn lần — ai onboard trước thì lấy ghế. 50 ghế Founding được cấp **tự động** cho 50 account onboard đầu tiên qua bộ đếm advisory-lock race-safe sẵn có (cap 50).
- **Source attribution giữ nguyên**: payload `src_<source>` mang theo kênh nhưng không đốt invite một-lần. First-touch-wins, source lạ/giả mạo bị bỏ qua (chỉ validate 5 source chính tắc).
- **Backward compatible**: path `invite_<token>` cũ vẫn hoạt động cho các link CSV đã phát hành — `_redeem_invite` giữ nguyên.

### Chi tiết kỹ thuật

- `FOUNDING_SOURCES` trở thành nguồn chân lý duy nhất trong `founding_member_service`; script `soft_launch_acquisition.py` re-export thành `SOURCES` (DRY).
- Thêm `record_source()` (idempotent, flush-only, đúng layer contract — không commit ở service).
- `handle_start` định tuyến: `invite_` → legacy redeem; còn lại → `_claim_founding` (đọc `src_`, cấp ghế, banner). Returning member không bị lặp banner/analytics nhờ check `was_founding`. Cap-reached organic user chỉ thấy source prefix, không thấy copy "cohort full" gây khó hiểu.
- Runbook (`docs/current/soft-launch-runbook.md`) cập nhật sang mô hình token-free, source-tracked.

### Test

- `tests/test_phase_4_1/test_epic_c.py`: 33 passed (thêm test cho `record_source`, `_claim_founding`, canonical `SOURCES is FOUNDING_SOURCES`, cap-reached, returning member).
- phase_4_1 + onboarding resume: 74 passed. `ruff check` sạch.

### Trade-off đã chấp nhận

Mất khả năng curate access (ai cũng có thể claim ghế) để đổi lấy "một link cho mỗi group" và giữ cohort tracking.

https://claude.ai/code/session_01XEr44nm2v12EHkuyfG2Lpb

---
_Generated by [Claude Code](https://claude.ai/code/session_01XEr44nm2v12EHkuyfG2Lpb)_