### PR TITLE
Phase 4.7 E1+E3: spending-drift warnings + guardrail flag infra (dark)

### DIFF
--- a/backend/bot/formatters/tone.py
+++ b/backend/bot/formatters/tone.py
@@ -89,6 +89,16 @@ def render_tone_variant(
     if variant is None:
         return None
 
+    # A tone block whose copy branches on the situation nests one more level:
+    # ``{gentle: {delay: [...], stall: [...], plain: [...]}}``. The caller names
+    # the branch via a ``copy_variant`` context key (e.g. the ``spending_drift``
+    # empathy trigger). A plain list/string block (every other surface) skips
+    # this and behaves exactly as before.
+    if isinstance(variant, dict):
+        variant = variant.get(ctx.get("copy_variant"))
+        if variant is None:
+            return None
+
     template = random.choice(variant) if isinstance(variant, list) else variant
     if not isinstance(template, str) or not template:
         return None

--- a/backend/bot/personality/empathy_engine.py
+++ b/backend/bot/personality/empathy_engine.py
@@ -45,6 +45,7 @@ from backend.models.event import Event
 from backend.models.expense import Expense
 from backend.models.twin_view_event import TwinViewEvent
 from backend.models.user import User
+from backend.services.decision import drift_service
 from backend.services.onboarding.onboarding_service import salutation_of
 
 logger = logging.getLogger(__name__)
@@ -126,6 +127,13 @@ _NON_ACTIVATION_EVENT_TYPES = frozenset(
     }
 )
 
+# Phase 4.7 Epic 1 — spending-drift warning cooldown. A drift is a slow,
+# month-scale signal (baseline is a 3-window median), so a fortnight between
+# nudges is long enough not to nag yet short enough to catch a pace that keeps
+# climbing. Longer than the acute ``large_transaction`` (1 day) and the
+# ``never_activated`` (3 days) triggers, matching ``user_silent_7_days``.
+SPENDING_DRIFT_COOLDOWN_DAYS = 14
+
 
 @dataclass(frozen=True)
 class EmpathyTrigger:
@@ -143,6 +151,7 @@ async def check_all_triggers(
     now: datetime | None = None,
     include_proactive: bool = True,
     include_activation_nudge: bool = False,
+    include_drift: bool = False,
 ) -> Optional[EmpathyTrigger]:
     """Walk checks in priority order. Return first trigger not on cooldown.
 
@@ -150,11 +159,12 @@ async def check_all_triggers(
 
     ``include_proactive`` gates the Phase 4.4 proactive-companion trigger
     (``onboarding_no_twin_return``). ``include_activation_nudge`` gates the
-    Phase 4.6 first-message trigger (``never_activated``). The engine never
-    reads env itself — the hourly job reads ``PROACTIVE_COMPANION_ENABLED`` /
-    ``ACTIVATION_NUDGE_ENABLED`` and passes the decisions in, per the layer
-    contract. When a flag is ``False`` its trigger is skipped while every
-    pre-existing empathy trigger still fires.
+    Phase 4.6 first-message trigger (``never_activated``). ``include_drift``
+    gates the Phase 4.7 spending-drift trigger (``spending_drift``). The engine
+    never reads env itself — the hourly job reads ``PROACTIVE_COMPANION_ENABLED``
+    / ``ACTIVATION_NUDGE_ENABLED`` / ``DRIFT_WARNING_ENABLED`` and passes the
+    decisions in, per the layer contract. When a flag is ``False`` its trigger
+    is skipped while every pre-existing empathy trigger still fires.
     """
     now = now or datetime.now(timezone.utc)
 
@@ -166,6 +176,12 @@ async def check_all_triggers(
         _check_payday_splurge,
         _check_over_budget_monthly,
     ]
+    # A drift warning carries a concrete goal consequence, so it outranks the
+    # ambient "come back" / silent-N-days nudges — but it stays below the acute
+    # single-transaction signals above. Gated dark until the G1 gate + owner
+    # sign-off (``DRIFT_WARNING_ENABLED``).
+    if include_drift:
+        checks.append(_check_spending_drift)
     if include_proactive:
         checks.append(_check_onboarding_no_twin_return)
     # The activation nudge owns the early window (1–7 days after opening the
@@ -259,6 +275,46 @@ async def _check_over_budget_monthly(
 ) -> EmpathyTrigger | None:
     """STUB — needs per-user budget config (not yet modeled)."""
     return None
+
+
+async def _check_spending_drift(
+    db: AsyncSession, user: User, now: datetime
+) -> EmpathyTrigger | None:
+    """Current-window spend has drifted above the user's own recent baseline.
+
+    Delegates the whole assessment — baseline median, dual threshold, and the
+    Twin consequence — to ``drift_service.compute_drift`` (pure ``assess`` under
+    a read-only gatherer). We fire only when it reports ``is_drifting``; the
+    context carries a ``copy_variant`` so the copy renders the right shape:
+
+    - ``delay``  — a goal slips a concrete number of months,
+    - ``stall``  — the drift would erase the whole saving rate (goal stalls),
+    - ``plain``  — drifting but no goal consequence to attach.
+
+    The engine reads no env; ``DRIFT_WARNING_ENABLED`` is gated at the job edge
+    and threaded in via ``include_drift``.
+    """
+    assessment = await drift_service.compute_drift(db, user, now=now)
+    if assessment is None or not assessment.is_drifting:
+        return None
+
+    context: dict = {"drift": format_money_full(assessment.drift_amount)}
+    if assessment.pace_unsustainable and assessment.goal_label:
+        context["copy_variant"] = "stall"
+        context["goal_label"] = assessment.goal_label
+    elif assessment.goal_delay_months and assessment.goal_label:
+        context["copy_variant"] = "delay"
+        context["goal_label"] = assessment.goal_label
+        context["goal_delay_months"] = assessment.goal_delay_months
+    else:
+        context["copy_variant"] = "plain"
+
+    return EmpathyTrigger(
+        name="spending_drift",
+        priority=3,
+        cooldown_days=SPENDING_DRIFT_COOLDOWN_DAYS,
+        context=context,
+    )
 
 
 async def _check_onboarding_no_twin_return(
@@ -629,18 +685,23 @@ def render_message(
     if variant is not None:
         return variant
 
-    spec = _load_messages().get(trigger.name) or {}
-    templates = spec.get("messages") or []
-    if not templates:
-        logger.warning("No empathy template for trigger %s", trigger.name)
-        return ""
-
-    template = random.choice(templates)
     context = {
         "name": user.get_greeting_name(),
         "salutation": salutation,
         **trigger.context,
     }
+    spec = _load_messages().get(trigger.name) or {}
+    templates = spec.get("messages") or []
+    # A trigger whose copy branches on the situation (e.g. ``spending_drift``:
+    # delay / stall / plain) stores ``messages`` as a dict keyed by the
+    # ``copy_variant`` the trigger put in its context, instead of a flat list.
+    if isinstance(templates, dict):
+        templates = templates.get(context.get("copy_variant")) or []
+    if not templates:
+        logger.warning("No empathy template for trigger %s", trigger.name)
+        return ""
+
+    template = random.choice(templates)
     try:
         return template.format(**context)
     except KeyError as exc:

--- a/backend/bot/personality/empathy_engine.py
+++ b/backend/bot/personality/empathy_engine.py
@@ -26,6 +26,7 @@ Design choices
 """
 from __future__ import annotations
 
+import html
 import logging
 import random
 import uuid
@@ -298,13 +299,19 @@ async def _check_spending_drift(
     if assessment is None or not assessment.is_drifting:
         return None
 
+    # ``_process_user`` sends drift messages with ``parse_mode="HTML"``, so a
+    # user-authored goal name containing ``<``, ``>`` or ``&`` would otherwise
+    # break Telegram's HTML parse (or inject markup). Escape it once here,
+    # before it enters the render context.
+    goal_label = html.escape(assessment.goal_label) if assessment.goal_label else None
+
     context: dict = {"drift": format_money_full(assessment.drift_amount)}
-    if assessment.pace_unsustainable and assessment.goal_label:
+    if assessment.pace_unsustainable and goal_label:
         context["copy_variant"] = "stall"
-        context["goal_label"] = assessment.goal_label
-    elif assessment.goal_delay_months and assessment.goal_label:
+        context["goal_label"] = goal_label
+    elif assessment.goal_delay_months and goal_label:
         context["copy_variant"] = "delay"
-        context["goal_label"] = assessment.goal_label
+        context["goal_label"] = goal_label
         context["goal_delay_months"] = assessment.goal_delay_months
     else:
         context["copy_variant"] = "plain"

--- a/backend/intent/handlers/decision_flags.py
+++ b/backend/intent/handlers/decision_flags.py
@@ -1,9 +1,17 @@
-"""Feature flags for Phase 4.5 Decision Engine surfaces.
+"""Feature flags for Phase 4.5 Decision Engine + Phase 4.7 Guardian surfaces.
 
 These helpers are read at the handler / API-router / worker edge only — never
 inside a service (layer contract §"Service NEVER reads env"). Each Decision
 Engine capability ships dark so the operator can flip it on per-surface once
 validated in prod. Same pattern as ``onboarding_v2.is_v2_enabled``.
+
+Kill-switch note (Phase 4.7 §8, ``SCAM_CHECK_ENABLED``): the flag is read at the
+handler edge on every request, but ``os.environ`` only changes on process
+restart. To disable a Guardian surface in <24h *without* a code deploy, the
+operator sets the env var and restarts the service (``scripts/rebuild-finance-prod.sh``
+/ launchd reload) — see the §8 runbook in ``phase-4.7-detailed.md``. A
+DB/config runtime toggle is deferred to a later phase unless §8 one-strike
+demands instant-off.
 """
 
 from __future__ import annotations
@@ -79,3 +87,32 @@ def is_activation_nudge_enabled() -> bool:
     ``activation_first_reply`` funnel stamp, so behaviour is byte-identical to
     pre-4.6. Read at the job / worker edge only (layer contract)."""
     return _enabled(ACTIVATION_NUDGE_ENABLED_ENV, default=False)
+
+
+DRIFT_WARNING_ENABLED_ENV = "DRIFT_WARNING_ENABLED"
+
+
+def is_drift_warning_enabled() -> bool:
+    """Drift / overspend warnings — Phase 4.7 Epic 1. OFF by default (gated on
+    the G1 decision-adoption gate + owner sign-off). When dark the hourly
+    empathy job skips the ``spending_drift`` trigger while every pre-existing
+    empathy trigger still fires, so behaviour is byte-identical to pre-4.7.
+    Read at the job edge only — the empathy engine never reads env (layer
+    contract)."""
+    return _enabled(DRIFT_WARNING_ENABLED_ENV, default=False)
+
+
+SCAM_CHECK_ENABLED_ENV = "SCAM_CHECK_ENABLED"
+
+
+def is_scam_check_enabled() -> bool:
+    """Scam check v1 — Phase 4.7 Epic 2 (red line). OFF by default; flip is
+    gated on legal sign-off of the red-flags wording + disclaimer. When dark a
+    "kèo này có nên không?" question delegates to the generic advisory handler
+    (byte-identical pre-4.7), never ``out_of_scope``.
+
+    This flag is the §8 kill switch: on a harmful-output report the operator
+    sets ``SCAM_CHECK_ENABLED=false`` and restarts the service to take the
+    surface offline in <24h without a code deploy (see module docstring +
+    ``phase-4.7-detailed.md`` §8 runbook). Read at the handler edge only."""
+    return _enabled(SCAM_CHECK_ENABLED_ENV, default=False)

--- a/backend/jobs/check_empathy_triggers.py
+++ b/backend/jobs/check_empathy_triggers.py
@@ -34,6 +34,7 @@ from backend.bot.personality import empathy_engine
 from backend.database import get_session_factory
 from backend.intent.handlers.decision_flags import (
     is_activation_nudge_enabled,
+    is_drift_warning_enabled,
     is_tone_dial_enabled,
 )
 from backend.jobs._active_users import get_active_users
@@ -210,6 +211,7 @@ async def _process_user(user: User, *, now: datetime) -> None:
             now=now,
             include_proactive=_proactive_companion_enabled(),
             include_activation_nudge=is_activation_nudge_enabled(),
+            include_drift=is_drift_warning_enabled(),
         )
         if not trigger:
             return

--- a/backend/models/decision_query_log.py
+++ b/backend/models/decision_query_log.py
@@ -15,8 +15,18 @@ from backend.database import Base
 # lookup table.
 QUERY_TYPE_SHOCK = "shock"
 QUERY_TYPE_FEASIBILITY = "feasibility"
+# Phase 4.7 / E2 — user-initiated scam check ("kèo này có nên không?"). Only
+# this *user-initiated* Guardian surface logs here. Proactive drift warnings
+# (Phase 4.7 / E1) deliberately do NOT: they stamp the empathy ``empathy_fired``
+# event stream instead, because ``/charts/decision-adoption`` (see
+# ``backend/api/admin/analytics.py``) aggregates every row in this table with no
+# ``query_type`` filter, so logging a proactive nudge here would inflate the
+# G1/G2 adoption + active-user metrics. Fits ``String(32)`` — no migration.
+QUERY_TYPE_SCAM_CHECK = "scam_check"
 
-VALID_QUERY_TYPES = frozenset({QUERY_TYPE_SHOCK, QUERY_TYPE_FEASIBILITY})
+VALID_QUERY_TYPES = frozenset(
+    {QUERY_TYPE_SHOCK, QUERY_TYPE_FEASIBILITY, QUERY_TYPE_SCAM_CHECK}
+)
 
 
 class DecisionQueryLog(Base):
@@ -66,5 +76,6 @@ __all__ = [
     "DecisionQueryLog",
     "QUERY_TYPE_SHOCK",
     "QUERY_TYPE_FEASIBILITY",
+    "QUERY_TYPE_SCAM_CHECK",
     "VALID_QUERY_TYPES",
 ]

--- a/backend/services/decision/drift_service.py
+++ b/backend/services/decision/drift_service.py
@@ -234,6 +234,7 @@ async def _spend_windows(
         Expense.user_id == user_id,
         Expense.deleted_at.is_(None),
         Expense.transaction_type == "expense",
+        Expense.category.notin_(_INTERNAL_CATEGORIES),
     )
     earliest = (await db.execute(earliest_stmt)).scalar_one_or_none()
     baseline_start = (now - timedelta(days=MIN_HISTORY_WINDOWS * _WINDOW_DAYS)).date()

--- a/backend/services/decision/drift_service.py
+++ b/backend/services/decision/drift_service.py
@@ -1,0 +1,304 @@
+"""Spending-drift assessment + Twin consequence — Phase 4.7 / E1 (#1.1).
+
+Decision Moment #3: the user's spending has drifted above their own recent
+baseline. A bare "you overspent" is noise; what makes it *land* is the concrete
+Twin consequence — "giữ nhịp này, mốc mua nhà lùi 14 tháng". So this module
+does two things and nothing else:
+
+1. **Baseline + drift** — baseline is the median non-transfer spend across the
+   three prior 30-day windows; drift is the current 30-day window measured
+   against it. We fire only when the overshoot clears BOTH a percentage
+   threshold (relative) AND an absolute VND floor (so a user whose baseline is
+   tiny doesn't get warned over a rounding-error overshoot).
+2. **Twin consequence** — if the user keeps this drifted pace, their monthly
+   saving rate shrinks by the drift amount, so their nearest goal completes
+   later. We reuse the same saving-rate arithmetic the goal projection uses
+   (remaining ÷ monthly savings = months) and report the *delay* in months.
+
+``assess`` is **pure**: no DB, no env, no clock, no writes, all ``Decimal``.
+The DB-facing ``compute_drift`` gathers the windows + goal + saving rate and
+hands them to ``assess`` — mirroring ``goal_projection`` (async reader that
+never commits) and ``plan_feasibility`` (pure ``assess`` under a thin gatherer).
+The empathy trigger (#1.2) calls ``compute_drift``.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from backend.models.expense import Expense
+from backend.models.goal import Goal
+from backend.models.user import User
+from backend.services.goal_projection import get_avg_monthly_savings
+
+# Categories that are internal movements of the user's own money, not
+# consumption — excluded from the baseline and the current window so a big
+# transfer to savings never reads as a spending blow-out. Mirrors the empathy
+# engine's ``_INTERNAL_CATEGORIES``.
+_INTERNAL_CATEGORIES = frozenset({"transfer", "saving", "savings", "investment"})
+
+# A drift fires only when the current window exceeds baseline by BOTH:
+#   - ``DEFAULT_DRIFT_PCT`` (relative) — a real change of pace, not noise, and
+#   - ``DEFAULT_DRIFT_ABS_FLOOR`` (absolute VND) — worth a nudge in real money.
+# Owner-signed defaults (phase-4.7-detailed.md, Owner-Decision #2). Both are
+# parameters so tests and a future per-user tune can override them.
+DEFAULT_DRIFT_PCT = Decimal("0.20")
+DEFAULT_DRIFT_ABS_FLOOR = Decimal("1000000")  # 1tr
+
+# Number of prior 30-day windows the baseline median is taken over. Below this
+# the baseline is not trustworthy, so we do not fire ("<3 tháng data").
+MIN_HISTORY_WINDOWS = 3
+
+_WINDOW_DAYS = 30
+
+
+@dataclass(frozen=True)
+class DriftAssessment:
+    """Result of a drift check.
+
+    ``is_drifting`` is the gate the trigger reads. ``goal_delay_months`` is the
+    concrete Twin consequence when it can be computed (drifting, a goal with
+    remaining > 0, a positive baseline saving rate, and a slip of ≥ 1 month) —
+    otherwise ``None`` and the copy falls back to a no-delta variant.
+    ``pace_unsustainable`` marks the case where the drift would erase the whole
+    saving rate (new rate ≤ 0), so the goal effectively stalls rather than
+    merely slipping.
+    """
+
+    baseline: Decimal
+    current_spend: Decimal
+    drift_amount: Decimal  # current - baseline (VND / 30-day window)
+    drift_pct: Decimal  # drift_amount / baseline
+    is_drifting: bool
+    goal_label: str | None
+    goal_delay_months: int | None
+    pace_unsustainable: bool
+
+
+def assess(
+    baseline_history: Sequence[Decimal],
+    current_spend: Decimal,
+    *,
+    goal_remaining: Decimal | None,
+    avg_monthly_savings: Decimal,
+    goal_label: str | None = None,
+    threshold_pct: Decimal = DEFAULT_DRIFT_PCT,
+    absolute_floor: Decimal = DEFAULT_DRIFT_ABS_FLOOR,
+) -> DriftAssessment | None:
+    """Assess whether ``current_spend`` has drifted above the baseline.
+
+    ``baseline_history`` is the non-transfer spend of each prior 30-day window
+    (order irrelevant — we take the median). Returns ``None`` when there is not
+    enough history (fewer than ``MIN_HISTORY_WINDOWS`` windows) or the baseline
+    is non-positive — in both cases we have no trustworthy reference to drift
+    against. Otherwise returns a ``DriftAssessment`` whose ``is_drifting`` tells
+    the caller whether to nudge.
+
+    Pure: no DB, no env, no clock. All money is ``Decimal``.
+    """
+    if len(baseline_history) < MIN_HISTORY_WINDOWS:
+        return None
+
+    baseline = _median(baseline_history)
+    if baseline <= 0:
+        return None
+
+    current = Decimal(current_spend)
+    drift_amount = current - baseline
+    drift_pct = drift_amount / baseline
+
+    is_drifting = drift_amount >= absolute_floor and drift_pct >= threshold_pct
+
+    goal_delay_months: int | None = None
+    pace_unsustainable = False
+    if is_drifting and goal_remaining is not None and goal_remaining > 0:
+        savings = Decimal(avg_monthly_savings)
+        if savings > 0:
+            drifted_savings = savings - drift_amount
+            if drifted_savings <= 0:
+                # The drift would swallow the entire saving rate — the goal
+                # doesn't just slip, it stalls. Surface that distinctly.
+                pace_unsustainable = True
+            else:
+                baseline_months = _months_to_reach(goal_remaining, savings)
+                drifted_months = _months_to_reach(goal_remaining, drifted_savings)
+                delay = drifted_months - baseline_months
+                if delay >= 1:
+                    goal_delay_months = delay
+
+    return DriftAssessment(
+        baseline=baseline,
+        current_spend=current,
+        drift_amount=drift_amount,
+        drift_pct=drift_pct,
+        is_drifting=is_drifting,
+        goal_label=goal_label,
+        goal_delay_months=goal_delay_months,
+        pace_unsustainable=pace_unsustainable,
+    )
+
+
+async def compute_drift(
+    db: AsyncSession,
+    user: User,
+    *,
+    now: datetime | None = None,
+    threshold_pct: Decimal = DEFAULT_DRIFT_PCT,
+    absolute_floor: Decimal = DEFAULT_DRIFT_ABS_FLOOR,
+) -> DriftAssessment | None:
+    """Gather the windows, nearest goal, and saving rate, then ``assess``.
+
+    Read-only: this reads several tables but never writes or commits (layer
+    contract — the empathy job owns the transaction boundary). Returns the same
+    ``None`` sentinel as ``assess`` when there is not enough history.
+    """
+    now = now or datetime.now(timezone.utc)
+
+    windows = await _spend_windows(db, user.id, now=now)
+    if windows is None:
+        return None
+    current_spend, baseline_history = windows
+
+    goal_remaining, goal_label = await _nearest_goal(db, user.id)
+    avg_savings = await get_avg_monthly_savings(db, user.id, today=now.date())
+
+    return assess(
+        baseline_history,
+        current_spend,
+        goal_remaining=goal_remaining,
+        avg_monthly_savings=avg_savings,
+        goal_label=goal_label,
+        threshold_pct=threshold_pct,
+        absolute_floor=absolute_floor,
+    )
+
+
+# ---------------------------------------------------------------------
+# Pure math helpers
+# ---------------------------------------------------------------------
+
+
+def _median(values: Sequence[Decimal]) -> Decimal:
+    ordered = sorted(Decimal(v) for v in values)
+    n = len(ordered)
+    mid = n // 2
+    if n % 2:
+        return ordered[mid]
+    return (ordered[mid - 1] + ordered[mid]) / Decimal(2)
+
+
+def _months_to_reach(remaining: Decimal, monthly_savings: Decimal) -> int:
+    """Whole months to save ``remaining`` at ``monthly_savings`` per month.
+
+    Rounds *up*: a partial final month still counts, so a slower rate always
+    reports at least as many months as a faster one — the delay we derive from
+    two of these is never negative for a genuine slowdown.
+    """
+    if monthly_savings <= 0:
+        raise ValueError("monthly_savings must be positive")
+    return max(1, math.ceil(remaining / monthly_savings))
+
+
+# ---------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------
+
+
+async def _spend_windows(
+    db: AsyncSession, user_id: uuid.UUID, *, now: datetime
+) -> tuple[Decimal, list[Decimal]] | None:
+    """Return ``(current_window_spend, [baseline window spends])`` or ``None``.
+
+    The current window is the trailing 30 days; the baseline windows are the
+    three 30-day windows before that. Using rolling 30-day windows (rather than
+    calendar months) keeps the current window full — a partial calendar month
+    would understate spend early in the month and misfire the drift check.
+
+    Returns ``None`` when the user has no expense older than the baseline span
+    (``MIN_HISTORY_WINDOWS`` × 30 days) — i.e. not enough history for a
+    trustworthy baseline.
+    """
+    span_days = (MIN_HISTORY_WINDOWS + 1) * _WINDOW_DAYS  # current + 3 baseline
+    since = (now - timedelta(days=span_days)).date()
+    today = now.date()
+
+    earliest_stmt = select(func.min(Expense.expense_date)).where(
+        Expense.user_id == user_id,
+        Expense.deleted_at.is_(None),
+        Expense.transaction_type == "expense",
+    )
+    earliest = (await db.execute(earliest_stmt)).scalar_one_or_none()
+    baseline_start = (now - timedelta(days=MIN_HISTORY_WINDOWS * _WINDOW_DAYS)).date()
+    if earliest is None or earliest > baseline_start:
+        return None
+
+    stmt = select(Expense.amount, Expense.expense_date).where(
+        Expense.user_id == user_id,
+        Expense.deleted_at.is_(None),
+        Expense.transaction_type == "expense",
+        Expense.expense_date >= since,
+        Expense.expense_date <= today,
+        Expense.category.notin_(_INTERNAL_CATEGORIES),
+    )
+    rows = (await db.execute(stmt)).all()
+
+    buckets = [Decimal(0) for _ in range(MIN_HISTORY_WINDOWS + 1)]
+    for amount, expense_date in rows:
+        days_ago = (today - expense_date).days
+        if days_ago < 0:
+            continue
+        idx = days_ago // _WINDOW_DAYS
+        if idx <= MIN_HISTORY_WINDOWS:
+            buckets[idx] += Decimal(amount or 0)
+
+    current_spend = buckets[0]
+    baseline_history = buckets[1:]
+    return current_spend, baseline_history
+
+
+async def _nearest_goal(
+    db: AsyncSession, user_id: uuid.UUID
+) -> tuple[Decimal | None, str | None]:
+    """The goal whose delay we'll report: the highest-priority active goal
+    that still has something left to save.
+
+    Ordered by ``priority`` (1 = highest), then soonest ``target_date``, then
+    oldest. Returns ``(remaining, name)`` for the first with ``remaining > 0``,
+    else ``(None, None)`` so ``assess`` skips the Twin consequence.
+    """
+    stmt = (
+        select(Goal)
+        .where(
+            Goal.user_id == user_id,
+            Goal.deleted_at.is_(None),
+            Goal.status == "active",
+        )
+        .order_by(
+            Goal.priority.asc(),
+            Goal.target_date.asc().nullslast(),
+            Goal.created_at.asc(),
+        )
+    )
+    for goal in (await db.execute(stmt)).scalars():
+        remaining = Decimal(goal.target_amount or 0) - Decimal(goal.current_amount or 0)
+        if remaining > 0:
+            return remaining, goal.name
+    return None, None
+
+
+__all__ = [
+    "DriftAssessment",
+    "assess",
+    "compute_drift",
+    "DEFAULT_DRIFT_PCT",
+    "DEFAULT_DRIFT_ABS_FLOOR",
+    "MIN_HISTORY_WINDOWS",
+]

--- a/content/empathy_messages.yaml
+++ b/content/empathy_messages.yaml
@@ -120,6 +120,41 @@ consecutive_over_budget:
 
       Có thể ngân sách đặt hơi thấp so với nhu cầu thực tế chăng? Chúng ta điều chỉnh cho hợp lý hơn nhé — không có gì xấu hổ cả, thực tế đang nói với chúng ta một điều gì đó 🌱
 
+# Phase 4.7 Epic 1 — spending-drift warning. Fires when the current 30-day
+# spend drifts above the user's own 3-window median baseline (> 20% AND at
+# least the absolute floor). The point is the Twin consequence, so `messages`
+# is a dict keyed by the trigger's `copy_variant`:
+#   delay  — a goal slips a concrete number of months ({goal_label},
+#            {goal_delay_months})
+#   stall  — the drift would erase the whole saving rate; the goal stalls
+#            ({goal_label})
+#   plain  — drifting but no goal consequence to attach
+# {drift} = pre-formatted overshoot amount above baseline. Voice: honest, not
+# harsh — name the number, offer a choice, never scold.
+spending_drift:
+  conditions: "Current 30-day spend > 20% AND ≥ absolute floor above 3-window median baseline"
+  cooldown_days: 14
+  messages:
+    delay:
+      - |-
+        Em để ý nhịp chi tháng này của {salutation} nhỉnh hơn mọi khi chừng {drift} 🌿
+
+        Nếu giữ nhịp này, mốc "{goal_label}" có thể lùi thêm khoảng {goal_delay_months} tháng. Em kể để {salutation} nắm thôi ạ — mình cân lại một chút là kịp lại ngay 💚
+      - |-
+        Tháng này {salutation} chi nhiều hơn nền quen thuộc tầm {drift} đó ạ.
+
+        Em soi qua Twin giúp {salutation}: giữ đà này thì "{goal_label}" chậm lại khoảng {goal_delay_months} tháng. Không có gì gấp đâu — chỉ cần {salutation} thấy để chủ động chọn nhé 🌱
+    stall:
+      - |-
+        Em để ý tháng này {salutation} chi vượt nền quen khoảng {drift} 🌿
+
+        Nhịp này gần như dùng hết phần {salutation} vẫn để dành mỗi tháng, nên mốc "{goal_label}" khó tiến thêm được. Em kể để mình cùng nhìn lại một chút thôi ạ 💚
+    plain:
+      - |-
+        Em để ý nhịp chi tháng này của {salutation} cao hơn mọi khi chừng {drift} 🌿
+
+        Chưa có gì đáng lo đâu ạ — em chỉ ghi lại để {salutation} thấy bức tranh rõ hơn. Khi nào rảnh mình ngồi soi lại cùng nhau nhé 💚
+
 # Phase 4.4 Epic 3 — proactive activation nudge. Fires when an onboarded
 # user saw their Twin once (at the end of onboarding) but hasn't returned
 # to it within the activation window. Voice: "em để ý thấy…", warm, never

--- a/content/tone_variants.yaml
+++ b/content/tone_variants.yaml
@@ -69,6 +69,45 @@ empathy:
 
         Không phán xét — nhưng đây là một pattern rõ. Muốn giữ mục tiêu thì đặt một mức trần cho cuối tuần là chắc ăn nhất.
 
+  # Spending-drift warning (Phase 4.7 E1). Nests one level past gentle/strict:
+  # the trigger's `copy_variant` (delay / stall / plain) picks the branch.
+  # {drift} = overshoot above baseline; {goal_label} = nearest goal name;
+  # {goal_delay_months} = months the goal slips (delay branch only). strict is
+  # thẳng thắn — names the number and the consequence — never sỉ nhục.
+  spending_drift:
+    gentle:
+      delay:
+        - |-
+          Em thấy tháng này {salutation} chi nhỉnh hơn mọi khi chừng {drift} 🌿
+
+          Giữ nhịp này thì mốc "{goal_label}" lùi thêm khoảng {goal_delay_months} tháng. Em kể để {salutation} nắm thôi — mình cân lại chút là kịp lại ngay 💚
+      stall:
+        - |-
+          Tháng này {salutation} chi vượt nền quen khoảng {drift} đó ạ 🌿
+
+          Nhịp này gần như dùng hết phần {salutation} vẫn để dành, nên "{goal_label}" khó tiến thêm. Mình cùng nhìn lại một chút nhé 💚
+      plain:
+        - |-
+          Em để ý nhịp chi tháng này của {salutation} cao hơn mọi khi chừng {drift} 🌿
+
+          Chưa có gì đáng lo đâu ạ — em ghi lại để {salutation} thấy bức tranh rõ hơn thôi 💚
+    strict:
+      delay:
+        - |-
+          Nói thẳng nha {salutation}: tháng này chi vượt nền quen {drift}.
+
+          Giữ nhịp này thì "{goal_label}" lùi khoảng {goal_delay_months} tháng. Cân lại phần chi thêm này là mốc về đúng hẹn.
+      stall:
+        - |-
+          Thẳng thắn nha {salutation}: tháng này chi vượt nền quen {drift}.
+
+          Mức này ăn gần hết phần để dành mỗi tháng, nên "{goal_label}" gần như đứng yên. Kéo phần chi thêm xuống thì mục tiêu mới nhích tiếp được.
+      plain:
+        - |-
+          Nói thẳng nha {salutation}: nhịp chi tháng này cao hơn nền quen {drift}.
+
+          Chưa thành vấn đề, nhưng đây là một pattern rõ — {salutation} nắm sớm để chủ động cân dòng tiền.
+
 # ============================================================
 # DECISION ANSWERS — feasibility / shock verdicts
 # ============================================================

--- a/tests/test_phase_4_4/test_epic3_proactive.py
+++ b/tests/test_phase_4_4/test_epic3_proactive.py
@@ -295,7 +295,13 @@ async def test_job_passes_include_proactive_into_check_all_triggers(monkeypatch)
         return 0
 
     async def fake_check(
-        db, user, *, now=None, include_proactive=True, include_activation_nudge=False
+        db,
+        user,
+        *,
+        now=None,
+        include_proactive=True,
+        include_activation_nudge=False,
+        include_drift=False,
     ):
         captured["include_proactive"] = include_proactive
         return None  # short-circuits the rest of _process_user

--- a/tests/test_phase_4_6/test_activation_nudge.py
+++ b/tests/test_phase_4_6/test_activation_nudge.py
@@ -414,7 +414,13 @@ async def test_job_passes_include_activation_nudge(monkeypatch):
         return 0
 
     async def fake_check(
-        db, user, *, now=None, include_proactive=True, include_activation_nudge=False
+        db,
+        user,
+        *,
+        now=None,
+        include_proactive=True,
+        include_activation_nudge=False,
+        include_drift=False,
     ):
         captured["include_activation_nudge"] = include_activation_nudge
         return None

--- a/tests/test_phase_4_7/test_spending_drift.py
+++ b/tests/test_phase_4_7/test_spending_drift.py
@@ -215,6 +215,72 @@ def test_assess_threshold_overrides_are_honoured():
 
 
 # ============================================================
+# _spend_windows — history gate excludes internal transfers
+# ============================================================
+
+
+class _ScalarResult:
+    def __init__(self, value):
+        self._value = value
+
+    def scalar_one_or_none(self):
+        return self._value
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return self._rows
+
+
+class _WindowsGateDB:
+    """Fake session for ``_spend_windows``' first (MIN expense_date) query.
+
+    It keys its answer off whether the *executed* MIN statement carries the
+    internal-category exclusion: if the production code applies the filter it
+    sees the user's earliest *non-internal* expense; if the filter is missing
+    it sees the earlier internal-transfer row. So the gate only returns ``None``
+    when the filter is really in the query — testing the fix, not the fake.
+    """
+
+    def __init__(self, *, earliest_all, earliest_noninternal):
+        self.earliest_all = earliest_all
+        self.earliest_noninternal = earliest_noninternal
+        self.calls = 0
+
+    async def execute(self, stmt):
+        self.calls += 1
+        sql = str(stmt).upper()
+        if self.calls == 1:
+            has_filter = "CATEGORY" in sql and "NOT IN" in sql
+            value = self.earliest_noninternal if has_filter else self.earliest_all
+            return _ScalarResult(value)
+        # No further query should run once the gate short-circuits to None.
+        raise AssertionError("gate should have returned before the spend query")
+
+
+@pytest.mark.asyncio
+async def test_spend_windows_gate_ignores_internal_transfer_history():
+    # The only pre-cutoff expense is an internal transfer (day -100), but the
+    # earliest genuine consumption is recent (day -50), inside the baseline
+    # span — so there is NOT enough real history and the gate must return None.
+    from datetime import timedelta
+
+    from backend.services.decision.drift_service import _spend_windows
+
+    today = NOW_TS.date()
+    db = _WindowsGateDB(
+        earliest_all=today - timedelta(days=100),  # transfer, before cutoff
+        earliest_noninternal=today - timedelta(days=50),  # too recent
+    )
+    result = await _spend_windows(db, uuid.uuid4(), now=NOW_TS)
+    assert result is None
+    assert db.calls == 1  # short-circuited on the gate, never ran the spend query
+
+
+# ============================================================
 # _check_spending_drift trigger (#1.2)
 # ============================================================
 
@@ -313,6 +379,36 @@ async def test_check_drift_plain_when_delay_but_no_goal_label(monkeypatch):
     trigger = await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS)
     assert trigger is not None
     assert trigger.context["copy_variant"] == "plain"
+
+
+@pytest.mark.asyncio
+async def test_check_drift_html_escapes_goal_label(monkeypatch):
+    # The hourly job sends drift messages with parse_mode="HTML", so a
+    # user-authored goal name with HTML metacharacters must be escaped before
+    # it reaches the render context — otherwise it breaks Telegram's HTML
+    # parse (or injects markup).
+    _patch_compute(
+        monkeypatch,
+        _assessment(goal_label="Mua <nhà> & xe", goal_delay_months=6),
+    )
+    trigger = await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS)
+    assert trigger is not None
+    assert trigger.context["copy_variant"] == "delay"
+    assert trigger.context["goal_label"] == "Mua &lt;nhà&gt; &amp; xe"
+    assert "<" not in trigger.context["goal_label"]
+
+
+@pytest.mark.asyncio
+async def test_check_drift_html_escapes_goal_label_in_stall(monkeypatch):
+    # Same escaping guarantee on the stall variant path.
+    _patch_compute(
+        monkeypatch,
+        _assessment(goal_label="Quỹ <dự phòng>", pace_unsustainable=True),
+    )
+    trigger = await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS)
+    assert trigger is not None
+    assert trigger.context["copy_variant"] == "stall"
+    assert trigger.context["goal_label"] == "Quỹ &lt;dự phòng&gt;"
 
 
 # ============================================================

--- a/tests/test_phase_4_7/test_spending_drift.py
+++ b/tests/test_phase_4_7/test_spending_drift.py
@@ -1,0 +1,749 @@
+"""Phase 4.7 Epic 1 — spending-drift warning ("nhịp chi trôi").
+
+Covers the safe, flag-dark drift work:
+
+- #1.1 the pure ``drift_service.assess`` math — median baseline, the dual
+  (percentage AND absolute-floor) threshold, the Twin-consequence delay in
+  months, and every edge that must NOT fire or must fall back to a no-delta
+  variant (too little history, non-positive baseline, zero/deficit saving
+  rate, sub-one-month slip).
+- #1.2 the ``spending_drift`` empathy trigger: fire / no-fire and the
+  ``copy_variant`` (delay / stall / plain) it hands the renderer.
+- the ``include_drift`` gate on ``check_all_triggers`` (default OFF, and its
+  priority slot between the acute single-transaction checks and the ambient
+  silent-N-days ones).
+- render_message + render_tone_variant across the nested variant dict, with
+  persona / localization invariants asserted over a batch, including the
+  tone-dark legacy path (the Twin delta must still render).
+- the ``DRIFT_WARNING_ENABLED`` flag reader (default false) and the hourly
+  job threading ``include_drift`` in.
+- that a drift nudge stays on the empathy ``empathy_sent`` stream and is NOT
+  logged to ``decision_query_logs`` (which would inflate the G1/G2 metrics).
+"""
+
+from __future__ import annotations
+
+import uuid
+from decimal import Decimal
+from types import SimpleNamespace
+
+import pytest
+
+from backend.analytics import EventType
+from backend.bot.personality import empathy_engine
+from backend.services.decision import drift_service
+from backend.services.decision.drift_service import (
+    DriftAssessment,
+    assess,
+)
+
+NOW_TS = empathy_engine.datetime(2026, 7, 12, 12, 0, tzinfo=empathy_engine.timezone.utc)
+
+# 30-day-window money, all Decimal (money is never float).
+_5TR = Decimal("5000000")
+_3TR = Decimal("3000000")
+_2TR = Decimal("2000000")
+_1TR = Decimal("1000000")
+
+
+# ============================================================
+# drift_service.assess — pure math (#1.1)
+# ============================================================
+
+
+def test_assess_none_when_too_few_windows():
+    # Only two baseline windows — median untrustworthy, so we never fire.
+    result = assess(
+        [_5TR, _5TR],
+        _5TR * 3,
+        goal_remaining=None,
+        avg_monthly_savings=_5TR,
+    )
+    assert result is None
+
+
+def test_assess_none_when_baseline_nonpositive():
+    # Three windows but all zero → baseline 0 → no reference to drift against.
+    result = assess(
+        [Decimal(0), Decimal(0), Decimal(0)],
+        _5TR,
+        goal_remaining=None,
+        avg_monthly_savings=_5TR,
+    )
+    assert result is None
+
+
+def test_assess_takes_median_baseline():
+    # Median of [4tr, 5tr, 9tr] is 5tr, NOT the 6tr mean — an outlier window
+    # must not drag the baseline up and mask a real drift.
+    result = assess(
+        [Decimal("4000000"), _5TR, Decimal("9000000")],
+        _5TR,  # current == median → no drift, but baseline is what we check
+        goal_remaining=None,
+        avg_monthly_savings=Decimal(0),
+    )
+    assert result is not None
+    assert result.baseline == _5TR
+
+
+def test_assess_not_drifting_below_pct():
+    # +10% overshoot clears the 1tr floor but not the 20% threshold.
+    result = assess(
+        [Decimal("100000000")] * 3,
+        Decimal("110000000"),
+        goal_remaining=None,
+        avg_monthly_savings=Decimal(0),
+    )
+    assert result is not None
+    assert result.is_drifting is False
+
+
+def test_assess_not_drifting_below_absolute_floor():
+    # +25% clears the pct threshold, but 500k overshoot is below the 1tr floor
+    # — a small-baseline user shouldn't be nudged over pocket change.
+    result = assess(
+        [_2TR, _2TR, _2TR],
+        Decimal("2500000"),
+        goal_remaining=None,
+        avg_monthly_savings=Decimal(0),
+    )
+    assert result is not None
+    assert result.drift_amount == Decimal("500000")
+    assert result.is_drifting is False
+
+
+def test_assess_drifting_when_both_thresholds_clear():
+    result = assess(
+        [_5TR, _5TR, _5TR],
+        Decimal("8000000"),  # +3tr = +60%
+        goal_remaining=None,
+        avg_monthly_savings=Decimal(0),
+    )
+    assert result is not None
+    assert result.is_drifting is True
+    assert result.drift_amount == _3TR
+    assert result.drift_pct == Decimal("0.6")
+
+
+def test_assess_reports_goal_delay_months():
+    # baseline 5tr, current 8tr → drift 3tr. Saving rate 5tr/mo → 2tr after
+    # drift. remaining 20tr: 4 months at 5tr vs 10 months at 2tr → 6-month slip.
+    result = assess(
+        [_5TR, _5TR, _5TR],
+        Decimal("8000000"),
+        goal_remaining=Decimal("20000000"),
+        avg_monthly_savings=_5TR,
+        goal_label="Mua nhà",
+    )
+    assert result is not None
+    assert result.is_drifting is True
+    assert result.goal_delay_months == 6
+    assert result.pace_unsustainable is False
+    assert result.goal_label == "Mua nhà"
+
+
+def test_assess_pace_unsustainable_when_drift_eats_whole_saving_rate():
+    # drift 3tr vs saving rate 2tr → new rate negative → the goal stalls,
+    # it doesn't merely slip. No month count; the copy uses the stall variant.
+    result = assess(
+        [_5TR, _5TR, _5TR],
+        Decimal("8000000"),
+        goal_remaining=Decimal("20000000"),
+        avg_monthly_savings=_2TR,
+        goal_label="Mua nhà",
+    )
+    assert result is not None
+    assert result.pace_unsustainable is True
+    assert result.goal_delay_months is None
+
+
+def test_assess_plain_when_saving_rate_zero():
+    # Saving rate floored at 0 upstream → no Twin delta to compute → plain.
+    result = assess(
+        [_5TR, _5TR, _5TR],
+        Decimal("8000000"),
+        goal_remaining=Decimal("20000000"),
+        avg_monthly_savings=Decimal(0),
+        goal_label="Mua nhà",
+    )
+    assert result is not None
+    assert result.is_drifting is True
+    assert result.goal_delay_months is None
+    assert result.pace_unsustainable is False
+
+
+def test_assess_plain_when_no_goal():
+    result = assess(
+        [_5TR, _5TR, _5TR],
+        Decimal("8000000"),
+        goal_remaining=None,
+        avg_monthly_savings=_5TR,
+    )
+    assert result is not None
+    assert result.is_drifting is True
+    assert result.goal_delay_months is None
+    assert result.goal_label is None
+
+
+def test_assess_no_delay_reported_when_slip_under_one_month():
+    # remaining 1tr: 1 month at 5tr vs 1 month at 2tr (both round up to 1) →
+    # 0-month slip → not surfaced (we only nudge on a slip the user can feel).
+    result = assess(
+        [_5TR, _5TR, _5TR],
+        Decimal("8000000"),
+        goal_remaining=_1TR,
+        avg_monthly_savings=_5TR,
+        goal_label="Quỹ dự phòng",
+    )
+    assert result is not None
+    assert result.is_drifting is True
+    assert result.goal_delay_months is None
+
+
+def test_assess_threshold_overrides_are_honoured():
+    # A caller (per-user tune / test) can loosen both gates.
+    result = assess(
+        [_2TR, _2TR, _2TR],
+        Decimal("2500000"),
+        goal_remaining=None,
+        avg_monthly_savings=Decimal(0),
+        threshold_pct=Decimal("0.10"),
+        absolute_floor=Decimal("100000"),
+    )
+    assert result is not None
+    assert result.is_drifting is True
+
+
+# ============================================================
+# _check_spending_drift trigger (#1.2)
+# ============================================================
+
+
+def _assessment(**over) -> DriftAssessment:
+    base = dict(
+        baseline=_5TR,
+        current_spend=Decimal("8000000"),
+        drift_amount=_3TR,
+        drift_pct=Decimal("0.6"),
+        is_drifting=True,
+        goal_label=None,
+        goal_delay_months=None,
+        pace_unsustainable=False,
+    )
+    base.update(over)
+    return DriftAssessment(**base)
+
+
+def _patch_compute(monkeypatch, assessment):
+    async def _fake(db, user, *, now=None):
+        return assessment
+
+    monkeypatch.setattr(drift_service, "compute_drift", _fake)
+
+
+def _drift_user():
+    return SimpleNamespace(
+        id=uuid.uuid4(),
+        salutation="anh",
+        get_greeting_name=lambda: "Minh",
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_drift_no_fire_when_none(monkeypatch):
+    _patch_compute(monkeypatch, None)
+    assert (
+        await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_drift_no_fire_when_not_drifting(monkeypatch):
+    _patch_compute(monkeypatch, _assessment(is_drifting=False))
+    assert (
+        await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS) is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_check_drift_delay_variant(monkeypatch):
+    _patch_compute(
+        monkeypatch,
+        _assessment(goal_label="Mua nhà", goal_delay_months=6),
+    )
+    trigger = await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS)
+    assert trigger is not None
+    assert trigger.name == "spending_drift"
+    assert trigger.priority == 3
+    assert trigger.cooldown_days == empathy_engine.SPENDING_DRIFT_COOLDOWN_DAYS == 14
+    assert trigger.context["copy_variant"] == "delay"
+    assert trigger.context["goal_label"] == "Mua nhà"
+    assert trigger.context["goal_delay_months"] == 6
+    # drift amount is pre-formatted currency, not a raw Decimal.
+    assert "đ" in trigger.context["drift"]
+
+
+@pytest.mark.asyncio
+async def test_check_drift_stall_variant(monkeypatch):
+    _patch_compute(
+        monkeypatch,
+        _assessment(goal_label="Mua nhà", pace_unsustainable=True),
+    )
+    trigger = await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS)
+    assert trigger is not None
+    assert trigger.context["copy_variant"] == "stall"
+    assert trigger.context["goal_label"] == "Mua nhà"
+    assert "goal_delay_months" not in trigger.context
+
+
+@pytest.mark.asyncio
+async def test_check_drift_plain_variant_when_no_goal(monkeypatch):
+    _patch_compute(monkeypatch, _assessment())  # no goal_label
+    trigger = await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS)
+    assert trigger is not None
+    assert trigger.context["copy_variant"] == "plain"
+    assert "goal_label" not in trigger.context
+
+
+@pytest.mark.asyncio
+async def test_check_drift_plain_when_delay_but_no_goal_label(monkeypatch):
+    # A delay figure with no goal label can't name a goal → plain, never a
+    # half-rendered "{goal_label}" placeholder.
+    _patch_compute(monkeypatch, _assessment(goal_delay_months=6, goal_label=None))
+    trigger = await empathy_engine._check_spending_drift(None, _drift_user(), NOW_TS)
+    assert trigger is not None
+    assert trigger.context["copy_variant"] == "plain"
+
+
+# ============================================================
+# include_drift gate on check_all_triggers
+# ============================================================
+
+
+def _async_none():
+    async def _inner(db, user, now):
+        return None
+
+    return _inner
+
+
+def _async_trigger(name, priority):
+    async def _inner(db, user, now):
+        return empathy_engine.EmpathyTrigger(
+            name=name, priority=priority, cooldown_days=1, context={}
+        )
+
+    return _inner
+
+
+def _silence_all_checks(monkeypatch):
+    for fn_name in (
+        "_check_large_transaction",
+        "_check_payday_splurge",
+        "_check_over_budget_monthly",
+        "_check_spending_drift",
+        "_check_onboarding_no_twin_return",
+        "_check_never_activated",
+        "_check_user_silent_7_days",
+        "_check_user_silent_30_days",
+        "_check_weekend_high_spending",
+        "_check_first_saving_month",
+        "_check_consecutive_over_budget",
+    ):
+        monkeypatch.setattr(empathy_engine, fn_name, _async_none())
+
+
+async def _never_on_cooldown(*_a, **_k):
+    return False
+
+
+class _EmptyDB:
+    async def execute(self, _stmt):  # pragma: no cover - never reached
+        raise AssertionError("no query expected when checks are stubbed")
+
+
+@pytest.mark.asyncio
+async def test_flag_on_drift_fires_before_silent(monkeypatch):
+    _silence_all_checks(monkeypatch)
+    # Drift sits BEFORE the ambient silent-N-days nudges — a concrete goal
+    # consequence outranks a generic "come back".
+    monkeypatch.setattr(
+        empathy_engine, "_check_spending_drift", _async_trigger("spending_drift", 3)
+    )
+    monkeypatch.setattr(
+        empathy_engine, "_check_user_silent_7_days", _async_trigger("old", 4)
+    )
+    monkeypatch.setattr(empathy_engine, "_is_on_cooldown", _never_on_cooldown)
+
+    trigger = await empathy_engine.check_all_triggers(
+        _EmptyDB(), _drift_user(), now=NOW_TS, include_drift=True
+    )
+    assert trigger is not None
+    assert trigger.name == "spending_drift"
+
+
+@pytest.mark.asyncio
+async def test_flag_on_drift_yields_to_acute_large_transaction(monkeypatch):
+    _silence_all_checks(monkeypatch)
+    # An acute single-transaction signal still outranks the slow drift signal.
+    monkeypatch.setattr(
+        empathy_engine, "_check_large_transaction", _async_trigger("large", 1)
+    )
+    monkeypatch.setattr(
+        empathy_engine, "_check_spending_drift", _async_trigger("spending_drift", 3)
+    )
+    monkeypatch.setattr(empathy_engine, "_is_on_cooldown", _never_on_cooldown)
+
+    trigger = await empathy_engine.check_all_triggers(
+        _EmptyDB(), _drift_user(), now=NOW_TS, include_drift=True
+    )
+    assert trigger is not None
+    assert trigger.name == "large"
+
+
+@pytest.mark.asyncio
+async def test_flag_off_skips_drift_but_silent_still_fires(monkeypatch):
+    _silence_all_checks(monkeypatch)
+    monkeypatch.setattr(
+        empathy_engine, "_check_spending_drift", _async_trigger("spending_drift", 3)
+    )
+    monkeypatch.setattr(
+        empathy_engine, "_check_user_silent_7_days", _async_trigger("old", 4)
+    )
+    monkeypatch.setattr(empathy_engine, "_is_on_cooldown", _never_on_cooldown)
+
+    trigger = await empathy_engine.check_all_triggers(
+        _EmptyDB(), _drift_user(), now=NOW_TS, include_drift=False
+    )
+    assert trigger is not None
+    assert trigger.name == "old"
+
+
+@pytest.mark.asyncio
+async def test_default_excludes_drift_trigger(monkeypatch):
+    """Drift defaults OFF — omitting the kwarg must NOT fire ``spending_drift``."""
+    _silence_all_checks(monkeypatch)
+    monkeypatch.setattr(
+        empathy_engine, "_check_spending_drift", _async_trigger("spending_drift", 3)
+    )
+    monkeypatch.setattr(
+        empathy_engine, "_check_user_silent_7_days", _async_trigger("old", 4)
+    )
+    monkeypatch.setattr(empathy_engine, "_is_on_cooldown", _never_on_cooldown)
+
+    trigger = await empathy_engine.check_all_triggers(
+        _EmptyDB(), _drift_user(), now=NOW_TS
+    )
+    assert trigger is not None
+    assert trigger.name == "old"
+
+
+@pytest.mark.asyncio
+async def test_cooldown_suppresses_drift(monkeypatch):
+    _silence_all_checks(monkeypatch)
+    monkeypatch.setattr(
+        empathy_engine, "_check_spending_drift", _async_trigger("spending_drift", 3)
+    )
+
+    async def _on_cooldown(*_a, **_k):
+        return True
+
+    monkeypatch.setattr(empathy_engine, "_is_on_cooldown", _on_cooldown)
+
+    trigger = await empathy_engine.check_all_triggers(
+        _EmptyDB(), _drift_user(), now=NOW_TS, include_drift=True
+    )
+    assert trigger is None
+
+
+# ============================================================
+# render_message — legacy (tone-dark) path across variants
+# ============================================================
+
+_BANNED_SCOLD = ("đừng", "không nên", "phải", "sai", "tệ", "lãng phí")
+_BANNED_CORPORATE = ("cfo", "decision engine", "gps")
+
+
+def _assert_persona(msg: str) -> None:
+    assert msg.strip()
+    low = msg.lower()
+    for term in _BANNED_CORPORATE:
+        assert term not in low, f"corporate term {term!r} leaked into copy"
+    for term in _BANNED_SCOLD:
+        assert term not in low, f"scolding term {term!r} leaked into copy"
+
+
+def _trigger(copy_variant, **ctx):
+    context = {"drift": "3,000,000đ", "copy_variant": copy_variant, **ctx}
+    return empathy_engine.EmpathyTrigger(
+        name="spending_drift",
+        priority=3,
+        cooldown_days=14,
+        context=context,
+    )
+
+
+def test_render_delay_variant_legacy_shows_twin_delta():
+    empathy_engine.reload_messages_for_tests()
+    user = SimpleNamespace(salutation="anh", get_greeting_name=lambda: "Minh")
+    trigger = _trigger("delay", goal_label="Mua nhà", goal_delay_months=6)
+
+    for _ in range(20):
+        msg = empathy_engine.render_message(trigger, user)  # tone dark
+        _assert_persona(msg)
+        assert "anh" in msg  # salutation threaded
+        assert "Mua nhà" in msg  # goal named
+        assert "6" in msg  # the Twin delta renders even with the dial dark
+        assert "3,000,000đ" in msg  # drift amount rendered
+        assert "{" not in msg  # no dangling placeholder
+
+
+def test_render_stall_variant_legacy():
+    empathy_engine.reload_messages_for_tests()
+    user = SimpleNamespace(salutation="chị", get_greeting_name=lambda: "Lan")
+    trigger = _trigger("stall", goal_label="Mua nhà")
+
+    for _ in range(20):
+        msg = empathy_engine.render_message(trigger, user)
+        _assert_persona(msg)
+        assert "chị" in msg
+        assert "Mua nhà" in msg
+        assert "{" not in msg
+
+
+def test_render_plain_variant_legacy():
+    empathy_engine.reload_messages_for_tests()
+    user = SimpleNamespace(salutation="bạn", get_greeting_name=lambda: "Anh")
+    trigger = _trigger("plain")
+
+    for _ in range(20):
+        msg = empathy_engine.render_message(trigger, user)
+        _assert_persona(msg)
+        assert "3,000,000đ" in msg
+        assert "{" not in msg
+
+
+# ============================================================
+# render_tone_variant — nested variant dict (gentle / strict)
+# ============================================================
+
+from backend.bot.formatters import tone as tone_mod  # noqa: E402
+
+
+@pytest.mark.parametrize("tone", ["gentle", "strict"])
+def test_tone_variant_delay_renders(tone):
+    tone_mod._tone_copy.cache_clear()
+    for _ in range(10):
+        out = tone_mod.render_tone_variant(
+            "empathy.spending_drift",
+            tone,
+            salutation="anh",
+            copy_variant="delay",
+            drift="3,000,000đ",
+            goal_label="Mua nhà",
+            goal_delay_months=6,
+        )
+        assert out is not None
+        _assert_persona(out)
+        assert "anh" in out
+        assert "Mua nhà" in out
+        assert "6" in out
+        assert "{" not in out
+
+
+@pytest.mark.parametrize("tone", ["gentle", "strict"])
+def test_tone_variant_stall_renders(tone):
+    tone_mod._tone_copy.cache_clear()
+    out = tone_mod.render_tone_variant(
+        "empathy.spending_drift",
+        tone,
+        salutation="anh",
+        copy_variant="stall",
+        drift="3,000,000đ",
+        goal_label="Mua nhà",
+    )
+    assert out is not None
+    _assert_persona(out)
+    assert "{" not in out
+
+
+@pytest.mark.parametrize("tone", ["gentle", "strict"])
+def test_tone_variant_plain_renders(tone):
+    tone_mod._tone_copy.cache_clear()
+    out = tone_mod.render_tone_variant(
+        "empathy.spending_drift",
+        tone,
+        salutation="anh",
+        copy_variant="plain",
+        drift="3,000,000đ",
+    )
+    assert out is not None
+    _assert_persona(out)
+    assert "{" not in out
+
+
+def test_tone_variant_none_for_unknown_copy_variant():
+    # A nested block with an unmatched branch falls back (None) so the caller
+    # keeps its legacy copy rather than rendering an empty string.
+    tone_mod._tone_copy.cache_clear()
+    out = tone_mod.render_tone_variant(
+        "empathy.spending_drift",
+        "gentle",
+        salutation="anh",
+        copy_variant="does-not-exist",
+        drift="3,000,000đ",
+    )
+    assert out is None
+
+
+def test_tone_variant_dark_returns_none():
+    # tone=None (dial dark) always yields None → caller uses legacy copy.
+    assert (
+        tone_mod.render_tone_variant(
+            "empathy.spending_drift",
+            None,
+            salutation="anh",
+            copy_variant="plain",
+            drift="3,000,000đ",
+        )
+        is None
+    )
+
+
+# ============================================================
+# DRIFT_WARNING_ENABLED flag (read at the job edge)
+# ============================================================
+
+
+def test_drift_flag_default_off(monkeypatch):
+    from backend.intent.handlers.decision_flags import is_drift_warning_enabled
+
+    monkeypatch.delenv("DRIFT_WARNING_ENABLED", raising=False)
+    assert is_drift_warning_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["1", "true", "yes", "on", "ON", "Yes"])
+def test_drift_flag_on(monkeypatch, val):
+    from backend.intent.handlers.decision_flags import is_drift_warning_enabled
+
+    monkeypatch.setenv("DRIFT_WARNING_ENABLED", val)
+    assert is_drift_warning_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["0", "false", "no", "off", "anything", ""])
+def test_drift_flag_off(monkeypatch, val):
+    from backend.intent.handlers.decision_flags import is_drift_warning_enabled
+
+    monkeypatch.setenv("DRIFT_WARNING_ENABLED", val)
+    assert is_drift_warning_enabled() is False
+
+
+# ============================================================
+# job wiring — the hourly job threads include_drift in
+# ============================================================
+
+
+class _JobDB:
+    async def commit(self):
+        return None
+
+
+class _JobSession:
+    async def __aenter__(self):
+        return _JobDB()
+
+    async def __aexit__(self, *_a):
+        return False
+
+
+def _stub_job_session(monkeypatch, check_empathy_triggers):
+    monkeypatch.setattr(
+        check_empathy_triggers, "get_session_factory", lambda: lambda: _JobSession()
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("flag,expected", [("true", True), ("false", False)])
+async def test_job_passes_include_drift(monkeypatch, flag, expected):
+    from backend.jobs import check_empathy_triggers
+
+    captured = {}
+
+    async def fake_count(*_a, **_k):
+        return 0
+
+    async def fake_check(db, user, **kwargs):
+        captured["include_drift"] = kwargs.get("include_drift")
+        return None
+
+    monkeypatch.setattr(empathy_engine, "count_empathy_fired_today", fake_count)
+    monkeypatch.setattr(empathy_engine, "check_all_triggers", fake_check)
+    monkeypatch.setenv("DRIFT_WARNING_ENABLED", flag)
+    _stub_job_session(monkeypatch, check_empathy_triggers)
+
+    user = SimpleNamespace(id=uuid.uuid4(), telegram_id=123, tone_preference=None)
+    await check_empathy_triggers._process_user(user, now=NOW_TS)
+
+    assert captured["include_drift"] is expected
+
+
+# ============================================================
+# drift stays on the empathy stream — NOT decision_query_logs
+# ============================================================
+
+
+@pytest.mark.asyncio
+async def test_drift_nudge_uses_empathy_stream_not_decision_log(monkeypatch):
+    """A drift nudge stamps the generic ``empathy_sent`` event and records an
+    ``empathy_fired`` cooldown row — it must NOT write ``decision_query_logs``
+    (that table feeds the G1/G2 adoption metrics, which a proactive nudge would
+    inflate — see ``decision_query_log`` module note)."""
+    from backend.jobs import check_empathy_triggers
+
+    async def fake_count(*_a, **_k):
+        return 0
+
+    async def fake_check(db, user, **_k):
+        return empathy_engine.EmpathyTrigger(
+            name="spending_drift", priority=3, cooldown_days=14, context={}
+        )
+
+    recorded = []
+
+    async def fake_record(db, user_id, trigger_name, **_k):
+        recorded.append(trigger_name)
+
+    async def fake_send(**_k):
+        return {"ok": True}
+
+    tracked = []
+
+    def fake_track(event_type, user_id=None, properties=None):
+        tracked.append(event_type)
+
+    monkeypatch.setattr(empathy_engine, "count_empathy_fired_today", fake_count)
+    monkeypatch.setattr(empathy_engine, "check_all_triggers", fake_check)
+    monkeypatch.setattr(empathy_engine, "render_message", lambda *a, **k: "nhịp chi")
+    monkeypatch.setattr(empathy_engine, "record_fired", fake_record)
+    monkeypatch.setattr(check_empathy_triggers, "send_message", fake_send)
+    monkeypatch.setattr(check_empathy_triggers.analytics, "track", fake_track)
+    monkeypatch.setenv("DRIFT_WARNING_ENABLED", "true")
+    _stub_job_session(monkeypatch, check_empathy_triggers)
+
+    user = SimpleNamespace(id=uuid.uuid4(), telegram_id=123, tone_preference=None)
+    await check_empathy_triggers._process_user(user, now=NOW_TS)
+
+    # Cooldown row stamped on the empathy stream, funnel event is the generic
+    # EMPATHY_SENT — never the activation funnel, never a decision-log write.
+    assert recorded == ["spending_drift"]
+    assert tracked == [EventType.EMPATHY_SENT]
+
+
+def test_no_drift_query_type_exists():
+    """Guard: drift must have no ``decision_query_logs`` query_type — the only
+    Phase 4.7 addition to that table is the user-initiated scam check."""
+    from backend.models import decision_query_log as dql
+
+    for value in dql.VALID_QUERY_TYPES:
+        assert "drift" not in value.lower()
+    assert dql.QUERY_TYPE_SCAM_CHECK == "scam_check"


### PR DESCRIPTION
## Summary

Lands the safe, additive, **flag-OFF-by-default** parts of Phase 4.7 — Guardian Layer: Epic 1 (proactive spending-drift warnings) and Epic 3 guardrail flag/kill-switch infra. E2 (scam-check feature content) is intentionally **not** included — it is legal-blocked — and **no flag is flipped on**. Flags stay dark until the G1 adoption gate passes.

## Epic 1 — proactive drift warning (OFF by default)

- **`drift_service.py`** (new) — pure math, no env / no commit / no transport, `Decimal` throughout. Baseline = median of non-transfer monthly spend over the 3 prior 30-day windows; drift = current 30-day window vs baseline. Fires only when drift `> 20%` **and** `>=` absolute VND floor. Computes the **Twin consequence**: how many months the nearest goal slips at the drifted pace (`delay`), or that the drift erases the whole saving rate (`stall`), else `plain`. Returns `None` with `< 3` windows of history or a non-positive baseline; no goal / zero saving rate → no consequence.
- **`empathy_engine.py`** — `_check_spending_drift` + `include_drift` param on `check_all_triggers`, mirroring `include_activation_nudge`. Priority sits between acute (`large_transaction`) and ambient (`user_silent_*`); 14-day cooldown. Engine **never reads env** — the job passes the flag decision in.
- **`check_empathy_triggers.py`** — reads `DRIFT_WARNING_ENABLED` at the job edge and threads `include_drift` into the engine. Cooldown / quiet-hours / daily-cap behaviour unchanged.
- **copy** — `spending_drift` block in `empathy_messages.yaml` + `tone_variants.yaml`, gentle/strict × `delay`/`stall`/`plain`, honest-not-harsh persona floor (no "đừng/không nên/phải/sai/tệ/lãng phí", no "Decision Engine/CFO/GPS"). `copy_variant` nested-dict rendering in `tone.py` + `render_message` so the Twin delta surfaces even when the tone dial is dark.

## Epic 3 — guardrail infra only (both flags default OFF)

- **`decision_flags.py`** — `DRIFT_WARNING_ENABLED` + `SCAM_CHECK_ENABLED` helpers reusing the existing `_enabled(env, *, default)` pattern; restart-based kill-switch runbook documented in the module docstring.
- **`decision_query_log.py`** — `QUERY_TYPE_SCAM_CHECK` constant (fits `String(32)`, no migration). Drift is proactive and stays on the `empathy_fired`/`empathy_sent` stream — it is **never** written to `decision_query_log`, which would inflate the G1/G2 adoption / active-user metrics.

## Tests

- New suite `tests/test_phase_4_7/test_spending_drift.py` (51 tests): `drift_service.assess` math + all edges; `_check_spending_drift` fire/no-fire + `copy_variant` selection; the `include_drift` gate (default OFF) and its priority slot; `render_message` + `render_tone_variant` variant-dict rendering with persona batch assertions (incl. the Twin delta rendering when the dial is dark); flag default-off/on/off; job wiring; and that drift stays off `decision_query_log`.
- Updated the two job-wiring stubs in `test_phase_4_4`/`test_phase_4_6` for the new `include_drift` kwarg.
- Full suite: 949 passing (the 3 remaining failures pre-exist on `main` and are unrelated: twin telegram surface + `phase43` money-format).

Close #998
Close #999
Close #1000
Close #1001
Close #1002
Close #1003

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suj5ENcPR7DooNU7GowadB