### PR TITLE
fix(onboarding): decision-moment review follow-ups (Phase 4.6 E3)

### DIFF
--- a/backend/bot/formatters/onboarding_decision.py
+++ b/backend/bot/formatters/onboarding_decision.py
@@ -115,22 +115,29 @@ def render_answer(
     label = config.goal_label
     label_cap = (label[:1].upper() + label[1:]) if label else label
     target = format_money_short(config.target_vnd)
-    years = _format_years(config.horizon_years)
 
-    if result.already_reached or result.band in _ACHIEVABLE_BANDS:
+    if result.already_reached:
+        # ``months`` here is the horizon fallback (the finished projection has no
+        # ``months_remaining``), so never phrase it as "còn X tháng" — celebrate
+        # instead of inventing a countdown.
+        body = answers.get("already_reached", "").format(
+            salutation=salutation,
+            goal_label=label,
+        )
+    elif result.band in _ACHIEVABLE_BANDS:
         body = answers.get("on_track", "").format(
             months=result.months,
             salutation=salutation,
             goal_label=label,
         )
     elif result.actual_monthly_savings > 0 and result.reachable_target is not None:
+        # Exactly one number: the amount the user is trending toward. The real
+        # milestone lives in the question above — repeating it here would turn
+        # the moment into a mini feasibility report.
         body = answers.get("building", "").format(
             reachable=format_money_short(result.reachable_target),
-            years=years,
             salutation=salutation,
             goal_label=label,
-            goal_label_cap=label_cap,
-            target=target,
         )
     else:
         # No saving-rate signal (the common onboarding case) → don't invent a
@@ -163,14 +170,6 @@ def _render_clarity(clarity: ClarityResult, *, salutation: str) -> str:
     return cl.get("above", "").format(
         salutation=salutation, score=clarity.score, sharpen_tail=tail
     )
-
-
-def _format_years(horizon_years: Decimal) -> str:
-    """ "5 năm" / "5.5 năm" — drop the trailing ``.0`` for whole years."""
-    years = Decimal(horizon_years)
-    if years == years.to_integral_value():
-        return f"{int(years)} năm"
-    return f"{years.normalize()} năm"
 
 
 def _join(*parts: str) -> str:

--- a/backend/bot/formatters/onboarding_decision.py
+++ b/backend/bot/formatters/onboarding_decision.py
@@ -119,10 +119,12 @@ def render_answer(
     if result.already_reached:
         # ``months`` here is the horizon fallback (the finished projection has no
         # ``months_remaining``), so never phrase it as "còn X tháng" — celebrate
-        # instead of inventing a countdown.
+        # instead of inventing a countdown. Keep the milestone {target} the user
+        # just cleared so the answer still carries one real number.
         body = answers.get("already_reached", "").format(
             salutation=salutation,
             goal_label=label,
+            target=target,
         )
     elif result.band in _ACHIEVABLE_BANDS:
         body = answers.get("on_track", "").format(
@@ -131,11 +133,13 @@ def render_answer(
             goal_label=label,
         )
     elif result.actual_monthly_savings > 0 and result.reachable_target is not None:
-        # Exactly one number: the amount the user is trending toward. The real
-        # milestone lives in the question above — repeating it here would turn
-        # the moment into a mini feasibility report.
+        # One money number: the amount the user is trending toward. Pair it with
+        # the {years} horizon that number is projected over — without the window
+        # the "reachable" figure is ambiguous. We still skip the original target
+        # here so the moment stays a nudge, not a mini feasibility report.
         body = answers.get("building", "").format(
             reachable=format_money_short(result.reachable_target),
+            years=_format_years(config.horizon_years),
             salutation=salutation,
             goal_label=label,
         )
@@ -170,6 +174,14 @@ def _render_clarity(clarity: ClarityResult, *, salutation: str) -> str:
     return cl.get("above", "").format(
         salutation=salutation, score=clarity.score, sharpen_tail=tail
     )
+
+
+def _format_years(horizon_years: Decimal) -> str:
+    """Render the horizon as "5 năm" / "5.5 năm", dropping a trailing ``.0``."""
+    years = Decimal(horizon_years)
+    if years == years.to_integral_value():
+        return f"{int(years)} năm"
+    return f"{years.normalize()} năm"
 
 
 def _join(*parts: str) -> str:

--- a/backend/bot/handlers/onboarding_v2.py
+++ b/backend/bot/handlers/onboarding_v2.py
@@ -1183,8 +1183,10 @@ async def _trigger_first_twin(
     # after the chart, before the feedback prompt. Flag read at the edge; off
     # keeps the reveal byte-identical to pre-4.6. Runs synchronously here (not
     # in the feedback task) because it needs the live DB session, which does
-    # not survive the worker boundary.
-    if is_onboarding_decision_moment_enabled():
+    # not survive the worker boundary. Skipped for the demo Twin: its 50tr
+    # portfolio is framed as giả định, so answering a decision on it (and
+    # logging it as a real feasibility interaction) would blur that framing.
+    if not demo and is_onboarding_decision_moment_enabled():
         await _send_decision_moment(db, chat_id, user)
 
     # Schedule the in-moment feedback prompt 7s later in a fire-and-forget
@@ -1218,45 +1220,54 @@ async def _send_decision_moment(db: AsyncSession, chat_id: int, user: User) -> N
     from backend.services.goal_projection import get_avg_monthly_savings
 
     try:
-        session = await onboarding_service.get_session(db, user.id)
-        if session is None:
-            return
+        # A SAVEPOINT isolates every DB touch in this best-effort block. If a
+        # read or the log flush errors, only this savepoint rolls back — the
+        # outer transaction (incl. mark_twin_shown just above) stays healthy and
+        # the worker's boundary commit still succeeds. Without it a poisoned
+        # session would fail that commit and silently undo the whole reveal.
+        async with db.begin_nested():
+            session = await onboarding_service.get_session(db, user.id)
+            if session is None:
+                return
 
-        config = onboarding_decision.goal_config(session.goal_choice)
-        salutation = onboarding_service.salutation_of(user)
-        start = session.first_asset_value_vnd or Decimal(0)
+            config = onboarding_decision.goal_config(session.goal_choice)
+            salutation = onboarding_service.salutation_of(user)
+            start = session.first_asset_value_vnd or Decimal(0)
 
-        # Single DB read for the saving rate (the feasibility engine is pure);
-        # clarity runs a handful of lightweight indexed reads.
-        avg_savings = await get_avg_monthly_savings(db, user.id)
-        result = plan_feasibility_service.assess(
-            start, config.target_vnd, config.horizon_years, avg_savings
-        )
-        clarity = await clarity_service.compute_clarity(db, user.id)
+            # Single DB read for the saving rate (the feasibility engine is
+            # pure); clarity runs a handful of lightweight indexed reads.
+            avg_savings = await get_avg_monthly_savings(db, user.id)
+            result = plan_feasibility_service.assess(
+                start, config.target_vnd, config.horizon_years, avg_savings
+            )
+            clarity = await clarity_service.compute_clarity(db, user.id)
 
-        await send_message(
-            chat_id,
-            onboarding_decision.render_question(config, salutation=salutation),
-            parse_mode="HTML",
-        )
-        await send_message(
-            chat_id,
-            onboarding_decision.render_answer(
-                result, config, clarity, salutation=salutation
-            ),
-            parse_mode="HTML",
-        )
+            await send_message(
+                chat_id,
+                onboarding_decision.render_question(config, salutation=salutation),
+                parse_mode="HTML",
+            )
+            await send_message(
+                chat_id,
+                onboarding_decision.render_answer(
+                    result, config, clarity, salutation=salutation
+                ),
+                parse_mode="HTML",
+            )
 
-        # Append-only funnel row. Onboarding always lands a verdict (there is
-        # no clarify turn), so success is always True; clarity_score threads the
-        # độ nét through for the E4 dashboard.
-        await decision_query_log_service.log_query(
-            db,
-            user_id=user.id,
-            query_type=QUERY_TYPE_FEASIBILITY,
-            success=True,
-            clarity_score=clarity.score,
-        )
+            # Append-only funnel row. Onboarding always lands a verdict (there
+            # is no clarify turn), so success is always True; clarity_score
+            # threads the độ nét through for the E4 dashboard.
+            await decision_query_log_service.log_query(
+                db,
+                user_id=user.id,
+                query_type=QUERY_TYPE_FEASIBILITY,
+                success=True,
+                clarity_score=clarity.score,
+            )
+
+        # Pure telemetry — outside the savepoint so a tracking hiccup can never
+        # roll back the funnel row we just flushed.
         analytics.track(
             "onboarding_decision_moment_shown",
             user_id=user.id,

--- a/content/onboarding/decision_moment.yaml
+++ b/content/onboarding/decision_moment.yaml
@@ -34,10 +34,12 @@ decision_moment:
     target_vnd: 100000000
     horizon_years: 3
   answers:
+    # already_reached — số dư đã chạm/vượt mốc: không nói "còn X tháng", chúc mừng luôn.
+    already_reached: "Ủa xịn ghê — {salutation} đã chạm {goal_label} rồi đó! 🎉 Giờ mình cùng nhắm tới mốc kế tiếp thôi nha."
     # on_track — đủ dữ liệu, đang trên đà: 1 con số = số tháng.
     on_track: "Tin vui nè: với nhịp này, khoảng {months} tháng nữa là {salutation} chạm {goal_label} rồi 🎯"
-    # building — có tiết kiệm nhưng còn chặng dài: 1 con số = mức đang trên đà tới.
-    building: "Với nhịp hiện tại, {salutation} đang trên đà tới khoảng {reachable} trong {years}. {goal_label_cap} thường quanh {target} — mình đi từng bước là tới thôi 💪"
+    # building — có tiết kiệm nhưng còn chặng dài: ĐÚNG 1 con số = mức đang trên đà tới.
+    building: "Với nhịp hiện tại, {salutation} đang trên đà tới khoảng {reachable} cho {goal_label} — cứ đi từng bước là tới thôi 💪"
     # direction — dữ liệu còn mỏng (chưa thấy nhịp tiết kiệm): 1 con số = mốc tham chiếu.
     direction: "{goal_label_cap} thường quanh mức {target}. Nhịp tiết kiệm của {salutation} mình chưa nhìn ra, nên đây mới là điểm khởi đầu thôi — mà hướng đi thì đã rõ rồi ✨"
   clarity:

--- a/content/onboarding/decision_moment.yaml
+++ b/content/onboarding/decision_moment.yaml
@@ -34,12 +34,16 @@ decision_moment:
     target_vnd: 100000000
     horizon_years: 3
   answers:
-    # already_reached — số dư đã chạm/vượt mốc: không nói "còn X tháng", chúc mừng luôn.
-    already_reached: "Ủa xịn ghê — {salutation} đã chạm {goal_label} rồi đó! 🎉 Giờ mình cùng nhắm tới mốc kế tiếp thôi nha."
+    # already_reached — số dư đã chạm/vượt mốc: KHÔNG nói "còn X tháng" (số tháng
+    # chỉ là horizon fallback, không phải thời gian thật), nhưng vẫn giữ 1 con số
+    # mục tiêu = mốc {target} vừa chạm, để câu trả lời không mất con số.
+    already_reached: "Ủa xịn ghê — {salutation} đã đủ mốc {target} cho {goal_label} rồi đó! 🎉 Giờ mình cùng nhắm cột mốc kế tiếp thôi nha."
     # on_track — đủ dữ liệu, đang trên đà: 1 con số = số tháng.
     on_track: "Tin vui nè: với nhịp này, khoảng {months} tháng nữa là {salutation} chạm {goal_label} rồi 🎯"
-    # building — có tiết kiệm nhưng còn chặng dài: ĐÚNG 1 con số = mức đang trên đà tới.
-    building: "Với nhịp hiện tại, {salutation} đang trên đà tới khoảng {reachable} cho {goal_label} — cứ đi từng bước là tới thôi 💪"
+    # building — có tiết kiệm nhưng còn chặng dài: 1 con số tiền = mức đang trên đà
+    # tới, KÈM mốc thời gian {years} để con số đó không mơ hồ (nó là dự phóng cho
+    # cả horizon). Vẫn KHÔNG lặp lại target gốc → không thành báo cáo mini.
+    building: "Với nhịp hiện tại, trong {years} tới {salutation} đang trên đà chạm khoảng {reachable} cho {goal_label} — cứ đi từng bước là tới thôi 💪"
     # direction — dữ liệu còn mỏng (chưa thấy nhịp tiết kiệm): 1 con số = mốc tham chiếu.
     direction: "{goal_label_cap} thường quanh mức {target}. Nhịp tiết kiệm của {salutation} mình chưa nhìn ra, nên đây mới là điểm khởi đầu thôi — mà hướng đi thì đã rõ rồi ✨"
   clarity:

--- a/tests/test_phase_4_6/test_onboarding_decision_moment.py
+++ b/tests/test_phase_4_6/test_onboarding_decision_moment.py
@@ -176,11 +176,15 @@ def test_answer_already_reached_celebrates_without_a_countdown():
     # Start already at/above target → already_reached shape.
     result = assess(cfg.target_vnd, cfg.target_vnd, cfg.horizon_years, Decimal(0))
     assert result.already_reached
+    from backend.bot.formatters.money import format_money_short
+
     text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="anh")
     assert "anh" in text
     # ``months`` is the horizon fallback here — must NOT be phrased as a
     # remaining countdown ("còn X tháng") for someone who is already there.
     assert f"{result.months} tháng" not in text
+    # But the answer still carries one real number: the milestone just cleared.
+    assert format_money_short(cfg.target_vnd) in text
     assert "{" not in text and "}" not in text
 
 
@@ -205,9 +209,12 @@ def test_answer_building_when_saving_but_short():
 
     text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="chị")
     assert format_money_short(result.reachable_target) in text
-    # Exactly one goal number: the reachable amount. The real milestone lives in
-    # the question, so it must NOT be repeated here (keeps the one-number promise).
+    # One money number: the reachable amount. The original milestone lives in the
+    # question, so it must NOT be repeated here (keeps the one-number promise).
     assert format_money_short(cfg.target_vnd) not in text
+    # …but the reachable figure is a projection over the horizon, so the {years}
+    # window it's measured against must appear to keep the number unambiguous.
+    assert onboarding_decision._format_years(cfg.horizon_years) in text
 
 
 def test_answer_direction_when_no_saving_signal():

--- a/tests/test_phase_4_6/test_onboarding_decision_moment.py
+++ b/tests/test_phase_4_6/test_onboarding_decision_moment.py
@@ -61,6 +61,27 @@ def _user(salutation: str = "bạn"):
     )
 
 
+class _FakeSavepoint:
+    """Async-CM stand-in for ``AsyncSession.begin_nested()`` — the handler wraps
+    its best-effort DB work in a SAVEPOINT, so the fake session must yield one.
+    Propagates exceptions (returns False) exactly like the real savepoint."""
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+
+class _FakeSession:
+    """Minimal ``AsyncSession`` duck for the handler tests — the DB reads/writes
+    are all monkeypatched, so the only method the handler calls on it directly is
+    ``begin_nested()``."""
+
+    def begin_nested(self):
+        return _FakeSavepoint()
+
+
 def _clarity(
     *,
     assets: int = 0,
@@ -150,14 +171,17 @@ def test_render_question_threads_salutation(code, salutation):
 # ----- answer: three honest shapes, always one number ----------------------
 
 
-def test_answer_on_track_when_already_reached():
+def test_answer_already_reached_celebrates_without_a_countdown():
     cfg = onboarding_decision.goal_config("emergency_fund")
-    # Start already at/above target → already_reached → on_track shape.
+    # Start already at/above target → already_reached shape.
     result = assess(cfg.target_vnd, cfg.target_vnd, cfg.horizon_years, Decimal(0))
     assert result.already_reached
     text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="anh")
     assert "anh" in text
-    assert str(result.months) in text
+    # ``months`` is the horizon fallback here — must NOT be phrased as a
+    # remaining countdown ("còn X tháng") for someone who is already there.
+    assert f"{result.months} tháng" not in text
+    assert "{" not in text and "}" not in text
 
 
 def test_answer_on_track_when_band_achievable():
@@ -181,8 +205,9 @@ def test_answer_building_when_saving_but_short():
 
     text = onboarding_decision.render_answer(result, cfg, _clarity(), salutation="chị")
     assert format_money_short(result.reachable_target) in text
-    # Still references the real milestone so the user keeps the north star.
-    assert format_money_short(cfg.target_vnd) in text
+    # Exactly one goal number: the reachable amount. The real milestone lives in
+    # the question, so it must NOT be repeated here (keeps the one-number promise).
+    assert format_money_short(cfg.target_vnd) not in text
 
 
 def test_answer_direction_when_no_saving_signal():
@@ -314,7 +339,7 @@ async def test_send_decision_moment_sends_question_answer_and_logs(monkeypatch):
     monkeypatch.setattr(onboarding_v2, "send_message", _send)
     monkeypatch.setattr(onboarding_v2.analytics, "track", _track)
 
-    await onboarding_v2._send_decision_moment(object(), chat_id=42, user=user)
+    await onboarding_v2._send_decision_moment(_FakeSession(), chat_id=42, user=user)
 
     # Exactly the question then the answer, both in the user's salutation.
     assert len(sent) == 2
@@ -350,7 +375,7 @@ async def test_send_decision_moment_noop_without_session(monkeypatch):
     monkeypatch.setattr(onboarding_v2, "send_message", _send)
     monkeypatch.setattr(onboarding_v2.analytics, "track", lambda *a, **k: None)
 
-    await onboarding_v2._send_decision_moment(object(), chat_id=42, user=_user())
+    await onboarding_v2._send_decision_moment(_FakeSession(), chat_id=42, user=_user())
     assert sent == []
 
 
@@ -368,5 +393,5 @@ async def test_send_decision_moment_is_best_effort(monkeypatch):
     monkeypatch.setattr(onboarding_v2, "send_message", lambda *a, **k: None)
     monkeypatch.setattr(onboarding_v2.analytics, "track", lambda *a, **k: None)
 
-    # Must not raise.
-    await onboarding_v2._send_decision_moment(object(), chat_id=42, user=_user())
+    # Must not raise — the savepoint rolls back and the wrapper swallows.
+    await onboarding_v2._send_decision_moment(_FakeSession(), chat_id=42, user=_user())


### PR DESCRIPTION
## Phase 4.6 · E3 — decision-moment review follow-ups

Follow-up to the merged decision moment (#985 / PR #986). Addresses the P2 findings raised in review, all confirmed real. Copy/formatter/handler-local — no engine or schema change.

Close #987

### What changed
- **Already-reached no longer invents a countdown, but still carries a number** — when `PlanFeasibility.already_reached` is true, `months` is only the horizon fallback (the finished projection has no `months_remaining`), so the old `on_track` copy told a user already at their milestone "khoảng 24 tháng nữa". Added a dedicated celebratory `already_reached` line with no month count, and it names the milestone `{target}` the user just cleared so the answer keeps one real goal number.
- **Best-effort DB work is now isolated in a SAVEPOINT** — `_send_decision_moment` wraps its reads + the `log_query` flush in `db.begin_nested()`. A failure there rolls back only the savepoint, so the outer transaction (incl. `mark_twin_shown`) stays healthy and the worker's boundary commit still succeeds. Previously a poisoned session would fail that commit and silently undo the whole reveal — defeating the "best-effort, never break the Twin" intent. Analytics `track` moved just outside the savepoint so a telemetry hiccup can't roll back the funnel row.
- **Demo Twin skips the decision moment** — gated on `not demo`. The demo 50tr portfolio is framed as giả định, so answering a decision on it (and logging a real feasibility interaction) would blur that framing.
- **`building` answer keeps one money number, paired with its horizon** — carries the single reachable amount the user is trending toward, plus the `{years}` window that amount is projected over (without it, "khoảng 59tr" is ambiguous). The original target is still omitted so the moment stays a nudge, not a mini feasibility report. `_format_years` helper retained for the horizon.

### Layer contract / conventions
- Flag / `demo` decision read at the handler edge; formatter stays pure (no I/O, no env).
- Only write is the flush-only `log_query`; the worker owns the commit. The savepoint does not commit — it releases into the outer transaction.
- All money `Decimal`; all user-facing strings in `content/onboarding/decision_moment.yaml`. No forbidden positioning terms, no harsh tone words.

### Tests
- `tests/test_phase_4_6/test_onboarding_decision_moment.py`: already-reached asserts **no** "N tháng" countdown but that the milestone number is present; building asserts one money number (reachable present, original target absent) plus the horizon window; the three `_send_decision_moment` tests run through the savepoint via a fake session that yields `begin_nested()`.
- `tests/test_phase_4_6/` = **95 passed**. `ruff check` clean on all changed files.
- The `not demo` gate is a one-line handler guard over the existing `_trigger_first_twin` flow; not covered by a dedicated integration test to avoid a brittle full-reveal mock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suj5ENcPR7DooNU7GowadB