### PR TITLE
feat(onboarding): decision moment after Twin reveal (Phase 4.6 E3)

### DIFF
--- a/backend/bot/formatters/onboarding_decision.py
+++ b/backend/bot/formatters/onboarding_decision.py
@@ -1,0 +1,180 @@
+"""Render the in-onboarding decision moment (Phase 4.6, E3).
+
+Pure formatting. Right after the Twin reveal Bé Tiền poses ONE goal-specific
+decision question and answers it on the spot with **exactly one** number, then
+tells the truth about how sharp the picture is (độ nét). It reuses the Phase
+4.5 outputs — :class:`PlanFeasibility` from ``plan_feasibility_service`` and
+:class:`ClarityResult` from ``clarity_service`` — so there is no new engine
+here: this module only picks the honest answer shape and threads the numbers in.
+
+Answer shapes, in decreasing order of how much we actually know:
+
+    on_track   (achievable band / already there) → 1 number = months to goal.
+    building   (some saving rate, still a reach)  → 1 number = reachable target
+                                                     the user is trending toward.
+    direction  (no saving-rate signal yet)        → 1 number = the typical
+                                                     milestone, framed as a
+                                                     starting direction not a "no".
+
+Every string lives in ``content/onboarding/decision_moment.yaml`` (never
+hardcoded). Layer note: this is a formatter — no I/O, no DB, no env. The
+``ONBOARDING_DECISION_MOMENT_ENABLED`` flag is decided at the handler edge
+before we are called.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from functools import lru_cache
+from pathlib import Path
+
+import yaml
+
+from backend.bot.formatters.money import format_money_short
+from backend.schemas.goal import FeasibilityBand
+from backend.services.decision.clarity_service import ClarityResult
+from backend.services.decision.plan_feasibility_service import PlanFeasibility
+
+_COPY_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "content"
+    / "onboarding"
+    / "decision_moment.yaml"
+)
+
+# Bands that mean "you can hit the actual target" — show months, no pivot.
+_ACHIEVABLE_BANDS = frozenset({FeasibilityBand.EASY, FeasibilityBand.FEASIBLE})
+
+
+@dataclass(frozen=True)
+class GoalDecisionConfig:
+    """The question + feasibility inputs for one goal, pulled from content.
+
+    ``target_vnd`` / ``horizon_years`` are typical first-life milestones for the
+    22-35 / Level 0→1 segment, not a promise — the honest-clarity line makes
+    that explicit. Money is a ``Decimal`` (layer contract), coerced from the
+    plain integer in the YAML.
+    """
+
+    question: str
+    goal_label: str
+    target_vnd: Decimal
+    horizon_years: Decimal
+
+
+@lru_cache(maxsize=1)
+def _copy() -> dict:
+    with _COPY_PATH.open(encoding="utf-8") as fh:
+        return yaml.safe_load(fh) or {}
+
+
+def _decision_copy() -> dict:
+    return dict(_copy().get("decision_moment") or {})
+
+
+def goal_config(goal_code: str | None) -> GoalDecisionConfig:
+    """Resolve the decision-moment config for ``goal_code``.
+
+    Unknown / legacy goals fall back to ``default_goal`` so the moment always
+    has a question to ask — the flag can never strand a user at a dead end.
+    """
+    copy = _decision_copy()
+    goals = copy.get("goals") or {}
+    block = goals.get(goal_code) if goal_code else None
+    if not block:
+        block = copy.get("default_goal") or {}
+    return GoalDecisionConfig(
+        question=block.get("question", ""),
+        goal_label=block.get("goal_label", "mục tiêu"),
+        target_vnd=Decimal(str(block.get("target_vnd", 0))),
+        horizon_years=Decimal(str(block.get("horizon_years", 3))),
+    )
+
+
+def render_question(config: GoalDecisionConfig, *, salutation: str = "bạn") -> str:
+    """The single goal-specific decision question."""
+    return config.question.format(salutation=salutation)
+
+
+def render_answer(
+    result: PlanFeasibility,
+    config: GoalDecisionConfig,
+    clarity: ClarityResult,
+    *,
+    salutation: str = "bạn",
+) -> str:
+    """Answer with exactly one number for the goal, plus an honest độ nét line.
+
+    Picks the answer shape from how much the feasibility engine could actually
+    conclude, then always appends the clarity line so the user knows how much
+    to trust the number. Never ends on a flat "no" — thin data pivots to a
+    directional milestone.
+    """
+    answers = _decision_copy().get("answers") or {}
+    label = config.goal_label
+    label_cap = (label[:1].upper() + label[1:]) if label else label
+    target = format_money_short(config.target_vnd)
+    years = _format_years(config.horizon_years)
+
+    if result.already_reached or result.band in _ACHIEVABLE_BANDS:
+        body = answers.get("on_track", "").format(
+            months=result.months,
+            salutation=salutation,
+            goal_label=label,
+        )
+    elif result.actual_monthly_savings > 0 and result.reachable_target is not None:
+        body = answers.get("building", "").format(
+            reachable=format_money_short(result.reachable_target),
+            years=years,
+            salutation=salutation,
+            goal_label=label,
+            goal_label_cap=label_cap,
+            target=target,
+        )
+    else:
+        # No saving-rate signal (the common onboarding case) → don't invent a
+        # timeline; point at the milestone and call the picture a start.
+        body = answers.get("direction", "").format(
+            salutation=salutation,
+            goal_label=label,
+            goal_label_cap=label_cap,
+            target=target,
+        )
+
+    return _join(body, _render_clarity(clarity, salutation=salutation))
+
+
+def _render_clarity(clarity: ClarityResult, *, salutation: str) -> str:
+    """The độ nét line — honest about how sharp the picture is, with the single
+    highest-leverage thing the user could add to sharpen it."""
+    cl = _decision_copy().get("clarity") or {}
+    sharpen_map = cl.get("sharpen") or {}
+    top = clarity.top_sharpen()
+    sharpen_text = sharpen_map.get(top.key, "") if top is not None else ""
+
+    if clarity.is_below_threshold:
+        return cl.get("below", "").format(
+            salutation=salutation, score=clarity.score, sharpen=sharpen_text
+        )
+    tail = (
+        cl.get("sharpen_tail", "").format(sharpen=sharpen_text) if sharpen_text else ""
+    )
+    return cl.get("above", "").format(
+        salutation=salutation, score=clarity.score, sharpen_tail=tail
+    )
+
+
+def _format_years(horizon_years: Decimal) -> str:
+    """ "5 năm" / "5.5 năm" — drop the trailing ``.0`` for whole years."""
+    years = Decimal(horizon_years)
+    if years == years.to_integral_value():
+        return f"{int(years)} năm"
+    return f"{years.normalize()} năm"
+
+
+def _join(*parts: str) -> str:
+    return "\n\n".join(p for p in parts if p)
+
+
+__all__ = ["GoalDecisionConfig", "goal_config", "render_answer", "render_question"]

--- a/backend/bot/handlers/onboarding_v2.py
+++ b/backend/bot/handlers/onboarding_v2.py
@@ -186,6 +186,29 @@ def is_onboarding_reset_enabled() -> bool:
     )
 
 
+ONBOARDING_DECISION_MOMENT_FLAG_ENV = "ONBOARDING_DECISION_MOMENT_ENABLED"
+
+
+def is_onboarding_decision_moment_enabled() -> bool:
+    """Phase 4.6 E3 — the in-onboarding decision moment is OFF by default.
+
+    When on, right after the Twin reveal Bé Tiền poses one goal-specific
+    decision question and answers it with a single number + honest độ nét,
+    reusing the Phase 4.5 feasibility + clarity services. When off, onboarding
+    ends at the Twin reveal exactly as before 4.6 (byte-identical). Read at the
+    handler edge and never inside a service (layer contract), same pattern as
+    ``is_v2_enabled`` / ``is_onboarding_reset_enabled``.
+    """
+    import os
+
+    return os.environ.get(ONBOARDING_DECISION_MOMENT_FLAG_ENV, "false").lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 # Fallback display order for the goal buttons when the content block omits an
 # explicit ``order`` list (legacy ``step_1_goal`` predates the key).
 _DEFAULT_GOAL_ORDER = ("understand_wealth", "plan_goal", "track_spending")
@@ -1155,12 +1178,98 @@ async def _trigger_first_twin(
         properties={"demo": demo},
     )
 
+    # Phase 4.6 E3 — the decision moment is the climax of the reveal: pose one
+    # goal-specific decision question and answer it with a single number right
+    # after the chart, before the feedback prompt. Flag read at the edge; off
+    # keeps the reveal byte-identical to pre-4.6. Runs synchronously here (not
+    # in the feedback task) because it needs the live DB session, which does
+    # not survive the worker boundary.
+    if is_onboarding_decision_moment_enabled():
+        await _send_decision_moment(db, chat_id, user)
+
     # Schedule the in-moment feedback prompt 7s later in a fire-and-forget
     # task. We capture the chat_id + user_id only (no DB session, no model
     # — those don't survive the worker boundary).
     asyncio.create_task(
         _send_feedback_prompt_after_delay(chat_id=chat_id, user_id=user.id, delay=7.0)
     )
+
+
+async def _send_decision_moment(db: AsyncSession, chat_id: int, user: User) -> None:
+    """Phase 4.6 E3 — one goal-specific decision question + a single-number answer.
+
+    Reuses the Phase 4.5 services (``plan_feasibility_service`` + ``clarity_service``)
+    — no new engine. Reads the chosen goal from the session to pick the question
+    and its typical milestone, answers on the spot with exactly one number, and
+    appends an honest độ nét line (usually low this early). The only write is one
+    append-only ``decision_query_log`` row via the flush-only service; the worker
+    owns the commit.
+
+    Best-effort by design: the decision moment must never break the Twin reveal,
+    so any failure is logged and swallowed — the user still keeps their Twin.
+    """
+    from backend.bot.formatters import onboarding_decision
+    from backend.models.decision_query_log import QUERY_TYPE_FEASIBILITY
+    from backend.services.decision import (
+        clarity_service,
+        decision_query_log_service,
+        plan_feasibility_service,
+    )
+    from backend.services.goal_projection import get_avg_monthly_savings
+
+    try:
+        session = await onboarding_service.get_session(db, user.id)
+        if session is None:
+            return
+
+        config = onboarding_decision.goal_config(session.goal_choice)
+        salutation = onboarding_service.salutation_of(user)
+        start = session.first_asset_value_vnd or Decimal(0)
+
+        # Single DB read for the saving rate (the feasibility engine is pure);
+        # clarity runs a handful of lightweight indexed reads.
+        avg_savings = await get_avg_monthly_savings(db, user.id)
+        result = plan_feasibility_service.assess(
+            start, config.target_vnd, config.horizon_years, avg_savings
+        )
+        clarity = await clarity_service.compute_clarity(db, user.id)
+
+        await send_message(
+            chat_id,
+            onboarding_decision.render_question(config, salutation=salutation),
+            parse_mode="HTML",
+        )
+        await send_message(
+            chat_id,
+            onboarding_decision.render_answer(
+                result, config, clarity, salutation=salutation
+            ),
+            parse_mode="HTML",
+        )
+
+        # Append-only funnel row. Onboarding always lands a verdict (there is
+        # no clarify turn), so success is always True; clarity_score threads the
+        # độ nét through for the E4 dashboard.
+        await decision_query_log_service.log_query(
+            db,
+            user_id=user.id,
+            query_type=QUERY_TYPE_FEASIBILITY,
+            success=True,
+            clarity_score=clarity.score,
+        )
+        analytics.track(
+            "onboarding_decision_moment_shown",
+            user_id=user.id,
+            properties={
+                "goal": session.goal_choice,
+                # band is a str either way (FeasibilityBand is a str-Enum, but the
+                # projection hands back bare strings) — normalise to the short code.
+                "band": getattr(result.band, "value", result.band),
+                "clarity_score": clarity.score,
+            },
+        )
+    except Exception:
+        logger.exception("Decision moment failed for user %s", user.id)
 
 
 async def _resolve_twin_cone(

--- a/content/onboarding/decision_moment.yaml
+++ b/content/onboarding/decision_moment.yaml
@@ -1,0 +1,54 @@
+# Phase 4.6 · E3 — Decision Moment trong onboarding.
+#
+# Ngay sau Twin reveal, Bé Tiền hỏi ĐÚNG 1 câu quyết định gắn goal đã chọn rồi
+# trả lời liền với đúng 1 con số + độ nét thành thật. Tái dùng
+# plan_feasibility_service + clarity_service (Phase 4.5) — không engine mới.
+#
+# Persona: honest-not-harsh, nói tiếng của 22-35 đang xây khoản đầu đời, 0 jargon.
+# {salutation} = anh/chị/bạn (fallback "bạn"). Mọi con số tiền ở đây là CONFIG
+# (coerce sang Decimal ở formatter), không phải chuỗi hiển thị cứng.
+
+decision_moment:
+  # Câu hỏi + tham số feasibility theo từng goal. target_vnd / horizon_years là
+  # mốc tham chiếu điển hình cho segment Level 0→1, KHÔNG phải cam kết.
+  goals:
+    emergency_fund:
+      question: "🤔 Thử một câu nha: với nhịp hiện tại, bao lâu nữa {salutation} gom đủ quỹ khẩn cấp cho mình?"
+      goal_label: "quỹ khẩn cấp"
+      target_vnd: 60000000
+      horizon_years: 2
+    first_home:
+      question: "🤔 Thử một câu nha: với nhịp hiện tại, bao lâu nữa {salutation} đủ cọc căn nhà đầu tiên?"
+      goal_label: "cọc nhà đầu tiên"
+      target_vnd: 300000000
+      horizon_years: 5
+    wedding:
+      question: "🤔 Thử một câu nha: với nhịp hiện tại, bao lâu nữa {salutation} lo đủ cho đám cưới mơ ước?"
+      goal_label: "đám cưới"
+      target_vnd: 200000000
+      horizon_years: 3
+  # Fallback cho goal legacy / goal lạ — vẫn trả lời được, không vỡ flow.
+  default_goal:
+    question: "🤔 Thử một câu nha: với nhịp hiện tại, bao lâu nữa {salutation} chạm mốc mình mong?"
+    goal_label: "mục tiêu đầu tiên"
+    target_vnd: 100000000
+    horizon_years: 3
+  answers:
+    # on_track — đủ dữ liệu, đang trên đà: 1 con số = số tháng.
+    on_track: "Tin vui nè: với nhịp này, khoảng {months} tháng nữa là {salutation} chạm {goal_label} rồi 🎯"
+    # building — có tiết kiệm nhưng còn chặng dài: 1 con số = mức đang trên đà tới.
+    building: "Với nhịp hiện tại, {salutation} đang trên đà tới khoảng {reachable} trong {years}. {goal_label_cap} thường quanh {target} — mình đi từng bước là tới thôi 💪"
+    # direction — dữ liệu còn mỏng (chưa thấy nhịp tiết kiệm): 1 con số = mốc tham chiếu.
+    direction: "{goal_label_cap} thường quanh mức {target}. Nhịp tiết kiệm của {salutation} mình chưa nhìn ra, nên đây mới là điểm khởi đầu thôi — mà hướng đi thì đã rõ rồi ✨"
+  clarity:
+    # Dòng độ nét — luôn kèm sau câu trả lời để thành thật về mức tin cậy.
+    below: "📷 Thú thật ảnh tài chính của {salutation} còn hơi mờ ({score}/100) — {sharpen} là mình nhìn rõ hơn hẳn."
+    above: "📷 Ảnh tài chính của {salutation} mới đang thành hình ({score}/100){sharpen_tail}"
+    sharpen_tail: " — thêm {sharpen} nữa là nét dần lên đó."
+    # Gợi ý làm nét theo component thiếu nhất (map từ clarity_service component key).
+    sharpen:
+      assets: "thêm vài tài sản nữa (tiết kiệm, ví, vàng…)"
+      asset_freshness: "cập nhật lại số dư mới nhất"
+      income: "cho mình biết thu nhập hằng tháng"
+      expenses: "ghi lại vài khoản chi gần đây"
+      goals: "đặt một mục tiêu cụ thể"

--- a/tests/test_phase_4_6/test_onboarding_decision_moment.py
+++ b/tests/test_phase_4_6/test_onboarding_decision_moment.py
@@ -1,0 +1,372 @@
+"""Phase 4.6 Epic 3 — Decision Moment in onboarding.
+
+Right after the Twin reveal, Bé Tiền poses ONE goal-specific decision question
+and answers it on the spot with **exactly one** number, then tells the truth
+about how sharp the picture is (độ nét). It reuses the Phase 4.5 services
+(``plan_feasibility_service`` + ``clarity_service``) — no new engine — behind
+the ``ONBOARDING_DECISION_MOMENT_ENABLED`` flag (default off).
+
+This suite locks the invariants that matter for the 22-35 / Level 0→1 segment:
+
+* **flag** — reads env truthy/falsy exactly like the sibling onboarding flags,
+  and is off by default so the reveal stays byte-identical to pre-4.6.
+* **config** — every reset goal resolves a question + typical milestone; an
+  unknown / legacy goal falls back to ``default_goal`` so the moment never
+  strands a user at a dead end. Money is a ``Decimal`` (layer contract).
+* **answer shapes** — the three honest shapes (on_track / building / direction)
+  are picked from how much the feasibility engine could conclude, and thin data
+  (the common onboarding case) pivots to a directional milestone, never a "no".
+* **độ nét** — the clarity line is always appended; below threshold it is
+  humble, above it nudges with the single highest-leverage thing to add.
+* **copy hygiene** — no forbidden positioning terms and no harsh tone words leak
+  into any user-facing string.
+* **handler** — ``_send_decision_moment`` sends question + answer, logs one
+  append-only feasibility row with the clarity score, and is best-effort so a
+  failure can never break the Twin reveal.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from backend.bot.formatters import onboarding_decision
+from backend.models.onboarding_session import RESET_GOALS
+from backend.services.decision.clarity_service import (
+    CLARITY_MIN_THRESHOLD,
+    ClarityInputs,
+    score_clarity,
+)
+from backend.services.decision.plan_feasibility_service import assess
+
+
+# forbidden user-facing positioning terms (CLAUDE.md — never in decision copy)
+_FORBIDDEN_TERMS = ("decision engine", "gps tài chính", "cfo", "personal cfo")
+
+# harsh / shaming tone words banned by the Bé Tiền persona guide.
+_BANNED_TONE = ("đừng", "không nên", "phải", "sai", "tệ", "lãng phí")
+
+_NOW = datetime(2026, 7, 12, tzinfo=timezone.utc)
+
+
+def _user(salutation: str = "bạn"):
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        display_name="Minh",
+        salutation=salutation,
+    )
+
+
+def _clarity(
+    *,
+    assets: int = 0,
+    types: int = 0,
+    fresh_days: int | None = None,
+    income: int = 0,
+    expense_months: int = 0,
+    goals: int = 0,
+):
+    """Build a real :class:`ClarityResult` from raw signals via the pure core."""
+    latest = None if fresh_days is None else _NOW - timedelta(days=fresh_days)
+    return score_clarity(
+        ClarityInputs(
+            active_asset_count=assets,
+            distinct_asset_types=types,
+            latest_asset_valued_at=latest,
+            income_source_count=income,
+            expense_month_count=expense_months,
+            active_goal_count=goals,
+            now=_NOW,
+        )
+    )
+
+
+# ----- flag: read at the edge, off by default ------------------------------
+
+
+def test_flag_helper_reads_env_truthy_and_falsy(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+
+    for on in ("1", "true", "yes", "on", "TRUE", "On"):
+        monkeypatch.setenv(onboarding_v2.ONBOARDING_DECISION_MOMENT_FLAG_ENV, on)
+        assert onboarding_v2.is_onboarding_decision_moment_enabled() is True, on
+    for off in ("0", "false", "no", "off", ""):
+        monkeypatch.setenv(onboarding_v2.ONBOARDING_DECISION_MOMENT_FLAG_ENV, off)
+        assert onboarding_v2.is_onboarding_decision_moment_enabled() is False, off
+    monkeypatch.delenv(
+        onboarding_v2.ONBOARDING_DECISION_MOMENT_FLAG_ENV, raising=False
+    )
+    assert onboarding_v2.is_onboarding_decision_moment_enabled() is False
+
+
+# ----- config: every goal resolves; unknown falls back ---------------------
+
+
+def test_goal_config_resolves_every_reset_goal():
+    for code in RESET_GOALS:
+        cfg = onboarding_decision.goal_config(code)
+        assert cfg.question.strip()
+        assert cfg.goal_label.strip()
+        assert cfg.target_vnd > 0
+        assert cfg.horizon_years > 0
+        # Money is Decimal (layer contract), not the raw int/float from YAML.
+        assert isinstance(cfg.target_vnd, Decimal)
+        assert isinstance(cfg.horizon_years, Decimal)
+
+
+def test_goal_config_reset_goals_have_distinct_milestones():
+    """Each reset goal points at its own typical milestone — a shared fallback
+    number would make the moment feel canned."""
+    targets = {code: onboarding_decision.goal_config(code).target_vnd for code in RESET_GOALS}
+    assert len(set(targets.values())) == len(RESET_GOALS), targets
+
+
+@pytest.mark.parametrize("code", [None, "understand_wealth", "no_such_goal", ""])
+def test_goal_config_falls_back_to_default_for_unknown(code):
+    """Legacy / unknown / empty codes still get a question — the default goal."""
+    cfg = onboarding_decision.goal_config(code)
+    default = onboarding_decision.goal_config("definitely_not_a_goal_code")
+    assert cfg == default
+    assert cfg.question.strip()
+    assert cfg.target_vnd == Decimal("100000000")
+
+
+# ----- question: threads salutation, no stray placeholder ------------------
+
+
+@pytest.mark.parametrize("code", list(RESET_GOALS) + [None])
+@pytest.mark.parametrize("salutation", ["anh", "chị", "bạn"])
+def test_render_question_threads_salutation(code, salutation):
+    cfg = onboarding_decision.goal_config(code)
+    q = onboarding_decision.render_question(cfg, salutation=salutation)
+    assert salutation in q
+    assert "{" not in q and "}" not in q  # no unfilled placeholder
+
+
+# ----- answer: three honest shapes, always one number ----------------------
+
+
+def test_answer_on_track_when_already_reached():
+    cfg = onboarding_decision.goal_config("emergency_fund")
+    # Start already at/above target → already_reached → on_track shape.
+    result = assess(cfg.target_vnd, cfg.target_vnd, cfg.horizon_years, Decimal(0))
+    assert result.already_reached
+    text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="anh")
+    assert "anh" in text
+    assert str(result.months) in text
+
+
+def test_answer_on_track_when_band_achievable():
+    cfg = onboarding_decision.goal_config("emergency_fund")
+    # Small gap, strong saving rate → EASY/FEASIBLE → on_track (months).
+    result = assess(
+        Decimal("50000000"), cfg.target_vnd, cfg.horizon_years, Decimal("5000000")
+    )
+    assert result.band in ("easy", "feasible")
+    text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="bạn")
+    assert str(result.months) in text
+
+
+def test_answer_building_when_saving_but_short():
+    cfg = onboarding_decision.goal_config("first_home")
+    # Some saving rate, still a long reach → building shape (reachable target).
+    result = assess(Decimal(0), cfg.target_vnd, cfg.horizon_years, Decimal("1000000"))
+    assert result.actual_monthly_savings > 0
+    assert result.reachable_target is not None
+    from backend.bot.formatters.money import format_money_short
+
+    text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="chị")
+    assert format_money_short(result.reachable_target) in text
+    # Still references the real milestone so the user keeps the north star.
+    assert format_money_short(cfg.target_vnd) in text
+
+
+def test_answer_direction_when_no_saving_signal():
+    """The common onboarding case: no saving-rate data → UNKNOWN band → point
+    at the milestone framed as a start, never a flat 'no'."""
+    cfg = onboarding_decision.goal_config("wedding")
+    result = assess(Decimal(0), cfg.target_vnd, cfg.horizon_years, Decimal(0))
+    assert result.actual_monthly_savings == 0
+    from backend.bot.formatters.money import format_money_short
+
+    text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="bạn")
+    assert format_money_short(cfg.target_vnd) in text
+    # No invented timeline — direction copy never states a month count as fact.
+    assert "{" not in text and "}" not in text
+
+
+# ----- độ nét: always appended, humble below threshold ---------------------
+
+
+def test_clarity_line_below_threshold_is_humble_and_suggests_sharpen():
+    cfg = onboarding_decision.goal_config("emergency_fund")
+    result = assess(Decimal(0), cfg.target_vnd, cfg.horizon_years, Decimal(0))
+    clarity = _clarity()  # all zero → score 0, below threshold
+    assert clarity.is_below_threshold
+    text = onboarding_decision.render_answer(result, cfg, clarity, salutation="bạn")
+
+    copy = onboarding_decision._decision_copy()["clarity"]
+    top = clarity.top_sharpen()
+    sharpen_text = copy["sharpen"][top.key]
+    assert str(clarity.score) in text
+    assert sharpen_text in text
+
+
+def test_clarity_line_above_threshold_nudges_with_sharpen_tail():
+    cfg = onboarding_decision.goal_config("emergency_fund")
+    result = assess(Decimal(0), cfg.target_vnd, cfg.horizon_years, Decimal(0))
+    # One fresh asset → score ~35, above threshold but still sharpenable.
+    clarity = _clarity(assets=1, types=1, fresh_days=5)
+    assert not clarity.is_below_threshold
+    assert clarity.score >= CLARITY_MIN_THRESHOLD
+    text = onboarding_decision.render_answer(result, cfg, clarity, salutation="bạn")
+
+    copy = onboarding_decision._decision_copy()["clarity"]
+    top = clarity.top_sharpen()
+    assert str(clarity.score) in text
+    assert copy["sharpen"][top.key] in text
+
+
+def test_clarity_sharpen_suggestion_tracks_the_missing_component():
+    """The sharpen nudge names the single highest-leverage missing dimension —
+    here assets+freshness are complete, so it should point at income."""
+    cfg = onboarding_decision.goal_config("emergency_fund")
+    result = assess(Decimal(0), cfg.target_vnd, cfg.horizon_years, Decimal(0))
+    clarity = _clarity(assets=3, types=3, fresh_days=5)  # assets+freshness maxed
+    top = clarity.top_sharpen()
+    assert top.key == "income"
+    text = onboarding_decision.render_answer(result, cfg, clarity, salutation="bạn")
+    copy = onboarding_decision._decision_copy()["clarity"]
+    assert copy["sharpen"]["income"] in text
+
+
+# ----- copy hygiene: no forbidden positioning / harsh tone -----------------
+
+
+def _all_copy_strings() -> str:
+    return str(onboarding_decision._decision_copy()).lower()
+
+
+def test_copy_has_no_forbidden_positioning_terms():
+    blob = _all_copy_strings()
+    for banned in _FORBIDDEN_TERMS:
+        assert banned not in blob, f"forbidden term leaked: {banned!r}"
+
+
+def test_copy_has_no_harsh_tone_words():
+    blob = _all_copy_strings()
+    for banned in _BANNED_TONE:
+        assert banned not in blob, f"harsh tone word leaked: {banned!r}"
+
+
+# ----- handler: _send_decision_moment wiring -------------------------------
+
+
+@pytest.mark.asyncio
+async def test_send_decision_moment_sends_question_answer_and_logs(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+    from backend.services.decision import (
+        clarity_service,
+        decision_query_log_service,
+    )
+    from backend.services.goal_projection import get_avg_monthly_savings  # noqa: F401
+    from backend.services import goal_projection
+    from backend.services.onboarding import onboarding_service
+
+    user = _user(salutation="anh")
+
+    async def _get_session(_db, _uid):
+        return SimpleNamespace(
+            goal_choice="emergency_fund",
+            first_asset_value_vnd=Decimal("10000000"),
+        )
+
+    async def _avg_savings(_db, _uid, **_k):
+        return Decimal(0)
+
+    async def _compute_clarity(_db, _uid, **_k):
+        return _clarity(assets=1, types=1, fresh_days=5)
+
+    sent: list[str] = []
+
+    async def _send(chat_id, text, **kwargs):
+        sent.append(text)
+        return {"result": {"message_id": len(sent)}}
+
+    logged: list[dict] = []
+
+    async def _log_query(_db, **kwargs):
+        logged.append(kwargs)
+
+    monkeypatch.setattr(onboarding_service, "get_session", _get_session)
+    monkeypatch.setattr(goal_projection, "get_avg_monthly_savings", _avg_savings)
+    monkeypatch.setattr(clarity_service, "compute_clarity", _compute_clarity)
+    monkeypatch.setattr(decision_query_log_service, "log_query", _log_query)
+    tracked: list[tuple] = []
+
+    def _track(event, **kwargs):
+        tracked.append((event, kwargs))
+
+    monkeypatch.setattr(onboarding_v2, "send_message", _send)
+    monkeypatch.setattr(onboarding_v2.analytics, "track", _track)
+
+    await onboarding_v2._send_decision_moment(object(), chat_id=42, user=user)
+
+    # Exactly the question then the answer, both in the user's salutation.
+    assert len(sent) == 2
+    assert all("anh" in msg for msg in sent)
+    # One append-only feasibility row carrying the độ nét through to E4.
+    assert len(logged) == 1
+    from backend.models.decision_query_log import QUERY_TYPE_FEASIBILITY
+
+    assert logged[0]["query_type"] == QUERY_TYPE_FEASIBILITY
+    assert logged[0]["success"] is True
+    assert logged[0]["clarity_score"] == _clarity(assets=1, types=1, fresh_days=5).score
+    # Analytics fired past the band read — guards the str-vs-enum band bug so a
+    # regression there can't be silently swallowed by the best-effort wrapper.
+    assert len(tracked) == 1
+    assert tracked[0][0] == "onboarding_decision_moment_shown"
+    assert tracked[0][1]["properties"]["band"] == "unknown"
+
+
+@pytest.mark.asyncio
+async def test_send_decision_moment_noop_without_session(monkeypatch):
+    from backend.bot.handlers import onboarding_v2
+    from backend.services.onboarding import onboarding_service
+
+    async def _get_session(_db, _uid):
+        return None
+
+    sent: list[str] = []
+
+    async def _send(chat_id, text, **kwargs):
+        sent.append(text)
+
+    monkeypatch.setattr(onboarding_service, "get_session", _get_session)
+    monkeypatch.setattr(onboarding_v2, "send_message", _send)
+    monkeypatch.setattr(onboarding_v2.analytics, "track", lambda *a, **k: None)
+
+    await onboarding_v2._send_decision_moment(object(), chat_id=42, user=_user())
+    assert sent == []
+
+
+@pytest.mark.asyncio
+async def test_send_decision_moment_is_best_effort(monkeypatch):
+    """A failure inside the moment must be swallowed — the Twin reveal already
+    happened and must never be broken by this add-on."""
+    from backend.bot.handlers import onboarding_v2
+    from backend.services.onboarding import onboarding_service
+
+    async def _boom(_db, _uid):
+        raise RuntimeError("db blew up")
+
+    monkeypatch.setattr(onboarding_service, "get_session", _boom)
+    monkeypatch.setattr(onboarding_v2, "send_message", lambda *a, **k: None)
+    monkeypatch.setattr(onboarding_v2.analytics, "track", lambda *a, **k: None)
+
+    # Must not raise.
+    await onboarding_v2._send_decision_moment(object(), chat_id=42, user=_user())


### PR DESCRIPTION
## Phase 4.6 · Epic E3 — Decision Moment trong onboarding

Right after the Twin reveal, Bé Tiền poses **one** goal-specific decision question and answers it on the spot with **exactly one number**, then tells the truth about how sharp the picture is (độ nét). Reuses the Phase 4.5 services (`plan_feasibility_service` + `clarity_service`) — **no new engine** — behind `ONBOARDING_DECISION_MOMENT_ENABLED` (default off, read at the handler edge). Off keeps the reveal byte-identical to pre-4.6.

Close #985

### What changed
- **`content/onboarding/decision_moment.yaml`** (new) — goal-specific questions + typical first-life milestones (quỹ khẩn cấp / cọc nhà / cưới), three honest answer shapes, and the độ nét line with a per-component sharpen nudge. All copy honest-not-harsh, salutation-aware, 0 jargon.
- **`backend/bot/formatters/onboarding_decision.py`** (new) — pure formatter (no I/O, no env). Picks the answer shape from how much the feasibility engine could conclude: `on_track` (months) → `building` (reachable target the user is trending toward) → `direction` (typical milestone framed as a start, for the common onboarding case with no saving-rate signal). Unknown / legacy goals fall back to `default_goal` so the moment never strands a user.
- **`backend/bot/handlers/onboarding_v2.py`** — `is_onboarding_decision_moment_enabled()` flag reader + `_send_decision_moment()` called at the climax of `_trigger_first_twin` (after the chart, before the feedback prompt; runs synchronously because it needs the live DB session). Sends question + answer, logs one append-only `decision_query_log` feasibility row with the clarity score for the E4 dashboard, and is **best-effort** (any failure is logged and swallowed so the Twin reveal can never break). The band is normalised to its short code since the projection hands it back as a bare string.

### Layer contract / conventions
- Flag read only at the handler edge, never in the formatter/service.
- Formatter is pure; the only write is one flush-only `log_query` — the worker owns the commit.
- All money is `Decimal`; all user-facing strings live in content YAML.
- No "Decision Engine / CFO / GPS tài chính" terms, no harsh tone words in copy.

### Tests
- `tests/test_phase_4_6/test_onboarding_decision_moment.py` (new, 31 tests): flag truthy/falsy + default-off; goal_config per reset goal + distinct milestones + fallback; question threads salutation with no stray placeholder; all three answer shapes (already-reached / achievable band / building / direction); độ nét below vs above threshold + sharpen suggestion tracks the missing component; copy hygiene (no forbidden terms, no harsh tone); `_send_decision_moment` sends question+answer+logs+analytics, no-ops without a session, and swallows failures.
- Full `tests/test_phase_4_6/` suite: **95 passed**. Broader onboarding/decision/clarity/feasibility selection: **244 passed**. `ruff check` clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suj5ENcPR7DooNU7GowadB