### PR TITLE
docs(releases): add Release 10 broadcast message (1.4.7.0.1)

### DIFF
--- a/docs/releases/release-10-broadcast.md
+++ b/docs/releases/release-10-broadcast.md
@@ -1,16 +1,15 @@
-# Release 10 — Broadcast Message (1.4.5.0)
+# Release 10 — Broadcast Message (1.4.7.0.1)
 
-> **Mục đích:** Tin nhắn gửi cho **tất cả user** thông báo về bản cập nhật 1.4.5.0.
+> **Mục đích:** Tin nhắn gửi cho **tất cả user** thông báo về bản cập nhật 1.4.7.0.1.
 > **Không phải deploy notes nội bộ.** Giọng văn Bé Tiền — ấm áp, thuần Việt, không jargon.
 
-> **⚠️ Lưu ý nội bộ (KHÔNG gửi cho user) — gate theo feature flag:**
-> Bản cập nhật này tập trung vào **khả năng hỏi một câu quyết định thật** (Phase 4.5) mà onboarding mới (Phase 4.6) đưa lên tuyến đầu. Chỉ broadcast **sau khi** đã bật flag tương ứng ở production, nếu không user bấm thử sẽ không thấy gì:
-> - Khối "Hỏi một câu, có hướng đi ngay" → cần `PLAN_FEASIBILITY_QA_ENABLED`
-> - Khối "Thanh độ nét" → cần `CLARITY_METER_ENABLED`
-> - Khối "Thử nếu… thì sao" → cần `SHOCK_SIMULATION_ENABLED`
-> - Xuất Excel `/export` → `EXPORT_EXCEL_ENABLED` đã `true` sẵn
+> **⚠️ Lưu ý nội bộ (KHÔNG gửi cho user) — trạng thái flag ở release này:**
+> Bản cập nhật này tập trung vào **khả năng hỏi một câu quyết định thật** (Phase 4.5) mà onboarding mới (Phase 4.6) đưa lên tuyến đầu. Ở release production lần này **cả 3 flag đều BẬT**, nên **cả 3 khối tính năng ở dưới đều gửi**:
+> - Khối "Hỏi một câu, có hướng đi ngay" → `PLAN_FEASIBILITY_QA_ENABLED` = **on** ✅
+> - Khối "Thanh độ nét" → `CLARITY_METER_ENABLED` = **on** ✅
+> - Khối "Thử nếu… thì sao" → `SHOCK_SIMULATION_ENABLED` = **on** ✅
+> - Xuất Excel `/export` → `EXPORT_EXCEL_ENABLED` đã `true` sẵn ✅
 >
-> Nếu ở lần release này **không** bật khối nào ở trên thì **bỏ khối đó ra** khỏi bản gửi.
 > **KHÔNG** nhắc tới Phase 4.7 (Guardian Layer — drift warning E1 + guardrail/kill-switch E3 đang build dark, flag off; scam-check E2 legal-blocked) và **KHÔNG** nhắc chi tiết nội bộ onboarding reset (chỉ chạm user mới) — đúng nguyên tắc không quảng cáo tính năng chưa bật.
 
 ---

--- a/docs/releases/release-10-broadcast.md
+++ b/docs/releases/release-10-broadcast.md
@@ -1,0 +1,53 @@
+# Release 10 — Broadcast Message (1.4.5.0)
+
+> **Mục đích:** Tin nhắn gửi cho **tất cả user** thông báo về bản cập nhật 1.4.5.0.
+> **Không phải deploy notes nội bộ.** Giọng văn Bé Tiền — ấm áp, thuần Việt, không jargon.
+
+> **⚠️ Lưu ý nội bộ (KHÔNG gửi cho user) — gate theo feature flag:**
+> Bản cập nhật này tập trung vào **khả năng hỏi một câu quyết định thật** (Phase 4.5) mà onboarding mới (Phase 4.6) đưa lên tuyến đầu. Chỉ broadcast **sau khi** đã bật flag tương ứng ở production, nếu không user bấm thử sẽ không thấy gì:
+> - Khối "Hỏi một câu, có hướng đi ngay" → cần `PLAN_FEASIBILITY_QA_ENABLED`
+> - Khối "Thanh độ nét" → cần `CLARITY_METER_ENABLED`
+> - Khối "Thử nếu… thì sao" → cần `SHOCK_SIMULATION_ENABLED`
+> - Xuất Excel `/export` → `EXPORT_EXCEL_ENABLED` đã `true` sẵn
+>
+> Nếu ở lần release này **không** bật khối nào ở trên thì **bỏ khối đó ra** khỏi bản gửi.
+> **KHÔNG** nhắc tới Phase 4.7 (Guardian Layer — drift warning E1 + guardrail/kill-switch E3 đang build dark, flag off; scam-check E2 legal-blocked) và **KHÔNG** nhắc chi tiết nội bộ onboarding reset (chỉ chạm user mới) — đúng nguyên tắc không quảng cáo tính năng chưa bật.
+
+---
+
+## Bản đầy đủ (gửi 1 lần qua Telegram broadcast)
+
+🎉 **Bé Tiền vừa lớn thêm một chút — có gì mới cho bạn**
+
+Lần này tụi mình làm được điều ấp ủ đã lâu: giờ bạn có thể **hỏi Bé Tiền một câu quyết định thật**, và nhận câu trả lời thẳng thắn dựa trên chính con số của bạn 👇
+
+🎯 **Hỏi một câu, có hướng đi ngay**
+Cứ nhắn tự nhiên như đang tâm sự:
+• *"3 năm nữa mình đủ cọc mua nhà chưa?"*
+• *"với nhịp này, bao lâu nữa mình có quỹ khẩn cấp 6 tháng?"*
+Bé Tiền nhìn tài sản + thu nhập của bạn rồi cho biết đủ hay chưa, còn cách bao xa, và mốc gần nhất trong tầm tay.
+
+🔎 **Thanh "độ nét" — thành thật về mức chắc chắn**
+Mỗi câu trả lời đi kèm một thanh **độ nét**: bức tranh tiền của bạn đang rõ tới đâu. Còn mờ thì Bé Tiền nói thật — *"đây là hướng, chưa phải con số đóng đinh"* — rồi gợi ý thêm một hai thông tin để lần sau nét hơn. Không phán xét, chỉ đồng hành.
+
+🌊 **Thử "nếu… thì sao" mà không đụng số liệu thật**
+Tò mò *"nếu mình rút 100tr ra thì danh mục xoay xở thế nào?"* — Bé Tiền chạy thử trên một bản sao, cho bạn xem trước, số liệu gốc của bạn vẫn nguyên vẹn.
+
+📤 **Xuất toàn bộ số liệu ra Excel**
+Gõ */export* là có ngay file Excel gọn gàng để bạn tự xem, lưu trữ hay đối chiếu.
+
+🌱 **Màn chào hỏi ấm hơn cho những người bạn mới**
+Bé Tiền cũng vừa làm lại phần chào hỏi cho người mới bắt đầu — hỏi đúng điều bạn muốn lo cho xong trước nhất về chuyện tiền, rồi đi cùng bạn từ đó. Nếu có bạn bè mới, mời họ thử nha.
+
+❤️ Cảm ơn bạn đã đồng hành. Có gì chưa ổn cứ nhắn Bé Tiền nha — feedback của bạn là cách tụi mình lớn lên.
+
+---
+
+## Bản notification (ngắn — push notification / teaser)
+
+🎉 **Bé Tiền có tính năng mới**
+• Hỏi một câu quyết định thật: *"3 năm nữa đủ cọc nhà chưa?"* → có hướng đi ngay
+• Mỗi câu trả lời kèm thanh **"độ nét"** — thành thật về mức chắc chắn
+• Thử *"nếu rút 100tr thì sao"* mà không đụng số liệu thật
+• Xuất toàn bộ số liệu ra Excel với */export*
+Cảm ơn bạn đã đồng hành ❤️


### PR DESCRIPTION
## Tóm tắt

Thêm `docs/releases/release-10-broadcast.md` — tin nhắn **gửi cho tất cả user** cho bản cập nhật 1.4.7.0.1, soạn theo đúng format của `release-9-broadcast.md` (một **Bản đầy đủ** gửi qua Telegram broadcast + một **Bản notification** ngắn), giọng văn Bé Tiền: ấm áp, thuần Việt, không jargon.

## Nội dung broadcast tập trung vào đâu

Headline là **khả năng hỏi một câu quyết định thật** (Phase 4.5 — plan feasibility Q&A + thanh "độ nét" + mô phỏng cú sốc) mà onboarding reset Phase 4.6 đưa lên tuyến đầu, cộng `/export` Excel (đã live). Đây là phần **user hiện tại thật sự thấy**.

## Trạng thái flag ở release này

**Cả 3 flag đều BẬT** → cả 3 khối tính năng đều gửi:
- `PLAN_FEASIBILITY_QA_ENABLED` = on ✅
- `CLARITY_METER_ENABLED` = on ✅
- `SHOCK_SIMULATION_ENABLED` = on ✅
- `/export` (`EXPORT_EXCEL_ENABLED`) đã `true` sẵn ✅

File giữ một block **Lưu ý nội bộ (KHÔNG gửi cho user)** ghi lại trạng thái flag để lưu vết cho operator.

## Chủ đích loại trừ (đúng nguyên tắc "không quảng cáo tính năng chưa bật")

- **Phase 4.7 Guardian Layer** — E1 drift warning + E3 guardrail/kill-switch đang **build dark, flag off**; E2 scam-check **legal-blocked** → không nhắc.
- **Nội bộ onboarding reset (Phase 4.6)** — chỉ chạm luồng **user mới**, user hiện tại đã onboard xong → chỉ giữ một dòng teaser nhẹ, không mô tả cơ chế.

## Test

Chỉ thêm tài liệu (`docs/releases/`), không đụng code → không có test tự động. Đã tự đọc lại để đảm bảo persona Bé Tiền, thuần Việt, tránh từ cấm ("đừng/không nên/phải/sai/tệ/lãng phí") và không dùng "Decision Engine"/"CFO"/"GPS tài chính".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Suj5ENcPR7DooNU7GowadB