### PR TITLE
fix(4.6-e4): tenant-scope decision-adoption chart + độ nét per active user

### DIFF
--- a/backend/api/admin/analytics.py
+++ b/backend/api/admin/analytics.py
@@ -397,17 +397,38 @@ async def decision_adoption(
 
     week_col = cast(func.date_trunc("week", func.timezone("Asia/Ho_Chi_Minh", DecisionQueryLog.created_at)), Date)
     cohort_col = func.coalesce(DecisionQueryLog.cohort, COHORT_UNATTRIBUTED)
+    # Per-user rollup first so độ nét is averaged over *active users* (G2), not
+    # over raw interactions — a chatty user must not skew the cohort's độ nét.
+    # Join ``users`` and scope by ``users.tenant_id`` like the other user-facing
+    # charts: ``decision_query_logs`` has no tenant column, so filtering it alone
+    # would leak other tenants' rows.
+    per_user = (
+        select(
+            week_col.label("week"),
+            cohort_col.label("cohort"),
+            DecisionQueryLog.user_id.label("user_id"),
+            func.count().label("user_interactions"),
+            func.avg(DecisionQueryLog.clarity_score).label("user_clarity"),
+        )
+        .join(User, User.id == DecisionQueryLog.user_id)
+        .where(
+            User.deleted_at.is_(None),
+            _tenant_filter(User, tenant_id),
+            DecisionQueryLog.created_at >= start_dt,
+        )
+        .group_by(week_col, cohort_col, DecisionQueryLog.user_id)
+        .subquery()
+    )
     rows = (
         await db.execute(
             select(
-                week_col.label("week"),
-                cohort_col.label("cohort"),
-                func.count().label("interactions"),
-                func.count(func.distinct(DecisionQueryLog.user_id)).label("active_users"),
-                func.avg(DecisionQueryLog.clarity_score).label("avg_clarity"),
+                per_user.c.week.label("week"),
+                per_user.c.cohort.label("cohort"),
+                func.sum(per_user.c.user_interactions).label("interactions"),
+                func.count().label("active_users"),
+                func.avg(per_user.c.user_clarity).label("avg_clarity"),
             )
-            .where(_tenant_filter(DecisionQueryLog, tenant_id), DecisionQueryLog.created_at >= start_dt)
-            .group_by(week_col, cohort_col)
+            .group_by(per_user.c.week, per_user.c.cohort)
         )
     ).all()
 

--- a/backend/tests/test_admin_analytics_decision_adoption.py
+++ b/backend/tests/test_admin_analytics_decision_adoption.py
@@ -23,7 +23,7 @@ import pytest
 from backend.api.admin import analytics as admin_analytics
 from backend.api.admin.analytics import VN_TZ, COHORT_UNATTRIBUTED
 from backend.models.admin_user import AdminUser
-from backend.models.decision_query_log import DecisionQueryLog
+from backend.models.user import User
 
 
 class _Row:
@@ -90,25 +90,45 @@ def cache_spy(monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# tenant scoping — decision_query_logs has no tenant_id column
+# tenant scoping — decision_query_logs has no tenant_id column, so the query
+# joins ``users`` and scopes by ``users.tenant_id`` (no cross-tenant leak).
 # --------------------------------------------------------------------------
 
 
-def test_tenant_filter_falls_back_to_default_tenant_only():
-    # No tenant_id column → default tenant sees everything, others see nothing.
-    assert str(admin_analytics._tenant_filter(DecisionQueryLog, 1)) == "true"
-    assert str(admin_analytics._tenant_filter(DecisionQueryLog, 2)) == "false"
+def test_user_tenant_filter_scopes_by_users_column():
+    # decision_query_logs has no tenant_id, so scoping rides on users.tenant_id;
+    # every tenant (default or not) gets a real column predicate, not true/false.
+    assert str(admin_analytics._tenant_filter(User, 1)).startswith("users.tenant_id")
+    assert str(admin_analytics._tenant_filter(User, 2)).startswith("users.tenant_id")
 
 
 @pytest.mark.asyncio
-async def test_non_default_tenant_query_is_scoped_to_false(cache_spy):
+async def test_query_scopes_via_users_tenant_column(cache_spy):
     _, _, _ = cache_spy
     db = _FakeDB([_RowsResult([])])
 
     await admin_analytics.decision_adoption(weeks=4, admin=_admin(2), db=db)
 
-    # The where-clause carries the false() guard for a non-default tenant.
-    assert "false" in str(db.statements[0])
+    # The join+where scopes by users.tenant_id, not a decision_query_logs guard.
+    compiled = str(db.statements[0])
+    assert "users.tenant_id" in compiled
+    assert "users.deleted_at" in compiled
+
+
+@pytest.mark.asyncio
+async def test_clarity_is_averaged_per_active_user_not_per_interaction(cache_spy):
+    """độ nét (G2) is a per-active-user average, so the query rolls up by
+    user_id first (inner group-by) then averages those per-user means — a chatty
+    user cannot skew the cohort's độ nét by sheer interaction count."""
+    _, _, _ = cache_spy
+    db = _FakeDB([_RowsResult([])])
+
+    await admin_analytics.decision_adoption(weeks=4, admin=_admin(1), db=db)
+
+    compiled = str(db.statements[0])
+    # A nested subquery grouped by user_id feeds the outer per-cohort average.
+    assert "decision_query_logs.user_id" in compiled
+    assert "GROUP BY" in compiled.upper()
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Close #991

Post-merge review of #990 (E4 / #4.2 — the decision-adoption admin chart) surfaced two defects. Both are contained corrections; the chart's JSON response shape is **unchanged**, so the frontend and the downstream dense-backfill/labeling logic are untouched.

## 1. Cross-tenant leak (security)
The query filtered `decision_query_logs` via `_tenant_filter(DecisionQueryLog, tenant_id)`, but that table has **no `tenant_id` column** — so the helper fell back to `true()`/`false()` with no user-scoped isolation (the default tenant would see every tenant's rows). Now the query **joins `users`** on `DecisionQueryLog.user_id` and scopes on `users.tenant_id` + `users.deleted_at IS NULL`, exactly like `user_tiers` / `cohort_retention`.

## 2. độ nét averaged per interaction, not per active user (correctness)
Gate **G2** (`strategy.md`) defines độ nét as the **average over active users**, but the chart computed `AVG(clarity_score)` over raw interaction rows, letting a chatty user skew the cohort mean. Now an inner subquery rolls up per `(week, cohort, user_id)` — per-user mean clarity + per-user interaction count — and the outer per-cohort aggregate `SUM`s interactions, `COUNT`s active users, and `AVG`s the per-user means.

## Tests
- Rewrote the two tenant-scoping tests for the `users.tenant_id` join reality (`users` is joined; every tenant now gets a real column predicate, not `true()`/`false()`).
- Added a test asserting độ nét rolls up by `user_id` before the per-cohort average.
- `PYTHONPATH=. pytest backend/tests/test_admin_analytics_decision_adoption.py` → 11 passed; `ruff check` clean on both changed files.

## Deliberately out of scope
Two larger, dimension-adding review points need product scoping first and are **not** in this PR:
- Adoption **denominator** = product-active / first-week users (G1).
- **D28-by-cohort** retention series (G2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suj5ENcPR7DooNU7GowadB