### PR TITLE
feat(4.6-e4): cohort-tagged decision log + admin adoption chart

### DIFF
--- a/alembic/versions/20260712_phase46_decision_query_log_cohort.py
+++ b/alembic/versions/20260712_phase46_decision_query_log_cohort.py
@@ -1,0 +1,42 @@
+"""phase 4.6 decision query log cohort tag (E4 #4.1)
+
+Adds an onboarding-cohort tag to the append-only decision-query log so the
+Phase 4.6 admin dashboard can split the new first-life segment (22-35,
+Level 0→1) from the legacy asset-management cohort. ``cohort`` is a short
+stable code ("reset" / "legacy") derived from the chosen goal, NULL when the
+goal is unknown or no session exists. A single-column index matches the
+dashboard's per-cohort grouping.
+
+Purely additive: a nullable column + one index. No backfill — pre-existing
+rows keep a NULL cohort, which the chart reads as "unattributed".
+
+Revision ID: 20260712dqcohort46
+Revises: 20260710dqlog45
+Create Date: 2026-07-12
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+
+revision = "20260712dqcohort46"
+down_revision = "20260710dqlog45"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "decision_query_logs",
+        sa.Column("cohort", sa.String(length=16), nullable=True),
+    )
+    op.create_index(
+        "idx_decision_query_log_cohort", "decision_query_logs", ["cohort"]
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("idx_decision_query_log_cohort", "decision_query_logs")
+    op.drop_column("decision_query_logs", "cohort")

--- a/backend/api/admin/analytics.py
+++ b/backend/api/admin/analytics.py
@@ -14,6 +14,7 @@ from backend.database import get_db
 from backend.models.admin_user import AdminUser
 from backend.models.agent_audit_log import AgentAuditLog
 from backend.models.cost_budget import LLMCostLog
+from backend.models.decision_query_log import DecisionQueryLog
 from backend.models.event import Event
 from backend.models.feature_event import FeatureEvent
 from backend.models.portfolio_asset import PortfolioAsset
@@ -21,6 +22,7 @@ from backend.models.user import User
 from backend.schemas.admin import (
     CohortRetentionResponse,
     DauChartResponse,
+    DecisionAdoptionResponse,
     FeatureClicksResponse,
     IntentBreakdownResponse,
     OverviewStatsResponse,
@@ -46,6 +48,15 @@ INTENT_LABELS = {
     "rule": "Rule-based (zero cost)",
     "llm_classifier": "LLM classified",
     "clarification": "Cần clarify",
+}
+# Onboarding cohort of the decision-adoption chart. ``unattributed`` buckets the
+# NULL-cohort rows (pre-4.6 logs + users who never chose an onboarding goal).
+# Ordered so the new first-life segment reads first, legacy second.
+COHORT_UNATTRIBUTED = "unattributed"
+DECISION_COHORT_LABELS = {
+    "reset": "Segment mới (reset)",
+    "legacy": "Cohort cũ (legacy)",
+    COHORT_UNATTRIBUTED: "Chưa gắn cohort",
 }
 DEFAULT_TENANT_ID = 1
 
@@ -352,4 +363,87 @@ async def cohort_retention(
         out.append({"cohort_week": cohort_week, "cohort_size": size, "retention": retention})
     response = {"cohorts": out}
     await cache_set(key, response, 86400)
+    return response
+
+
+@router.get("/charts/decision-adoption", response_model=DecisionAdoptionResponse)
+async def decision_adoption(
+    weeks: int = Query(default=8, ge=1, le=26),
+    admin: AdminUser = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Weekly Decision-Engine adoption, split by onboarding cohort.
+
+    Reads the append-only ``decision_query_logs`` (Phase 4.5) tagged with the
+    onboarding cohort in #4.1, and reports per week × cohort: interactions (row
+    count), active users (distinct ``user_id``), interactions/user, and the
+    average độ nét. Feeds gates G1/G2 — does the new first-life ``reset`` segment
+    engage the decision surfaces differently from the ``legacy`` cohort?
+
+    Output is aggregate-only (counts + averages) so no PII ever leaves the
+    query; tenant isolation and JWT auth match the other admin charts.
+    """
+    tenant_id = _admin_tenant_id(admin)
+    key = f"admin:tenant:{tenant_id}:charts:decision-adoption:{weeks}"
+    cached = await cache_get(key)
+    if cached is not None:
+        return cached
+
+    today = datetime.now(VN_TZ).date()
+    current_week = today - timedelta(days=today.weekday())
+    first_week = current_week - timedelta(weeks=weeks - 1)
+    start_dt = datetime.combine(first_week, time.min, tzinfo=VN_TZ).astimezone(timezone.utc)
+    week_list = [first_week + timedelta(weeks=offset) for offset in range(weeks)]
+
+    week_col = cast(func.date_trunc("week", func.timezone("Asia/Ho_Chi_Minh", DecisionQueryLog.created_at)), Date)
+    cohort_col = func.coalesce(DecisionQueryLog.cohort, COHORT_UNATTRIBUTED)
+    rows = (
+        await db.execute(
+            select(
+                week_col.label("week"),
+                cohort_col.label("cohort"),
+                func.count().label("interactions"),
+                func.count(func.distinct(DecisionQueryLog.user_id)).label("active_users"),
+                func.avg(DecisionQueryLog.clarity_score).label("avg_clarity"),
+            )
+            .where(_tenant_filter(DecisionQueryLog, tenant_id), DecisionQueryLog.created_at >= start_dt)
+            .group_by(week_col, cohort_col)
+        )
+    ).all()
+
+    # (cohort, week) -> metrics, so we can emit a dense series per cohort.
+    by_cohort: dict[str, dict[date, dict]] = defaultdict(dict)
+    for row in rows:
+        interactions = int(row.interactions)
+        active_users = int(row.active_users)
+        by_cohort[row.cohort][row.week] = {
+            "week": row.week,
+            "interactions": interactions,
+            "active_users": active_users,
+            "interactions_per_user": round(interactions / active_users, 2) if active_users else 0.0,
+            "avg_clarity": round(float(row.avg_clarity), 1) if row.avg_clarity is not None else None,
+        }
+
+    cohorts = []
+    for cohort, label in DECISION_COHORT_LABELS.items():
+        weeks_seen = by_cohort.get(cohort)
+        if not weeks_seen:
+            continue  # skip a cohort with zero interactions in the window
+        points = [
+            weeks_seen.get(
+                week,
+                {
+                    "week": week,
+                    "interactions": 0,
+                    "active_users": 0,
+                    "interactions_per_user": 0.0,
+                    "avg_clarity": None,
+                },
+            )
+            for week in week_list
+        ]
+        cohorts.append({"cohort": cohort, "label": label, "points": points})
+
+    response = {"weeks": week_list, "cohorts": cohorts}
+    await cache_set(key, response, 1800)
     return response

--- a/backend/bot/handlers/onboarding_v2.py
+++ b/backend/bot/handlers/onboarding_v2.py
@@ -1212,6 +1212,7 @@ async def _send_decision_moment(db: AsyncSession, chat_id: int, user: User) -> N
     """
     from backend.bot.formatters import onboarding_decision
     from backend.models.decision_query_log import QUERY_TYPE_FEASIBILITY
+    from backend.models.onboarding_session import cohort_for_goal
     from backend.services.decision import (
         clarity_service,
         decision_query_log_service,
@@ -1257,13 +1258,16 @@ async def _send_decision_moment(db: AsyncSession, chat_id: int, user: User) -> N
 
             # Append-only funnel row. Onboarding always lands a verdict (there
             # is no clarify turn), so success is always True; clarity_score
-            # threads the độ nét through for the E4 dashboard.
+            # threads the độ nét through for the E4 dashboard, and the cohort
+            # tag (free from the session goal) lets the chart split the new
+            # first-life segment from the legacy cohort.
             await decision_query_log_service.log_query(
                 db,
                 user_id=user.id,
                 query_type=QUERY_TYPE_FEASIBILITY,
                 success=True,
                 clarity_score=clarity.score,
+                cohort=cohort_for_goal(session.goal_choice),
             )
 
         # Pure telemetry — outside the savepoint so a tracking hiccup can never

--- a/backend/intent/handlers/decision_feasibility.py
+++ b/backend/intent/handlers/decision_feasibility.py
@@ -37,7 +37,11 @@ from backend.intent.handlers.decision_flags import (
 from backend.intent.intents import IntentResult
 from backend.models.decision_query_log import QUERY_TYPE_FEASIBILITY
 from backend.models.user import User
-from backend.services.decision import decision_query_log_service, plan_feasibility_service
+from backend.services.decision import (
+    cohort_service,
+    decision_query_log_service,
+    plan_feasibility_service,
+)
 from backend.services.goal_projection import get_avg_monthly_savings
 from backend.services.onboarding.onboarding_service import salutation_of
 
@@ -57,6 +61,9 @@ class DecisionFeasibilityHandler(IntentHandler):
             return await AdvisoryHandler().handle(intent, user, db)
 
         answer, success = await self._answer(intent, user, db)
+        # Phase 4.6 E4 — tag the row with the onboarding cohort so the admin
+        # chart can split the new first-life segment from the legacy cohort.
+        cohort = await cohort_service.resolve_user_cohort(db, user.id)
         # E5 #5.1 — one append-only row per handled query, including the
         # clarify turns that never reach a verdict (success=False).
         await decision_query_log_service.log_query(
@@ -64,6 +71,7 @@ class DecisionFeasibilityHandler(IntentHandler):
             user_id=user.id,
             query_type=QUERY_TYPE_FEASIBILITY,
             success=success,
+            cohort=cohort,
         )
         return answer
 

--- a/backend/intent/handlers/decision_shock.py
+++ b/backend/intent/handlers/decision_shock.py
@@ -49,7 +49,11 @@ from backend.intent.handlers.decision_flags import (
 from backend.intent.intents import IntentResult
 from backend.models.decision_query_log import QUERY_TYPE_SHOCK
 from backend.models.user import User
-from backend.services.decision import clarity_service, decision_query_log_service
+from backend.services.decision import (
+    clarity_service,
+    cohort_service,
+    decision_query_log_service,
+)
 from backend.services.decision.liquidation_advisor import rank_options
 from backend.services.decision.shock_simulation_service import simulate_shock
 from backend.twin.services.twin_projection_service import load_portfolio_snapshot
@@ -73,6 +77,9 @@ class DecisionShockHandler(IntentHandler):
             return await AdvisoryHandler().handle(intent, user, db)
 
         answer, success, clarity_score = await self._answer(intent, user, db)
+        # Phase 4.6 E4 — tag the row with the onboarding cohort so the admin
+        # chart can split the new first-life segment from the legacy cohort.
+        cohort = await cohort_service.resolve_user_cohort(db, user.id)
         # E5 #5.1 — one append-only row per handled query, including the
         # clarify/empty/confirm turns that never reach a verdict (success=False).
         await decision_query_log_service.log_query(
@@ -81,6 +88,7 @@ class DecisionShockHandler(IntentHandler):
             query_type=QUERY_TYPE_SHOCK,
             success=success,
             clarity_score=clarity_score,
+            cohort=cohort,
         )
         return answer
 

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -59,6 +59,8 @@ from backend.models.license import (
 )
 from backend.models.onboarding_session import (
     ALL_GOALS,
+    COHORT_LEGACY,
+    COHORT_RESET,
     GOAL_EMERGENCY_FUND,
     GOAL_FIRST_HOME,
     GOAL_PLAN_GOAL,
@@ -67,6 +69,7 @@ from backend.models.onboarding_session import (
     GOAL_WEDDING,
     LEGACY_GOALS,
     RESET_GOALS,
+    cohort_for_goal,
     SEGMENT_HNW,
     SEGMENT_MASS_AFFLUENT,
     SEGMENT_STARTER,
@@ -174,6 +177,9 @@ __all__ = [
     "LEGACY_GOALS",
     "RESET_GOALS",
     "ALL_GOALS",
+    "COHORT_RESET",
+    "COHORT_LEGACY",
+    "cohort_for_goal",
     "SEGMENT_STARTER",
     "SEGMENT_YOUNG_PRO",
     "SEGMENT_MASS_AFFLUENT",

--- a/backend/models/decision_query_log.py
+++ b/backend/models/decision_query_log.py
@@ -45,6 +45,11 @@ class DecisionQueryLog(Base):
     # meter was off or the turn never reached a verdict.
     clarity_score: Mapped[Decimal | None] = mapped_column(Numeric(5, 2))
     success: Mapped[bool] = mapped_column(Boolean, nullable=False)
+    # Onboarding cohort at answer time (Phase 4.6 / E4), derived from the chosen
+    # goal via ``onboarding_session.cohort_for_goal`` — "reset" (first-life
+    # segment) / "legacy" (asset-management). NULL when the goal is unknown or
+    # no session exists, so the admin chart can split the new segment out.
+    cohort: Mapped[str | None] = mapped_column(String(16))
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), default=datetime.utcnow, nullable=False
     )
@@ -53,6 +58,7 @@ class DecisionQueryLog(Base):
         Index("idx_decision_query_log_user_id", "user_id"),
         Index("idx_decision_query_log_query_type", "query_type"),
         Index("idx_decision_query_log_created_at", "created_at"),
+        Index("idx_decision_query_log_cohort", "cohort"),
     )
 
 

--- a/backend/models/onboarding_session.py
+++ b/backend/models/onboarding_session.py
@@ -66,6 +66,29 @@ RESET_GOALS = (GOAL_EMERGENCY_FUND, GOAL_FIRST_HOME, GOAL_WEDDING)
 # ``next(iter(ALL_GOALS))`` in tests rely on it as the default.
 ALL_GOALS = LEGACY_GOALS + RESET_GOALS
 
+# Phase 4.6 (E4) — onboarding cohort, derived from the chosen goal so the admin
+# dashboard can split the new first-life segment (22-35, Level 0→1) from the
+# legacy asset-management cohort. ``reset`` = a first-life goal (emergency fund
+# / first home / wedding); ``legacy`` = an asset-management goal. Persisted as a
+# short stable code on ``decision_query_logs.cohort`` (≤ 16 chars).
+COHORT_RESET = "reset"
+COHORT_LEGACY = "legacy"
+
+
+def cohort_for_goal(goal_choice: str | None) -> str | None:
+    """Classify an onboarding ``goal_choice`` into its cohort tag.
+
+    Pure function (no I/O) so both the model layer and the flush-only log
+    service can share one source of truth. A reset goal → ``COHORT_RESET``, a
+    legacy goal → ``COHORT_LEGACY``, and anything unknown / ``None`` → ``None``
+    so an unrecognised goal is left untagged rather than mis-bucketed.
+    """
+    if goal_choice in RESET_GOALS:
+        return COHORT_RESET
+    if goal_choice in LEGACY_GOALS:
+        return COHORT_LEGACY
+    return None
+
 # Wealth segments — inferred from first asset value (not self-reported).
 SEGMENT_STARTER = "starter"
 SEGMENT_YOUNG_PRO = "young_pro"

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -167,6 +167,25 @@ class CohortRetentionResponse(BaseModel):
     cohorts: list[CohortRetentionRow]
 
 
+class DecisionAdoptionPoint(BaseModel):
+    week: date
+    interactions: int
+    active_users: int
+    interactions_per_user: float
+    avg_clarity: float | None = None
+
+
+class DecisionAdoptionCohort(BaseModel):
+    cohort: str
+    label: str
+    points: list[DecisionAdoptionPoint]
+
+
+class DecisionAdoptionResponse(BaseModel):
+    weeks: list[date]
+    cohorts: list[DecisionAdoptionCohort]
+
+
 class LicenseSummaryBucket(BaseModel):
     key: str
     count: int

--- a/backend/services/decision/cohort_service.py
+++ b/backend/services/decision/cohort_service.py
@@ -1,0 +1,39 @@
+"""Resolve a user's onboarding cohort — Phase 4.6 / E4 (#4.1).
+
+The decision-query log tags each row with the onboarding cohort so the admin
+dashboard can split the new first-life segment (22-35, Level 0→1) from the
+legacy asset-management cohort. The onboarding decision moment already has the
+session loaded, so it classifies inline; the shock + feasibility handlers only
+carry a ``user_id``, so they use this one-lookup resolver.
+
+Layer contract: read-only helper (single indexed PK lookup, no write, no env,
+no transport). The pure ``cohort_for_goal`` classifier is the single source of
+truth for the goal → cohort mapping.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.onboarding_session import OnboardingSession, cohort_for_goal
+
+
+async def resolve_user_cohort(db: AsyncSession, user_id: uuid.UUID) -> str | None:
+    """Return the onboarding cohort tag for ``user_id`` ("reset" / "legacy") or
+    ``None`` when there is no session, no goal, or an unknown goal.
+
+    One indexed primary-key lookup of ``goal_choice`` — cheap enough for the
+    decision hot path — then the pure classifier does the mapping.
+    """
+    goal_choice = await db.scalar(
+        select(OnboardingSession.goal_choice).where(
+            OnboardingSession.user_id == user_id
+        )
+    )
+    return cohort_for_goal(goal_choice)
+
+
+__all__ = ["resolve_user_cohort"]

--- a/backend/services/decision/decision_query_log_service.py
+++ b/backend/services/decision/decision_query_log_service.py
@@ -30,12 +30,17 @@ async def log_query(
     query_type: str,
     success: bool,
     clarity_score: Decimal | int | None = None,
+    cohort: str | None = None,
 ) -> DecisionQueryLog:
     """Append one decision-query row and flush.
 
     ``clarity_score`` is the độ nét at answer time (0..100) when the clarity
     meter is on, else ``None``. An ``int`` score is accepted and coerced to
     ``Decimal`` so callers can pass ``ClarityResult.score`` straight through.
+
+    ``cohort`` is the onboarding cohort tag (Phase 4.6 / E4) — "reset" /
+    "legacy" / ``None`` — already classified by the caller so this service
+    stays a pure writer. ``None`` leaves the row unattributed.
     """
     score = Decimal(clarity_score) if clarity_score is not None else None
     row = DecisionQueryLog(
@@ -43,6 +48,7 @@ async def log_query(
         query_type=query_type,
         success=success,
         clarity_score=score,
+        cohort=cohort,
     )
     db.add(row)
     await db.flush()

--- a/backend/tests/test_admin_analytics_decision_adoption.py
+++ b/backend/tests/test_admin_analytics_decision_adoption.py
@@ -1,0 +1,286 @@
+"""Phase 4.6 / E4 / Issue #4.2 — the decision-adoption admin chart.
+
+``GET /charts/decision-adoption`` reads the append-only ``decision_query_logs``
+(tagged with an onboarding cohort in #4.1) and reports, per ISO week × cohort:
+interactions, active users, interactions/user, and the average độ nét. The
+endpoint is DB-free under test — a ``_FakeDB`` replays the single grouped query
+and ``cache_get`` / ``cache_set`` are monkeypatched.
+
+Coverage: cache key + tenant scoping, cohort splitting (reset / legacy /
+unattributed) in a fixed display order, dense per-week backfill of gaps,
+``interactions_per_user`` rounding, ``avg_clarity`` ``None`` passthrough,
+zero-interaction cohort skipping, the cache-hit short-circuit, and the
+aggregate-only (no-PII) shape of the payload.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+from decimal import Decimal
+
+import pytest
+
+from backend.api.admin import analytics as admin_analytics
+from backend.api.admin.analytics import VN_TZ, COHORT_UNATTRIBUTED
+from backend.models.admin_user import AdminUser
+from backend.models.decision_query_log import DecisionQueryLog
+
+
+class _Row:
+    def __init__(self, **values):
+        self.__dict__.update(values)
+        self._values = list(values.values())
+
+    def __getitem__(self, index: int):
+        return self._values[index]
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeDB:
+    def __init__(self, results):
+        self.results = list(results)
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return self.results.pop(0)
+
+
+def _admin(tenant_id: int | None = 1) -> AdminUser:
+    return AdminUser(
+        id=1,
+        email="admin@example.com",
+        password_hash="hash",
+        role="super_admin",
+        tenant_id=tenant_id,
+        is_active=True,
+    )
+
+
+def _current_week() -> date:
+    """Monday of the current VN week — mirrors the endpoint's bucketing."""
+    today = datetime.now(VN_TZ).date()
+    return today - timedelta(days=today.weekday())
+
+
+@pytest.fixture
+def cache_spy(monkeypatch):
+    """Monkeypatch the cache; return (get_keys, set_calls, seed)."""
+    get_keys: list[str] = []
+    set_calls: list[tuple] = []
+    seeded: dict[str, object] = {}
+
+    async def fake_cache_get(key):
+        get_keys.append(key)
+        return seeded.get(key)
+
+    async def fake_cache_set(key, value, ttl):
+        set_calls.append((key, value, ttl))
+
+    monkeypatch.setattr(admin_analytics, "cache_get", fake_cache_get)
+    monkeypatch.setattr(admin_analytics, "cache_set", fake_cache_set)
+    return get_keys, set_calls, seeded
+
+
+# --------------------------------------------------------------------------
+# tenant scoping — decision_query_logs has no tenant_id column
+# --------------------------------------------------------------------------
+
+
+def test_tenant_filter_falls_back_to_default_tenant_only():
+    # No tenant_id column → default tenant sees everything, others see nothing.
+    assert str(admin_analytics._tenant_filter(DecisionQueryLog, 1)) == "true"
+    assert str(admin_analytics._tenant_filter(DecisionQueryLog, 2)) == "false"
+
+
+@pytest.mark.asyncio
+async def test_non_default_tenant_query_is_scoped_to_false(cache_spy):
+    _, _, _ = cache_spy
+    db = _FakeDB([_RowsResult([])])
+
+    await admin_analytics.decision_adoption(weeks=4, admin=_admin(2), db=db)
+
+    # The where-clause carries the false() guard for a non-default tenant.
+    assert "false" in str(db.statements[0])
+
+
+# --------------------------------------------------------------------------
+# happy path — split cohorts, dense backfill, rounding
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_splits_cohorts_and_backfills_missing_weeks(cache_spy):
+    get_keys, set_calls, _ = cache_spy
+    w = _current_week()
+    weeks = [w - timedelta(weeks=3), w - timedelta(weeks=2), w - timedelta(weeks=1), w]
+
+    db = _FakeDB([
+        _RowsResult([
+            _Row(week=weeks[0], cohort="reset", interactions=4, active_users=2, avg_clarity=Decimal("8.0")),
+            _Row(week=weeks[3], cohort="reset", interactions=3, active_users=3, avg_clarity=6.5),
+            _Row(week=weeks[2], cohort="legacy", interactions=2, active_users=1, avg_clarity=None),
+        ])
+    ])
+
+    response = await admin_analytics.decision_adoption(weeks=4, admin=_admin(1), db=db)
+
+    assert get_keys == ["admin:tenant:1:charts:decision-adoption:4"]
+    assert set_calls[0][0] == "admin:tenant:1:charts:decision-adoption:4"
+    assert set_calls[0][2] == 1800
+
+    assert response["weeks"] == weeks
+    # reset first, legacy second (unattributed absent), matching label order.
+    assert [c["cohort"] for c in response["cohorts"]] == ["reset", "legacy"]
+    assert [c["label"] for c in response["cohorts"]] == ["Segment mới (reset)", "Cohort cũ (legacy)"]
+
+    reset = response["cohorts"][0]["points"]
+    assert [p["week"] for p in reset] == weeks  # dense: one point per week
+    assert reset[0] == {
+        "week": weeks[0],
+        "interactions": 4,
+        "active_users": 2,
+        "interactions_per_user": 2.0,
+        "avg_clarity": 8.0,
+    }
+    # gap weeks are back-filled with zeros / None, never dropped.
+    assert reset[1] == {
+        "week": weeks[1],
+        "interactions": 0,
+        "active_users": 0,
+        "interactions_per_user": 0.0,
+        "avg_clarity": None,
+    }
+    assert reset[3]["interactions"] == 3
+    assert reset[3]["interactions_per_user"] == 1.0
+    assert reset[3]["avg_clarity"] == 6.5
+
+    legacy = response["cohorts"][1]["points"]
+    assert legacy[2]["interactions"] == 2
+    assert legacy[2]["active_users"] == 1
+    assert legacy[2]["interactions_per_user"] == 2.0
+    assert legacy[2]["avg_clarity"] is None  # NULL avg → None, no crash
+
+
+@pytest.mark.asyncio
+async def test_interactions_per_user_rounds_to_two_places(cache_spy):
+    w = _current_week()
+    db = _FakeDB([
+        _RowsResult([
+            _Row(week=w, cohort="reset", interactions=5, active_users=3, avg_clarity=Decimal("7.25")),
+        ])
+    ])
+
+    response = await admin_analytics.decision_adoption(weeks=1, admin=_admin(1), db=db)
+
+    point = response["cohorts"][0]["points"][0]
+    assert point["interactions_per_user"] == round(5 / 3, 2)  # 1.67
+    assert point["avg_clarity"] == 7.2  # round(7.25, 1) → banker's/half-even
+
+
+# --------------------------------------------------------------------------
+# the unattributed bucket + zero-cohort skipping + ordering
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_null_cohort_surfaces_as_unattributed(cache_spy):
+    w = _current_week()
+    # coalesce() happens in SQL, so the fake row already carries the label.
+    db = _FakeDB([
+        _RowsResult([
+            _Row(week=w, cohort=COHORT_UNATTRIBUTED, interactions=1, active_users=1, avg_clarity=None),
+        ])
+    ])
+
+    response = await admin_analytics.decision_adoption(weeks=1, admin=_admin(1), db=db)
+
+    assert [c["cohort"] for c in response["cohorts"]] == [COHORT_UNATTRIBUTED]
+    assert response["cohorts"][0]["label"] == "Chưa gắn cohort"
+
+
+@pytest.mark.asyncio
+async def test_zero_interaction_cohorts_are_skipped(cache_spy):
+    w = _current_week()
+    db = _FakeDB([
+        _RowsResult([
+            _Row(week=w, cohort="legacy", interactions=2, active_users=2, avg_clarity=None),
+        ])
+    ])
+
+    response = await admin_analytics.decision_adoption(weeks=2, admin=_admin(1), db=db)
+
+    # Only the cohort with rows appears; reset / unattributed are omitted.
+    assert [c["cohort"] for c in response["cohorts"]] == ["legacy"]
+
+
+@pytest.mark.asyncio
+async def test_all_three_cohorts_keep_label_order(cache_spy):
+    w = _current_week()
+    db = _FakeDB([
+        _RowsResult([
+            # deliberately out of order — output order comes from the label map.
+            _Row(week=w, cohort=COHORT_UNATTRIBUTED, interactions=1, active_users=1, avg_clarity=None),
+            _Row(week=w, cohort="legacy", interactions=1, active_users=1, avg_clarity=None),
+            _Row(week=w, cohort="reset", interactions=1, active_users=1, avg_clarity=None),
+        ])
+    ])
+
+    response = await admin_analytics.decision_adoption(weeks=1, admin=_admin(1), db=db)
+
+    assert [c["cohort"] for c in response["cohorts"]] == ["reset", "legacy", COHORT_UNATTRIBUTED]
+
+
+# --------------------------------------------------------------------------
+# empty window, cache short-circuit, PII shape
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_empty_window_returns_weeks_but_no_cohorts(cache_spy):
+    w = _current_week()
+    db = _FakeDB([_RowsResult([])])
+
+    response = await admin_analytics.decision_adoption(weeks=3, admin=_admin(1), db=db)
+
+    assert response["cohorts"] == []
+    assert response["weeks"] == [w - timedelta(weeks=2), w - timedelta(weeks=1), w]
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_short_circuits_the_query(cache_spy):
+    get_keys, set_calls, seeded = cache_spy
+    key = "admin:tenant:1:charts:decision-adoption:8"
+    seeded[key] = {"weeks": [], "cohorts": [], "cached": True}
+    db = _FakeDB([])  # would IndexError if execute() were called
+
+    response = await admin_analytics.decision_adoption(weeks=8, admin=_admin(1), db=db)
+
+    assert response == {"weeks": [], "cohorts": [], "cached": True}
+    assert get_keys == [key]
+    assert set_calls == []  # nothing re-cached on a hit
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_payload_is_aggregate_only_no_user_ids(cache_spy):
+    w = _current_week()
+    db = _FakeDB([
+        _RowsResult([
+            _Row(week=w, cohort="reset", interactions=3, active_users=2, avg_clarity=Decimal("5.0")),
+        ])
+    ])
+
+    response = await admin_analytics.decision_adoption(weeks=1, admin=_admin(1), db=db)
+
+    point_keys = set(response["cohorts"][0]["points"][0].keys())
+    assert point_keys == {"week", "interactions", "active_users", "interactions_per_user", "avg_clarity"}
+    # no user-identifying field ever leaves the aggregate query.
+    assert not any("user_id" in k or "phone" in k or "email" in k for k in point_keys)

--- a/betien-admin/src/api/adminDashboard.js
+++ b/betien-admin/src/api/adminDashboard.js
@@ -34,6 +34,10 @@ export function getCohortRetention(weeks = 8) {
   return apiFetch(buildAdminDashboardPath('/charts/cohort-retention', { weeks }));
 }
 
+export function getDecisionAdoption(weeks = 8) {
+  return apiFetch(buildAdminDashboardPath('/charts/decision-adoption', { weeks }));
+}
+
 export function getLicenseSummary() {
   return apiFetch('/licenses/summary');
 }

--- a/betien-admin/src/pages/DashboardPage.jsx
+++ b/betien-admin/src/pages/DashboardPage.jsx
@@ -26,6 +26,8 @@ import {
   BarChart,
   CartesianGrid,
   Cell,
+  Line,
+  LineChart,
   Pie,
   PieChart,
   ResponsiveContainer,
@@ -41,6 +43,7 @@ import TwinDashboard from './TwinDashboard/TwinDashboard';
 import {
   changeUserStatus,
   getCohortRetention,
+  getDecisionAdoption,
   getDau,
   getFeatureClicks,
   getIntentBreakdown,
@@ -104,6 +107,7 @@ function DashboardContent() {
   const [intentBreakdown, setIntentBreakdown] = useState([]);
   const [userTiers, setUserTiers] = useState([]);
   const [cohorts, setCohorts] = useState([]);
+  const [decisionAdoption, setDecisionAdoption] = useState({ weeks: [], cohorts: [] });
   const [licenseSummary, setLicenseSummary] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -115,7 +119,7 @@ function DashboardContent() {
       setError('');
       try {
         const days = selectedRange.days;
-        const [overviewPayload, growthPayload, dauPayload, clicksPayload, intentPayload, tiersPayload, cohortPayload, licensePayload] = await Promise.all([
+        const [overviewPayload, growthPayload, dauPayload, clicksPayload, intentPayload, tiersPayload, cohortPayload, decisionPayload, licensePayload] = await Promise.all([
           getOverview(range),
           getUserGrowth(days),
           getDau(Math.min(days, 90)),
@@ -123,6 +127,7 @@ function DashboardContent() {
           getIntentBreakdown(days),
           getUserTiers(),
           getCohortRetention(8),
+          getDecisionAdoption(8),
           getLicenseSummary(),
         ]);
         if (!alive) return;
@@ -133,6 +138,7 @@ function DashboardContent() {
         setIntentBreakdown(intentPayload.data || []);
         setUserTiers(tiersPayload.data || []);
         setCohorts(cohortPayload.cohorts || []);
+        setDecisionAdoption({ weeks: decisionPayload.weeks || [], cohorts: decisionPayload.cohorts || [] });
         setLicenseSummary(licensePayload);
       } catch (err) {
         if (alive) setError(err.message || 'Không tải được dashboard.');
@@ -164,6 +170,7 @@ function DashboardContent() {
           <TierDistributionChart loading={loading} data={userTiers} />
         </section>
         <CohortRetentionTable loading={loading} cohorts={cohorts} />
+        <DecisionAdoptionChart loading={loading} weeks={decisionAdoption.weeks} cohorts={decisionAdoption.cohorts} />
         <LicenseFoundationCard loading={loading} summary={licenseSummary} />
         <UserDirectory refreshNonce={refreshNonce} />
       </div>
@@ -448,6 +455,86 @@ function RetentionCell({ value }) {
     <td className={`rounded-xl px-3 py-3 text-center font-mono text-xs font-semibold ${presentation.className}`} style={presentation.style}>
       {presentation.text}
     </td>
+  );
+}
+
+const decisionMetrics = [
+  { key: 'interactions_per_user', label: 'Tương tác / user', format: 'decimal' },
+  { key: 'interactions', label: 'Tổng tương tác', format: 'number' },
+  { key: 'active_users', label: 'Active users', format: 'number' },
+  { key: 'avg_clarity', label: 'Độ nét TB', format: 'decimal' },
+];
+
+function formatWeekLabel(week) {
+  return typeof week === 'string' ? week.slice(5).replace('-', '/') : String(week);
+}
+
+function buildDecisionAdoptionSeries(weeks, cohorts, metric) {
+  return weeks.map((week, index) => {
+    const row = { label: formatWeekLabel(week) };
+    cohorts.forEach((cohort) => {
+      const value = cohort.points?.[index]?.[metric];
+      row[cohort.cohort] = value === undefined ? null : value;
+    });
+    return row;
+  });
+}
+
+function DecisionAdoptionChart({ loading, weeks, cohorts }) {
+  const [metric, setMetric] = useState('interactions_per_user');
+  const data = useMemo(() => buildDecisionAdoptionSeries(weeks, cohorts, metric), [weeks, cohorts, metric]);
+  const empty = cohorts.length === 0;
+  const totals = cohorts.map((cohort) => ({
+    cohort,
+    total: (cohort.points || []).reduce((sum, point) => sum + (point.interactions || 0), 0),
+  }));
+  const busiest = totals.slice().sort((a, b) => b.total - a.total)[0];
+  return (
+    <MetricShell eyebrow="Adoption" title="Decision adoption theo cohort">
+      <div className="-mt-2 mb-4 flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <p className="text-xs text-ink-500">Tương tác quyết định theo tuần, tách segment mới (reset) khỏi cohort cũ (legacy).</p>
+        <div className="flex flex-wrap gap-1.5">
+          {decisionMetrics.map((option) => (
+            <button
+              key={option.key}
+              type="button"
+              onClick={() => setMetric(option.key)}
+              className={`rounded-full border px-3 py-1 text-xs font-medium transition ${metric === option.key ? 'border-gold bg-gold-50 text-gold' : 'border-hairline text-ink-500 hover:border-gold'}`}
+            >
+              {option.label}
+            </button>
+          ))}
+        </div>
+      </div>
+      <ChartFrame loading={loading} empty={empty || data.length === 0}>
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data} margin={{ top: 10, right: 12, left: -20, bottom: 0 }}>
+            <CartesianGrid stroke="#E8E0D3" vertical={false} />
+            <XAxis dataKey="label" tickLine={false} axisLine={false} tick={{ fill: '#52677A', fontSize: 11 }} />
+            <YAxis tickLine={false} axisLine={false} tick={{ fill: '#52677A', fontSize: 11 }} />
+            <Tooltip content={<CustomTooltip />} />
+            {cohorts.map((cohort, index) => (
+              <Line
+                key={cohort.cohort}
+                type="monotone"
+                dataKey={cohort.cohort}
+                name={cohort.label}
+                stroke={pieColors[index % pieColors.length]}
+                strokeWidth={2}
+                dot={false}
+                connectNulls
+              />
+            ))}
+          </LineChart>
+        </ResponsiveContainer>
+      </ChartFrame>
+      <Legend data={cohorts.map((cohort, index) => ({ label: cohort.label, value: `${formatNumber(totals[index].total)} tương tác`, color: pieColors[index % pieColors.length] }))} />
+      <Insight>
+        {busiest && busiest.total > 0
+          ? `${busiest.cohort.label} dẫn đầu về tổng tương tác (${formatNumber(busiest.total)}); theo dõi interactions/user để so sánh mức gắn kết giữa các cohort.`
+          : 'Chưa có decision query nào được ghi log để tách cohort.'}
+      </Insight>
+    </MetricShell>
   );
 }
 

--- a/tests/test_phase_4_5/conftest.py
+++ b/tests/test_phase_4_5/conftest.py
@@ -13,12 +13,19 @@ class FakeSession:
     ``session.added`` when it cares about the logging side effect.
     """
 
-    def __init__(self) -> None:
+    def __init__(self, *, goal_choice: str | None = None) -> None:
         self.added: list = []
         self.flushes = 0
+        # Phase 4.6 E4: the decision handlers resolve the onboarding cohort with
+        # one ``db.scalar`` lookup of ``goal_choice``. Default ``None`` keeps the
+        # pre-4.6 tests untagged; a test can pass a goal to exercise tagging.
+        self.goal_choice = goal_choice
 
     def add(self, obj) -> None:
         self.added.append(obj)
 
     async def flush(self) -> None:
         self.flushes += 1
+
+    async def scalar(self, *args, **kwargs):
+        return self.goal_choice

--- a/tests/test_phase_4_6/test_decision_cohort_tag.py
+++ b/tests/test_phase_4_6/test_decision_cohort_tag.py
@@ -1,0 +1,239 @@
+"""Phase 4.6 / E4 / Issue #4.1 — cohort tag on the decision query log.
+
+The append-only ``decision_query_logs`` rows now carry an onboarding cohort so
+the admin dashboard can split the new first-life segment (22-35, Level 0→1)
+from the legacy asset-management cohort. Three layers under test:
+
+* ``cohort_for_goal`` — the pure classifier (reset / legacy / None).
+* ``cohort_service.resolve_user_cohort`` — the one-lookup resolver used by the
+  shock + feasibility handlers, which only carry a ``user_id``.
+* ``log_query`` + the two handlers — the ``cohort`` is threaded onto the row,
+  and an untagged user still logs (cohort ``None``), never crashing.
+
+All DB-free: the shared ``FakeSession`` records added rows and stubs the single
+``db.scalar`` cohort lookup.
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from backend import models
+from backend.intent.handlers import decision_feasibility as dfh
+from backend.intent.handlers import decision_shock as dsh
+from backend.intent.handlers.decision_feasibility import DecisionFeasibilityHandler
+from backend.intent.handlers.decision_shock import DecisionShockHandler
+from backend.intent.intents import IntentResult, IntentType
+from backend.models.decision_query_log import (
+    QUERY_TYPE_FEASIBILITY,
+    QUERY_TYPE_SHOCK,
+    DecisionQueryLog,
+)
+from backend.models.onboarding_session import (
+    COHORT_LEGACY,
+    COHORT_RESET,
+    GOAL_EMERGENCY_FUND,
+    GOAL_FIRST_HOME,
+    GOAL_PLAN_GOAL,
+    GOAL_TRACK_SPENDING,
+    GOAL_UNDERSTAND_WEALTH,
+    GOAL_WEDDING,
+    LEGACY_GOALS,
+    RESET_GOALS,
+    cohort_for_goal,
+)
+from backend.services.decision import cohort_service
+from backend.services.decision import decision_query_log_service as log_svc
+from backend.twin.services.twin_projection_service import PortfolioSnapshot
+from tests.test_phase_4_5.conftest import FakeSession
+
+SHOCK_FLAG = "SHOCK_SIMULATION_ENABLED"
+FEAS_FLAG = "PLAN_FEASIBILITY_QA_ENABLED"
+CLARITY_FLAG = "CLARITY_METER_ENABLED"
+
+
+def _user():
+    return SimpleNamespace(id=uuid.uuid4(), salutation="bạn")
+
+
+def _logged_rows(db: FakeSession) -> list[DecisionQueryLog]:
+    return [r for r in db.added if isinstance(r, DecisionQueryLog)]
+
+
+# --------------------------------------------------------------------------
+# The pure classifier
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("goal", RESET_GOALS)
+def test_reset_goals_map_to_reset_cohort(goal):
+    assert cohort_for_goal(goal) == COHORT_RESET
+
+
+@pytest.mark.parametrize("goal", LEGACY_GOALS)
+def test_legacy_goals_map_to_legacy_cohort(goal):
+    assert cohort_for_goal(goal) == COHORT_LEGACY
+
+
+@pytest.mark.parametrize("goal", [None, "", "some_unknown_goal", "RESET"])
+def test_unknown_or_missing_goal_is_untagged(goal):
+    assert cohort_for_goal(goal) is None
+
+
+def test_cohorts_are_disjoint_and_reset_covers_new_segment():
+    # Every first-life goal is reset, every asset-management goal is legacy,
+    # and the two sets never overlap — no goal is ambiguously bucketed.
+    assert {cohort_for_goal(g) for g in RESET_GOALS} == {COHORT_RESET}
+    assert {cohort_for_goal(g) for g in LEGACY_GOALS} == {COHORT_LEGACY}
+    assert set(RESET_GOALS).isdisjoint(LEGACY_GOALS)
+
+
+def test_cohort_codes_fit_the_column():
+    # decision_query_logs.cohort is String(16).
+    assert len(COHORT_RESET) <= 16
+    assert len(COHORT_LEGACY) <= 16
+
+
+def test_reexported_from_models_package():
+    assert models.cohort_for_goal is cohort_for_goal
+    assert models.COHORT_RESET == COHORT_RESET
+    assert models.COHORT_LEGACY == COHORT_LEGACY
+
+
+# --------------------------------------------------------------------------
+# The one-lookup resolver
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("goal", "expected"),
+    [
+        (GOAL_EMERGENCY_FUND, COHORT_RESET),
+        (GOAL_FIRST_HOME, COHORT_RESET),
+        (GOAL_WEDDING, COHORT_RESET),
+        (GOAL_UNDERSTAND_WEALTH, COHORT_LEGACY),
+        (GOAL_PLAN_GOAL, COHORT_LEGACY),
+        (GOAL_TRACK_SPENDING, COHORT_LEGACY),
+        (None, None),
+    ],
+)
+async def test_resolve_user_cohort(goal, expected):
+    db = FakeSession(goal_choice=goal)
+    assert await cohort_service.resolve_user_cohort(db, uuid.uuid4()) == expected
+
+
+# --------------------------------------------------------------------------
+# The flush-only writer
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_log_query_persists_cohort():
+    db = FakeSession()
+    row = await log_svc.log_query(
+        db,
+        user_id=uuid.uuid4(),
+        query_type=QUERY_TYPE_SHOCK,
+        success=True,
+        cohort=COHORT_RESET,
+    )
+    assert row.cohort == COHORT_RESET
+    assert db.flushes == 1
+
+
+@pytest.mark.asyncio
+async def test_log_query_cohort_defaults_to_none():
+    db = FakeSession()
+    row = await log_svc.log_query(
+        db, user_id=uuid.uuid4(), query_type=QUERY_TYPE_FEASIBILITY, success=False
+    )
+    assert row.cohort is None
+
+
+# --------------------------------------------------------------------------
+# Handler threading — the cohort lands on the logged row
+# --------------------------------------------------------------------------
+
+
+def _shock_intent(**params) -> IntentResult:
+    return IntentResult(
+        intent=IntentType.DECISION_SHOCK,
+        confidence=0.8,
+        parameters=dict(params),
+        raw_text="nếu phải chi 200tr thì sao",
+    )
+
+
+def _feas_intent(**params) -> IntentResult:
+    return IntentResult(
+        intent=IntentType.DECISION_FEASIBILITY,
+        confidence=0.8,
+        parameters=dict(params),
+        raw_text="muốn có 1 tỷ sau 5 năm khả thi không",
+    )
+
+
+def _snapshot(net_worth: Decimal = Decimal(1_000_000_000)) -> PortfolioSnapshot:
+    amounts = {
+        "cash_savings": net_worth * Decimal("0.3"),
+        "stocks_vn": net_worth * Decimal("0.4"),
+        "gold": net_worth * Decimal("0.3"),
+    }
+    total = sum(amounts.values(), Decimal(0))
+    return PortfolioSnapshot(
+        base_net_worth=net_worth,
+        monthly_savings=Decimal(5_000_000),
+        allocation_amounts=amounts,
+        allocation_weights={k: v / total for k, v in amounts.items()},
+    )
+
+
+@pytest.mark.asyncio
+async def test_shock_tags_row_with_reset_cohort(monkeypatch):
+    monkeypatch.setenv(SHOCK_FLAG, "true")
+    monkeypatch.delenv(CLARITY_FLAG, raising=False)
+
+    async def fake_load(db, user_id):
+        return _snapshot()
+
+    monkeypatch.setattr(dsh, "load_portfolio_snapshot", fake_load)
+    # A reset-goal user asking a shock question → row.cohort == "reset".
+    db = FakeSession(goal_choice=GOAL_FIRST_HOME)
+    await DecisionShockHandler().handle(
+        _shock_intent(shock_amount=200_000_000), _user(), db
+    )
+    rows = _logged_rows(db)
+    assert len(rows) == 1
+    assert rows[0].cohort == COHORT_RESET
+
+
+@pytest.mark.asyncio
+async def test_shock_untagged_user_logs_with_none_cohort(monkeypatch):
+    monkeypatch.setenv(SHOCK_FLAG, "true")
+    db = FakeSession()  # no onboarding goal → untagged, still logs
+    await DecisionShockHandler().handle(_shock_intent(), _user(), db)
+    rows = _logged_rows(db)
+    assert len(rows) == 1
+    assert rows[0].cohort is None
+
+
+@pytest.mark.asyncio
+async def test_feasibility_tags_row_with_legacy_cohort(monkeypatch):
+    monkeypatch.setenv(FEAS_FLAG, "true")
+
+    async def fake_savings(db, user_id, *, today=None):
+        return Decimal(5_000_000)
+
+    monkeypatch.setattr(dfh, "get_avg_monthly_savings", fake_savings)
+    db = FakeSession(goal_choice=GOAL_UNDERSTAND_WEALTH)
+    await DecisionFeasibilityHandler().handle(
+        _feas_intent(target_amount=60_000_000, horizon_years=5), _user(), db
+    )
+    rows = _logged_rows(db)
+    assert len(rows) == 1
+    assert rows[0].cohort == COHORT_LEGACY


### PR DESCRIPTION
## Phase 4.6 — Epic E4: Instrumentation Cohort → Admin Dashboard

Closes the final Phase 4.6 epic. The append-only decision query log now carries an onboarding **cohort**, and the admin dashboard surfaces weekly decision-adoption split by cohort — so we can tell whether the new first-life segment (22-35, Level 0→1) engages the decision surfaces differently from the legacy asset-management cohort.

### #4.1 — Cohort tag on `decision_query_logs`
- `cohort_for_goal()` classifier on `OnboardingSession` → `reset` (first-life goals) / `legacy` (asset-management goals) / `None`, re-exported from the models package.
- New nullable `decision_query_logs.cohort` `String(16)` column + index (migration `20260712dqcohort46`, single head).
- `cohort_service.resolve_user_cohort()` — one view-only lookup used by the shock + feasibility handlers (which only carry a `user_id`); the onboarding decision moment reuses the already-loaded session for free.
- `log_query()` threads `cohort` onto the row (flush-only, no `db.commit()`); untagged users still log with `cohort=None` and never crash.

### #4.2 — `GET /charts/decision-adoption` + dashboard chart
- Per ISO week × cohort: interactions, active users, interactions/user, and average độ nét.
- **Aggregate-only** (counts + averages) — no user IDs leave the query; JWT auth + tenant scoping match the other admin charts; cached 30 min.
- Dense per-week backfill (gaps → zeros/None), cohorts with zero interactions skipped, fixed display order (reset → legacy → unattributed).
- React `LineChart` with a metric toggle, per-cohort legend (total interactions), and an insight line highlighting the busiest cohort.

### Consistency / performance / security
- Layer contract respected: classifier is pure, resolver is view-only, service is flush-only, feature-flag reads stay at the handler edge.
- `Decimal` throughout; cohort code fits the `String(16)` column.
- Single grouped SQL query per chart request, served from cache for 30 min.
- Output is aggregate-only, so the admin PII-mask posture is inherently preserved.

### Tests
- 25 unit tests for the cohort tag (classifier, resolver, `log_query`, handler threading).
- 10 unit tests for the chart endpoint (cache key + tenant scoping, cohort splitting, dense backfill, rounding, `avg_clarity` None, zero-cohort skipping, cache short-circuit, no-PII shape).
- Full touched-area suite green (347 passed); `ruff check` clean on all changed files.

Close #989

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suj5ENcPR7DooNU7GowadB