### PR TITLE
feat(4.6-e4): D28 retention theo cohort (reset vs legacy)

### DIFF
--- a/backend/api/admin/analytics.py
+++ b/backend/api/admin/analytics.py
@@ -17,12 +17,14 @@ from backend.models.cost_budget import LLMCostLog
 from backend.models.decision_query_log import DecisionQueryLog
 from backend.models.event import Event
 from backend.models.feature_event import FeatureEvent
+from backend.models.onboarding_session import OnboardingSession, cohort_for_goal
 from backend.models.portfolio_asset import PortfolioAsset
 from backend.models.user import User
 from backend.schemas.admin import (
     CohortRetentionResponse,
     DauChartResponse,
     DecisionAdoptionResponse,
+    DecisionRetentionResponse,
     FeatureClicksResponse,
     IntentBreakdownResponse,
     OverviewStatsResponse,
@@ -58,6 +60,9 @@ DECISION_COHORT_LABELS = {
     "legacy": "Cohort cũ (legacy)",
     COHORT_UNATTRIBUTED: "Chưa gắn cohort",
 }
+# D28 retention ≈ four weeks after signup, so it lives at week-offset 4 (w4) of a
+# cohort's retention curve. Feeds gate G2 (D28 ≥ 25%).
+D28_OFFSET = 4
 DEFAULT_TENANT_ID = 1
 
 
@@ -467,4 +472,121 @@ async def decision_adoption(
 
     response = {"weeks": week_list, "cohorts": cohorts}
     await cache_set(key, response, 1800)
+    return response
+
+
+@router.get("/charts/decision-retention", response_model=DecisionRetentionResponse)
+async def decision_retention(
+    weeks: int = Query(default=8, ge=1, le=26),
+    admin: AdminUser = Depends(get_current_admin),
+    db: AsyncSession = Depends(get_db),
+) -> dict:
+    """Signup→week-N retention, split by onboarding cohort — headline D28 (G2).
+
+    Complements ``decision-adoption`` (which is anchored on the calendar week of
+    each interaction) with a classic retention curve anchored on each user's
+    *signup week*, bucketed by their onboarding cohort (``reset`` first-life vs
+    ``legacy`` asset-management vs ``unattributed``). Retention at offset *k* is
+    the share of that cohort's users who were old enough to reach week *k* and
+    had any activity in it — so the denominator (``eligible``) shrinks for later
+    offsets rather than diluting them with users who have not had the time yet.
+    ``d28`` mirrors offset 4 (≈28 days), the metric behind gate G2 (≥25%).
+
+    Activity reuses ``events`` (same signal as ``cohort-retention``); tenant
+    isolation rides on ``users.tenant_id`` and the payload is aggregate-only
+    (cohort sizes + percentages), so no PII ever leaves the query.
+    """
+    tenant_id = _admin_tenant_id(admin)
+    key = f"admin:tenant:{tenant_id}:charts:decision-retention:{weeks}"
+    cached = await cache_get(key)
+    if cached is not None:
+        return cached
+
+    today = datetime.now(VN_TZ).date()
+    current_week = today - timedelta(days=today.weekday())
+    first_week = current_week - timedelta(weeks=weeks - 1)
+    start_dt = datetime.combine(first_week, time.min, tzinfo=VN_TZ).astimezone(timezone.utc)
+
+    # Each user's signup week + onboarding cohort (left join keeps users who
+    # never opened an onboarding session — they fall to ``unattributed``).
+    signup_week_col = cast(func.date_trunc("week", func.timezone("Asia/Ho_Chi_Minh", User.created_at)), Date)
+    user_rows = (
+        await db.execute(
+            select(User.id, signup_week_col.label("signup_week"), OnboardingSession.goal_choice)
+            .outerjoin(OnboardingSession, OnboardingSession.user_id == User.id)
+            .where(
+                User.deleted_at.is_(None),
+                _tenant_filter(User, tenant_id),
+                User.created_at >= start_dt,
+            )
+        )
+    ).all()
+
+    user_signup: dict = {}
+    user_cohort: dict = {}
+    cohort_users: dict[str, set] = defaultdict(set)
+    for uid, signup_week, goal_choice in user_rows:
+        cohort = cohort_for_goal(goal_choice) or COHORT_UNATTRIBUTED
+        user_signup[uid] = signup_week
+        user_cohort[uid] = cohort
+        cohort_users[cohort].add(uid)
+
+    activity_expr = cast(func.date_trunc("week", func.timezone("Asia/Ho_Chi_Minh", Event.timestamp)), Date)
+    if user_signup:
+        activity_rows = (
+            await db.execute(
+                select(Event.user_id, activity_expr.label("active_week"))
+                .where(
+                    Event.user_id.in_(list(user_signup.keys())),
+                    _tenant_filter(Event, tenant_id),
+                    Event.timestamp >= start_dt,
+                )
+                .distinct()
+            )
+        ).all()
+    else:
+        activity_rows = []
+
+    # (cohort, offset) -> users active at that offset from their own signup week.
+    retained: dict[tuple[str, int], set] = defaultdict(set)
+    for uid, active_week in activity_rows:
+        signup_week = user_signup.get(uid)
+        if signup_week is None or active_week < signup_week:
+            continue
+        offset = int((active_week - signup_week).days / 7)
+        if offset < weeks:
+            retained[(user_cohort[uid], offset)].add(uid)
+
+    cohorts = []
+    for cohort, label in DECISION_COHORT_LABELS.items():
+        members = cohort_users.get(cohort)
+        if not members:
+            continue  # skip a cohort with no users in the window
+        # A user is eligible for offset k once k weeks have elapsed since signup.
+        max_elapsed = {uid: int((current_week - user_signup[uid]).days / 7) for uid in members}
+        retention: dict[str, int | None] = {}
+        eligible: dict[str, int] = {}
+        for offset in range(weeks):
+            key_name = f"w{offset}"
+            eligible_count = sum(1 for uid in members if max_elapsed[uid] >= offset)
+            eligible[key_name] = eligible_count
+            if eligible_count == 0:
+                retention[key_name] = None
+            elif offset == 0:
+                retention[key_name] = 100
+            else:
+                retention[key_name] = round((len(retained[(cohort, offset)]) / eligible_count) * 100)
+        cohorts.append(
+            {
+                "cohort": cohort,
+                "label": label,
+                "cohort_size": len(members),
+                "retention": retention,
+                "eligible": eligible,
+                "d28": retention.get(f"w{D28_OFFSET}"),
+            }
+        )
+
+    response = {"weeks": weeks, "cohorts": cohorts}
+    await cache_set(key, response, 86400)
     return response

--- a/backend/schemas/admin.py
+++ b/backend/schemas/admin.py
@@ -186,6 +186,25 @@ class DecisionAdoptionResponse(BaseModel):
     cohorts: list[DecisionAdoptionCohort]
 
 
+class DecisionRetentionCohort(BaseModel):
+    cohort: str
+    label: str
+    cohort_size: int
+    # w0..wN → % of *eligible* users (old enough to reach the offset) who were
+    # active that week. ``None`` where the window has no eligible users yet.
+    retention: dict[str, int | None]
+    # w0..wN → the denominator behind each retention %, so D28 is auditable.
+    eligible: dict[str, int]
+    # Convenience mirror of ``retention["w4"]`` (≈28 days); ``None`` if the
+    # requested window is shorter than five weeks or no user is old enough.
+    d28: int | None = None
+
+
+class DecisionRetentionResponse(BaseModel):
+    weeks: int
+    cohorts: list[DecisionRetentionCohort]
+
+
 class LicenseSummaryBucket(BaseModel):
     key: str
     count: int

--- a/backend/tests/test_admin_analytics_decision_retention.py
+++ b/backend/tests/test_admin_analytics_decision_retention.py
@@ -1,0 +1,270 @@
+"""Phase 4.6 / E4 / Issue #4.2 — the decision-retention admin chart.
+
+``GET /charts/decision-retention`` reads ``users`` (left-joined to
+``onboarding_sessions`` for the cohort goal) plus ``events`` and reports a
+classic signup→week-N retention curve per onboarding cohort (reset / legacy /
+unattributed), headlined by D28 (offset 4, ≈28 days) — the metric behind gate
+G2. The endpoint is DB-free under test: a ``_FakeDB`` replays the two queries
+(users, then activity) and ``cache_get`` / ``cache_set`` are monkeypatched.
+
+Coverage: cache key + tenant scoping via ``users.tenant_id``, cohort bucketing
+from ``goal_choice`` (reset / legacy / unattributed), the shrinking ``eligible``
+denominator for later offsets, D28 (w4) computation, ``None`` where no user is
+old enough, the cohort-skip + label order, the cache-hit short-circuit, and the
+aggregate-only (no-PII) shape of the payload.
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import pytest
+
+from backend.api.admin import analytics as admin_analytics
+from backend.api.admin.analytics import VN_TZ, COHORT_UNATTRIBUTED
+from backend.models.admin_user import AdminUser
+from backend.models.user import User
+
+
+class _Row:
+    def __init__(self, **values):
+        self.__dict__.update(values)
+        self._values = list(values.values())
+
+    def __getitem__(self, index: int):
+        return self._values[index]
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _FakeDB:
+    def __init__(self, results):
+        self.results = list(results)
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return self.results.pop(0)
+
+
+def _admin(tenant_id: int | None = 1) -> AdminUser:
+    return AdminUser(
+        id=1,
+        email="admin@example.com",
+        password_hash="hash",
+        role="super_admin",
+        tenant_id=tenant_id,
+        is_active=True,
+    )
+
+
+def _current_week() -> date:
+    """Monday of the current VN week — mirrors the endpoint's bucketing."""
+    today = datetime.now(VN_TZ).date()
+    return today - timedelta(days=today.weekday())
+
+
+@pytest.fixture
+def cache_spy(monkeypatch):
+    """Monkeypatch the cache; return (get_keys, set_calls, seed)."""
+    get_keys: list[str] = []
+    set_calls: list[tuple] = []
+    seeded: dict[str, object] = {}
+
+    async def fake_cache_get(key):
+        get_keys.append(key)
+        return seeded.get(key)
+
+    async def fake_cache_set(key, value, ttl):
+        set_calls.append((key, value, ttl))
+
+    monkeypatch.setattr(admin_analytics, "cache_get", fake_cache_get)
+    monkeypatch.setattr(admin_analytics, "cache_set", fake_cache_set)
+    return get_keys, set_calls, seeded
+
+
+def _cohort(response, name):
+    return next(c for c in response["cohorts"] if c["cohort"] == name)
+
+
+# --------------------------------------------------------------------------
+# tenant scoping — users has tenant_id, so the query scopes by users.tenant_id
+# and left-joins onboarding_sessions for the cohort goal (no cross-tenant leak).
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_scopes_via_users_tenant_column(cache_spy):
+    db = _FakeDB([_RowsResult([])])  # no users → activity query is skipped
+
+    await admin_analytics.decision_retention(weeks=8, admin=_admin(2), db=db)
+
+    compiled = str(db.statements[0])
+    assert "users.tenant_id" in compiled
+    assert "users.deleted_at" in compiled
+    assert "onboarding_sessions" in compiled  # left join carries the cohort goal
+
+
+# --------------------------------------------------------------------------
+# happy path — cohort bucketing, shrinking eligible denominator, D28
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_buckets_cohorts_and_computes_d28(cache_spy):
+    get_keys, set_calls, _ = cache_spy
+    w = _current_week()
+    signup_4wk = w - timedelta(weeks=4)  # max_elapsed == 4 → eligible through w4
+
+    users = _RowsResult([
+        _Row(id="A", signup_week=signup_4wk, goal_choice="emergency_fund"),  # reset
+        _Row(id="B", signup_week=signup_4wk, goal_choice="first_home"),      # reset
+        _Row(id="C", signup_week=w, goal_choice="understand_wealth"),        # legacy (too new)
+        _Row(id="D", signup_week=signup_4wk, goal_choice=None),              # unattributed
+    ])
+    activity = _RowsResult([
+        _Row(user_id="A", active_week=signup_4wk),  # w0
+        _Row(user_id="A", active_week=w),           # w4 — A is D28-retained
+        _Row(user_id="B", active_week=signup_4wk),  # w0 only — B drops before w4
+        _Row(user_id="C", active_week=w),           # w0
+        _Row(user_id="D", active_week=signup_4wk),  # w0 only
+    ])
+    db = _FakeDB([users, activity])
+
+    response = await admin_analytics.decision_retention(weeks=8, admin=_admin(1), db=db)
+
+    assert get_keys == ["admin:tenant:1:charts:decision-retention:8"]
+    assert set_calls[0][0] == "admin:tenant:1:charts:decision-retention:8"
+    assert set_calls[0][2] == 86400
+    assert response["weeks"] == 8
+
+    reset = _cohort(response, "reset")
+    assert reset["label"] == "Segment mới (reset)"
+    assert reset["cohort_size"] == 2
+    # Both reset users are old enough for w0..w4; nobody is old enough for w5+.
+    assert reset["eligible"]["w4"] == 2
+    assert reset["eligible"]["w5"] == 0
+    assert reset["retention"]["w0"] == 100
+    assert reset["retention"]["w1"] == 0  # nobody active at offset 1
+    assert reset["retention"]["w4"] == 50  # A retained, B not → 1/2
+    assert reset["retention"]["w5"] is None  # no eligible user yet
+    assert reset["d28"] == 50
+
+    legacy = _cohort(response, "legacy")
+    assert legacy["cohort_size"] == 1
+    assert legacy["eligible"]["w4"] == 0  # C signed up this week
+    assert legacy["retention"]["w0"] == 100
+    assert legacy["retention"]["w4"] is None
+    assert legacy["d28"] is None
+
+    unattributed = _cohort(response, COHORT_UNATTRIBUTED)
+    assert unattributed["label"] == "Chưa gắn cohort"
+    assert unattributed["cohort_size"] == 1
+    assert unattributed["eligible"]["w4"] == 1
+    assert unattributed["retention"]["w4"] == 0  # D never returned
+    assert unattributed["d28"] == 0
+
+
+@pytest.mark.asyncio
+async def test_cohorts_keep_label_order(cache_spy):
+    w = _current_week()
+    old = w - timedelta(weeks=4)
+    users = _RowsResult([
+        # deliberately out of label order — output order comes from the map.
+        _Row(id="D", signup_week=old, goal_choice=None),
+        _Row(id="C", signup_week=old, goal_choice="track_spending"),
+        _Row(id="A", signup_week=old, goal_choice="wedding"),
+    ])
+    activity = _RowsResult([])
+    db = _FakeDB([users, activity])
+
+    response = await admin_analytics.decision_retention(weeks=8, admin=_admin(1), db=db)
+
+    assert [c["cohort"] for c in response["cohorts"]] == ["reset", "legacy", COHORT_UNATTRIBUTED]
+
+
+@pytest.mark.asyncio
+async def test_cohort_with_no_users_is_skipped(cache_spy):
+    w = _current_week()
+    users = _RowsResult([
+        _Row(id="A", signup_week=w - timedelta(weeks=4), goal_choice="first_home"),
+    ])
+    activity = _RowsResult([_Row(user_id="A", active_week=w - timedelta(weeks=4))])
+    db = _FakeDB([users, activity])
+
+    response = await admin_analytics.decision_retention(weeks=8, admin=_admin(1), db=db)
+
+    assert [c["cohort"] for c in response["cohorts"]] == ["reset"]
+
+
+# --------------------------------------------------------------------------
+# short window, empty window, cache short-circuit, PII shape
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_d28_is_none_when_window_shorter_than_five_weeks(cache_spy):
+    w = _current_week()
+    users = _RowsResult([
+        _Row(id="A", signup_week=w - timedelta(weeks=3), goal_choice="wedding"),
+    ])
+    activity = _RowsResult([_Row(user_id="A", active_week=w - timedelta(weeks=3))])
+    db = _FakeDB([users, activity])
+
+    response = await admin_analytics.decision_retention(weeks=4, admin=_admin(1), db=db)
+
+    reset = _cohort(response, "reset")
+    assert "w4" not in reset["retention"]  # window stops at w3
+    assert reset["d28"] is None
+
+
+@pytest.mark.asyncio
+async def test_empty_window_skips_activity_query(cache_spy):
+    db = _FakeDB([_RowsResult([])])  # only the users query runs
+
+    response = await admin_analytics.decision_retention(weeks=6, admin=_admin(1), db=db)
+
+    assert response == {"weeks": 6, "cohorts": []}
+    assert len(db.statements) == 1  # activity query short-circuited
+
+
+@pytest.mark.asyncio
+async def test_cache_hit_short_circuits_the_query(cache_spy):
+    get_keys, set_calls, seeded = cache_spy
+    key = "admin:tenant:1:charts:decision-retention:8"
+    seeded[key] = {"weeks": 8, "cohorts": [], "cached": True}
+    db = _FakeDB([])  # would IndexError if execute() were called
+
+    response = await admin_analytics.decision_retention(weeks=8, admin=_admin(1), db=db)
+
+    assert response == {"weeks": 8, "cohorts": [], "cached": True}
+    assert get_keys == [key]
+    assert set_calls == []
+    assert db.statements == []
+
+
+@pytest.mark.asyncio
+async def test_payload_is_aggregate_only_no_user_ids(cache_spy):
+    w = _current_week()
+    users = _RowsResult([
+        _Row(id="A", signup_week=w - timedelta(weeks=4), goal_choice="emergency_fund"),
+    ])
+    activity = _RowsResult([_Row(user_id="A", active_week=w - timedelta(weeks=4))])
+    db = _FakeDB([users, activity])
+
+    response = await admin_analytics.decision_retention(weeks=8, admin=_admin(1), db=db)
+
+    cohort_keys = set(response["cohorts"][0].keys())
+    assert cohort_keys == {"cohort", "label", "cohort_size", "retention", "eligible", "d28"}
+    assert not any("user_id" in k or "phone" in k or "email" in k for k in cohort_keys)
+
+
+def test_tenant_filter_scopes_by_users_column():
+    assert str(admin_analytics._tenant_filter(User, 1)).startswith("users.tenant_id")
+    assert str(admin_analytics._tenant_filter(User, 2)).startswith("users.tenant_id")

--- a/betien-admin/src/api/adminDashboard.js
+++ b/betien-admin/src/api/adminDashboard.js
@@ -38,6 +38,10 @@ export function getDecisionAdoption(weeks = 8) {
   return apiFetch(buildAdminDashboardPath('/charts/decision-adoption', { weeks }));
 }
 
+export function getDecisionRetention(weeks = 8) {
+  return apiFetch(buildAdminDashboardPath('/charts/decision-retention', { weeks }));
+}
+
 export function getLicenseSummary() {
   return apiFetch('/licenses/summary');
 }

--- a/betien-admin/src/pages/DashboardPage.jsx
+++ b/betien-admin/src/pages/DashboardPage.jsx
@@ -44,6 +44,7 @@ import {
   changeUserStatus,
   getCohortRetention,
   getDecisionAdoption,
+  getDecisionRetention,
   getDau,
   getFeatureClicks,
   getIntentBreakdown,
@@ -108,6 +109,7 @@ function DashboardContent() {
   const [userTiers, setUserTiers] = useState([]);
   const [cohorts, setCohorts] = useState([]);
   const [decisionAdoption, setDecisionAdoption] = useState({ weeks: [], cohorts: [] });
+  const [decisionRetention, setDecisionRetention] = useState({ weeks: 8, cohorts: [] });
   const [licenseSummary, setLicenseSummary] = useState(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState('');
@@ -119,7 +121,7 @@ function DashboardContent() {
       setError('');
       try {
         const days = selectedRange.days;
-        const [overviewPayload, growthPayload, dauPayload, clicksPayload, intentPayload, tiersPayload, cohortPayload, decisionPayload, licensePayload] = await Promise.all([
+        const [overviewPayload, growthPayload, dauPayload, clicksPayload, intentPayload, tiersPayload, cohortPayload, decisionPayload, retentionPayload, licensePayload] = await Promise.all([
           getOverview(range),
           getUserGrowth(days),
           getDau(Math.min(days, 90)),
@@ -128,6 +130,7 @@ function DashboardContent() {
           getUserTiers(),
           getCohortRetention(8),
           getDecisionAdoption(8),
+          getDecisionRetention(8),
           getLicenseSummary(),
         ]);
         if (!alive) return;
@@ -139,6 +142,7 @@ function DashboardContent() {
         setUserTiers(tiersPayload.data || []);
         setCohorts(cohortPayload.cohorts || []);
         setDecisionAdoption({ weeks: decisionPayload.weeks || [], cohorts: decisionPayload.cohorts || [] });
+        setDecisionRetention({ weeks: retentionPayload.weeks || 8, cohorts: retentionPayload.cohorts || [] });
         setLicenseSummary(licensePayload);
       } catch (err) {
         if (alive) setError(err.message || 'Không tải được dashboard.');
@@ -171,6 +175,7 @@ function DashboardContent() {
         </section>
         <CohortRetentionTable loading={loading} cohorts={cohorts} />
         <DecisionAdoptionChart loading={loading} weeks={decisionAdoption.weeks} cohorts={decisionAdoption.cohorts} />
+        <DecisionRetentionTable loading={loading} weeks={decisionRetention.weeks} cohorts={decisionRetention.cohorts} />
         <LicenseFoundationCard loading={loading} summary={licenseSummary} />
         <UserDirectory refreshNonce={refreshNonce} />
       </div>
@@ -448,12 +453,20 @@ function CohortRetentionTable({ loading, cohorts }) {
   );
 }
 
-function RetentionCell({ value }) {
+function RetentionCell({ value, subLabel = null, highlight = false }) {
   const presentation = getRetentionCellPresentation(value);
-  if (!presentation) return <td className="rounded-xl bg-paper px-3 py-3" />;
+  const ring = highlight ? 'ring-1 ring-gold' : '';
+  if (!presentation) {
+    return (
+      <td className={`rounded-xl bg-paper px-3 py-3 text-center ${ring}`}>
+        {subLabel ? <span className="font-mono text-[10px] text-ink-400">{subLabel}</span> : null}
+      </td>
+    );
+  }
   return (
-    <td className={`rounded-xl px-3 py-3 text-center font-mono text-xs font-semibold ${presentation.className}`} style={presentation.style}>
-      {presentation.text}
+    <td className={`rounded-xl px-3 py-3 text-center font-mono text-xs font-semibold ${presentation.className} ${ring}`} style={presentation.style}>
+      <span>{presentation.text}</span>
+      {subLabel ? <span className="mt-0.5 block text-[10px] font-normal opacity-70">{subLabel}</span> : null}
     </td>
   );
 }
@@ -533,6 +546,70 @@ function DecisionAdoptionChart({ loading, weeks, cohorts }) {
         {busiest && busiest.total > 0
           ? `${busiest.cohort.label} dẫn đầu về tổng tương tác (${formatNumber(busiest.total)}); theo dõi interactions/user để so sánh mức gắn kết giữa các cohort.`
           : 'Chưa có decision query nào được ghi log để tách cohort.'}
+      </Insight>
+    </MetricShell>
+  );
+}
+
+const D28_KEY = 'w4';
+
+function retentionWeekKeys(weeks) {
+  const count = Math.min(Math.max(Number(weeks) || 0, 0), 26);
+  return Array.from({ length: count }, (_, offset) => `w${offset}`);
+}
+
+function DecisionRetentionTable({ loading, weeks, cohorts }) {
+  const weekKeys = retentionWeekKeys(weeks);
+  const leader = cohorts
+    .filter((cohort) => cohort.d28 !== null && cohort.d28 !== undefined)
+    .sort((a, b) => b.d28 - a.d28)[0];
+  return (
+    <MetricShell eyebrow="Retention" title="D28 theo cohort">
+      <p className="-mt-2 mb-4 text-xs text-ink-500">
+        Retention tính từ tuần user tham gia, tách segment mới (reset) khỏi cohort cũ (legacy). D28 (w4) là chỉ số gate G2 (≥25%); mẫu số là số user đủ thời gian chạm mốc.
+      </p>
+      {loading && cohorts.length === 0 ? (
+        <div className="h-56 animate-pulse rounded-2xl bg-ink-100" />
+      ) : cohorts.length === 0 ? (
+        <EmptyState message="Chưa đủ cohort để tách D28." className="h-48" />
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="min-w-full border-separate border-spacing-1 text-sm">
+            <thead>
+              <tr className="text-left text-[11px] uppercase tracking-[0.16em] text-ink-500">
+                <th className="sticky left-0 bg-porcelain px-3 py-2">Cohort</th>
+                <th className="px-3 py-2 text-right">Users</th>
+                {weekKeys.map((key) => (
+                  <th key={key} className={`px-3 py-2 text-center ${key === D28_KEY ? 'text-gold' : ''}`}>
+                    {key.toUpperCase()}
+                    {key === D28_KEY ? ' · D28' : ''}
+                  </th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {cohorts.map((cohort) => (
+                <tr key={cohort.cohort}>
+                  <td className="sticky left-0 rounded-xl bg-paper px-3 py-3 text-xs font-medium text-ink-900">{cohort.label}</td>
+                  <td className="rounded-xl bg-paper px-3 py-3 text-right font-mono text-xs text-ink-500">{cohort.cohort_size}</td>
+                  {weekKeys.map((key) => (
+                    <RetentionCell
+                      key={key}
+                      value={cohort.retention?.[key]}
+                      subLabel={cohort.eligible?.[key] !== undefined ? `n=${cohort.eligible[key]}` : null}
+                      highlight={key === D28_KEY}
+                    />
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+      <Insight>
+        {leader
+          ? `${leader.label} đang dẫn D28 ở mức ${leader.d28}% — so với gate G2 (≥25%). Mẫu số n= là số user đủ thời gian chạm mốc, nên các tuần sau có thể ít user hơn.`
+          : 'Chưa đủ user chạm mốc D28 để tách cohort — cần thêm thời gian tích luỹ cohort mới.'}
       </Insight>
     </MetricShell>
   );


### PR DESCRIPTION
## Tóm tắt

E4 DoD yêu cầu admin analytics hiển thị **D28 theo cohort, tách segment mới** (`phase-4.6-issues.md:119`), và Strategy G2 đặt mốc **D28 ≥ 25%**. Chart `decision-adoption` hiện chỉ đo interactions/user + độ nét theo tuần lịch — không trả lời được "sau ~28 ngày kể từ đăng ký, bao nhiêu % user còn hoạt động?" và không tách reset khỏi legacy.

PR này thêm một chart retention riêng, neo theo **tuần đăng ký** của user, bucket theo onboarding cohort, headline bằng **D28 (offset w4, ≈28 ngày)**.

## Thay đổi

**Backend**
- Endpoint mới `GET /charts/decision-retention` (read-only, tenant-scope qua `users.tenant_id`, left-join `onboarding_sessions` lấy `goal_choice`).
- Bucket theo cohort: `reset` (Segment mới) / `legacy` (Cohort cũ) / `unattributed` (Chưa gắn cohort), dùng `cohort_for_goal`.
- Classic signup→week-N retention với denominator `eligible` **co lại theo từng offset** — chỉ đếm user đủ tuổi để chạm offset k, nên D28 không bị pha loãng bởi user quá mới. `eligible` được trả ra để con số D28 audit được.
- Schema `DecisionRetentionResponse` / `DecisionRetentionCohort` — aggregate-only, không PII.

**Frontend (admin dashboard)**
- `getDecisionRetention` trong API client + wiring vào `DashboardPage`.
- Bảng "D28 theo cohort" highlight cột D28 (w4) và đối chiếu mốc G2 25%; `RetentionCell` được mở rộng thêm `subLabel`/`highlight` (backward-compatible với `CohortRetentionTable`).

## Vì sao endpoint mới thay vì gộp vào `decision-adoption`

Hai chart có time semantics khác nhau: adoption neo theo tuần lịch/tương tác, retention neo theo tuần đăng ký. Gộp lại sẽ gây nhầm lẫn và lệch với pattern `cohort-retention` (vốn là endpoint riêng).

## Test

- 9 test mới trong `test_admin_analytics_decision_retention.py`: tenant scoping qua `users.tenant_id`, cohort bucketing, `eligible` co lại theo offset, D28 (w4), `None` khi window ngắn hơn 5 tuần, empty-window skip activity query, cache short-circuit, no-PII payload.
- Regression `decision-adoption` (11 test) vẫn xanh; ruff sạch.

## Follow-up

Đã file #994 (HELD): định nghĩa lại "product-active" làm denominator cho retention/DAU — là quyết định sản phẩm, chưa chốt, không implement trong PR này.

Close #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suj5ENcPR7DooNU7GowadB